### PR TITLE
Rework pkgName -> pkgFolder detection

### DIFF
--- a/packages/monorepo/release/src/copyChangelogs.ts
+++ b/packages/monorepo/release/src/copyChangelogs.ts
@@ -47,7 +47,7 @@ async function getChangelogContent(
   branch: string,
 ): Promise<string | null> {
   const changelogPath = join(
-    getPackPackageDirectory(packageName),
+    await getPackPackageDirectory(packageName),
     "CHANGELOG.md",
   );
   let content: Result<{}> = {} as Result<{}>;
@@ -82,7 +82,7 @@ async function updateChangelog(
   fullTargetBranchChangelogContent: string,
 ): Promise<void> {
   const changelogPath = join(
-    getPackPackageDirectory(packageName),
+    await getPackPackageDirectory(packageName),
     "CHANGELOG.md",
   );
 

--- a/packages/monorepo/release/src/runTagRelease.ts
+++ b/packages/monorepo/release/src/runTagRelease.ts
@@ -35,7 +35,7 @@ async function createGithubReleaseTag(
   context: GithubContext,
   sha: string,
 ) {
-  const changelogPath = `${getPackPackageDirectory(packageName)}/CHANGELOG.md`;
+  const changelogPath = `${await getPackPackageDirectory(packageName)}/CHANGELOG.md`;
   const changelogContent = await context.octokit.rest.repos.getContent({
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -165,7 +165,7 @@ export async function runTagRelease(
 
   for (const publishedPackage of publishedPackages.publishedPackages) {
     const packageName = publishedPackage.name;
-    const packagePath = `${getPackPackageDirectory(packageName)}/package.json`;
+    const packagePath = `${await getPackPackageDirectory(packageName)}/package.json`;
     const pkg = await context.octokit.rest.repos.getContent({
       owner: context.repo.owner,
       repo: context.repo.repo,

--- a/packages/monorepo/release/src/util/getPackPackageDirectory.test.ts
+++ b/packages/monorepo/release/src/util/getPackPackageDirectory.test.ts
@@ -18,27 +18,29 @@ import { describe, expect, it } from "vitest";
 import { getPackPackageDirectory } from "./getPackPackageDirectory.js";
 
 describe("getPackPackageDirectory", () => {
-  it("should handle flat package structure", () => {
-    const result = getPackPackageDirectory("@palantir/pack.release");
-
-    expect(result).toBe("packages/release");
-  });
-
-  it("should handle nested package structure with 2 levels", () => {
-    const result = getPackPackageDirectory("@palantir/pack.monorepo.release");
+  it("should return directory for nested package structure", async () => {
+    const result = await getPackPackageDirectory("@palantir/pack.monorepo.release");
 
     expect(result).toBe("packages/monorepo/release");
   });
 
-  it("should handle nested package structure with 3 levels", () => {
-    const result = getPackPackageDirectory("@palantir/pack.document-schema.model-types");
+  it("should return directory for deeply nested package structure", async () => {
+    const result = await getPackPackageDirectory("@palantir/pack.document-schema.model-types");
 
     expect(result).toBe("packages/document-schema/model-types");
   });
 
-  it("should handle deeply nested structures", () => {
-    const result = getPackPackageDirectory("@palantir/pack.a.b.c.d.e");
+  it("should use cached results on subsequent calls", async () => {
+    const result1 = await getPackPackageDirectory("@palantir/pack.monorepo.release");
+    const result2 = await getPackPackageDirectory("@palantir/pack.monorepo.release");
 
-    expect(result).toBe("packages/a/b/c/d/e");
+    expect(result1).toBe(result2);
+    expect(result1).toBe("packages/monorepo/release");
+  });
+
+  it("should throw error for non-existent package", async () => {
+    await expect(
+      getPackPackageDirectory("@palantir/pack.does-not-exist"),
+    ).rejects.toThrow("Package \"@palantir/pack.does-not-exist\" not found in workspace");
   });
 });


### PR DESCRIPTION
Will allow us to have:
- `packages/auth/core` -> `@palantir/pack.auth`
- `packages/auth/foundry` -> `@palantir/pack.auth.foundry`