### PR TITLE
Improve create request and add ontologyRid config

### DIFF
--- a/.changeset/jolly-teams-look.md
+++ b/.changeset/jolly-teams-look.md
@@ -1,0 +1,10 @@
+---
+"@palantir/pack.document-schema.model-types": patch
+"@palantir/pack.state.foundry": patch
+"@palantir/pack.state.core": patch
+"@palantir/pack.state.demo": patch
+"@palantir/pack.core": patch
+"@palantir/pack.app": patch
+---
+
+Improve document creation API to separate create request from raw API types

--- a/packages/app/src/__tests__/initPackApp.auth.test.ts
+++ b/packages/app/src/__tests__/initPackApp.auth.test.ts
@@ -32,6 +32,12 @@ vi.mock("../utils/getDocumentServiceConfig.js", () => ({
   ]),
 }));
 
+const TEST_FOUNDRY_URL = "https://test.palantir.com";
+const TEST_CLIENT_ID = "test-client-id";
+const TEST_REDIRECT_URL = "http://localhost:3000/auth/callback";
+const TEST_ONTOLOGY_RID = "ri.ontology.main.ontology.test-ontology";
+const TEST_CLIENT_SECRET = "test-client-secret";
+
 describe("initPackApp - Auth Integration", () => {
   const TEST_APP_CONFIG = {
     appId: "test-app",
@@ -45,15 +51,10 @@ describe("initPackApp - Auth Integration", () => {
       appVersion: "1.0.0",
       baseUrl: "https://page-env.example.com",
       clientId: "page-env-client-id",
+      ontologyRid: TEST_ONTOLOGY_RID,
       redirectUrl: "http://localhost:3000/page-env-callback",
     });
   });
-
-  const TEST_FOUNDRY_URL = "https://test.palantir.com";
-  const TEST_CLIENT_ID = "test-client-id";
-  const TEST_REDIRECT_URL = "http://localhost:3000/auth/callback";
-  const TEST_ONTOLOGY_RID = "ri.ontology.main.ontology.test-ontology";
-  const TEST_CLIENT_SECRET = "test-client-secret";
 
   function createTestPublicClient(): Client {
     const auth = createPublicOauthClient(

--- a/packages/app/src/utils/getPageEnv.ts
+++ b/packages/app/src/utils/getPageEnv.ts
@@ -19,6 +19,7 @@ interface Return {
   appVersion: string | null;
   baseUrl: string | null;
   clientId: string | null;
+  ontologyRid: string | null;
   redirectUrl: string | null;
 }
 
@@ -27,12 +28,14 @@ export function getPageEnv(): Return {
   const appVersion = getMetaTagContent("pack-appVersion");
   const foundryUrl = getMetaTagContent("osdk-foundryUrl");
   const clientId = getMetaTagContent("osdk-clientId");
+  const ontologyRid = getMetaTagContent("osdk-ontologyRid");
   const redirectUrl = getMetaTagContent("osdk-redirectUrl");
   return {
     appId,
     appVersion,
     baseUrl: foundryUrl,
     clientId,
+    ontologyRid,
     redirectUrl,
   };
 }

--- a/packages/app/src/utils/initPackApp.ts
+++ b/packages/app/src/utils/initPackApp.ts
@@ -312,6 +312,8 @@ function getAppConfig(
     throw new Error("No appId provided or present in document meta[pack-appId]");
   }
 
+  const ontologyRid = options.ontologyRid ?? pageEnv.ontologyRid;
+
   return {
     app: {
       appId,
@@ -319,6 +321,11 @@ function getAppConfig(
     },
     isTestMode,
     logger,
+    ontologyRid: ontologyRid != null && ontologyRid !== ""
+      ? Promise.resolve(ontologyRid)
+      : Promise.reject(
+        new Error("No ontologyRid provided or present in document meta[osdk-ontologyRid]"),
+      ),
     osdkClient: client,
     remote: {
       packWsPath: options.remote?.packWsPath ?? "/api/v2/packSubscriptions",

--- a/packages/auth/foundry/src/__tests__/AuthServiceConfidential.test.ts
+++ b/packages/auth/foundry/src/__tests__/AuthServiceConfidential.test.ts
@@ -53,6 +53,7 @@ describe("ConfidentialOauthService", () => {
         app: { appId: "test-app" },
         isTestMode: false,
         logger: mockLogger,
+        ontologyRid: Promise.resolve("ri.ontology...test"),
         osdkClient: mockOsdkClient,
         remote: {
           packWsPath: "/api/v2/packSubscriptions",

--- a/packages/auth/foundry/src/__tests__/AuthServicePublic.test.ts
+++ b/packages/auth/foundry/src/__tests__/AuthServicePublic.test.ts
@@ -52,6 +52,7 @@ describe("PublicOauthService", () => {
         app: { appId: "test-app" },
         isTestMode: false,
         logger: mockLogger,
+        ontologyRid: Promise.resolve("ri.ontology...test"),
         osdkClient: mockOsdkClient,
         remote: {
           packWsPath: "/api/v2/packSubscriptions",

--- a/packages/auth/foundry/src/__tests__/AuthServiceStatic.test.ts
+++ b/packages/auth/foundry/src/__tests__/AuthServiceStatic.test.ts
@@ -49,6 +49,7 @@ describe("StaticTokenService", () => {
         app: { appId: "test-app" },
         isTestMode: false,
         logger: mockLogger,
+        ontologyRid: Promise.resolve("ri.ontology...test"),
         osdkClient: mockOsdkClient,
         remote: {
           packWsPath: "/api/v2/packSubscriptions",
@@ -228,6 +229,7 @@ describe("StaticTokenService", () => {
             app: { appId: "test-app" },
             isTestMode: true,
             logger: mockLogger,
+            ontologyRid: Promise.resolve("ri.ontology...test"),
             osdkClient: mock<Client>(),
             remote: {
               packWsPath: "/api/v2/packSubscriptions",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,4 +23,5 @@ export type { TokenProvider } from "./types/TokenProvider.js";
 export type { Unsubscribe } from "./types/Unsubscribe.js";
 export { assertNever } from "./utils/assertNever.js";
 export { generateId } from "./utils/generateId.js";
+export { getOntologyRid } from "./utils/getOntologyRid.js";
 export { justOnce } from "./utils/justOnce.js";

--- a/packages/core/src/types/AppConfig.ts
+++ b/packages/core/src/types/AppConfig.ts
@@ -29,6 +29,7 @@ export interface AppConfig {
 
   readonly logger: Logger;
 
+  readonly ontologyRid: Promise<string>;
   readonly osdkClient: Client;
 
   readonly remote: {
@@ -67,6 +68,9 @@ export interface AppOptions {
    * Internal testing overrides.
    */
   readonly moduleOverrides?: readonly ModuleConfigTuple[];
+
+  // TODO: ideally we can extract this from the osdkClient but it hides everything and provides no util.
+  readonly ontologyRid?: string | Promise<string>;
 
   readonly remote?: {
     /**

--- a/packages/core/src/utils/getOntologyRid.ts
+++ b/packages/core/src/utils/getOntologyRid.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { PackApp, PackAppInternal } from "../types/PackApp.js";
+
+export async function getOntologyRid(app: PackApp | PackAppInternal): Promise<string> {
+  return app.config.ontologyRid;
+}

--- a/packages/document-schema/model-types/src/index.ts
+++ b/packages/document-schema/model-types/src/index.ts
@@ -28,6 +28,9 @@ export type {
   DiscretionaryPrincipal_GroupId,
   DiscretionaryPrincipal_UserId,
   DocumentMetadata,
+  DocumentSecurity,
+  DocumentSecurityDiscretionary,
+  DocumentSecurityMandatory,
 } from "./types/DocumentMetadata.js";
 export { DocumentRefBrand } from "./types/DocumentRef.js";
 export type { DocumentId, DocumentRef, PresenceSubscriptionOptions } from "./types/DocumentRef.js";

--- a/packages/document-schema/model-types/src/types/DocumentMetadata.ts
+++ b/packages/document-schema/model-types/src/types/DocumentMetadata.ts
@@ -32,19 +32,25 @@ export type DiscretionaryPrincipal =
   | DiscretionaryPrincipal_GroupId
   | DiscretionaryPrincipal_UserId;
 
+export interface DocumentSecurityDiscretionary {
+  readonly editors?: readonly DiscretionaryPrincipal[];
+  readonly owners?: readonly DiscretionaryPrincipal[];
+  readonly viewers?: readonly DiscretionaryPrincipal[];
+}
+
+export interface DocumentSecurityMandatory {
+  readonly classification?: readonly string[];
+  readonly markings?: readonly string[];
+}
+
+export interface DocumentSecurity {
+  readonly discretionary: DocumentSecurityDiscretionary;
+  readonly mandatory: DocumentSecurityMandatory;
+}
+
 export interface DocumentMetadata {
   readonly documentTypeName: string;
   readonly name: string;
   readonly ontologyRid: string;
-  readonly security: {
-    readonly discretionary: {
-      readonly editors?: readonly DiscretionaryPrincipal[];
-      readonly owners: readonly DiscretionaryPrincipal[];
-      readonly viewers?: readonly DiscretionaryPrincipal[];
-    };
-    readonly mandatory: {
-      readonly classification?: readonly string[];
-      readonly markings?: readonly string[];
-    };
-  };
+  readonly security: DocumentSecurity;
 }

--- a/packages/monorepo/cspell/dict.npm-packages.txt
+++ b/packages/monorepo/cspell/dict.npm-packages.txt
@@ -1,5 +1,6 @@
 arethetypeswrong
 attw
+blueprintjs
 cometd
 consola
 dprint
@@ -18,4 +19,5 @@ Momentjs
 monorepolint
 ngeohash
 npmjs
+rbush
 tsup

--- a/packages/state/core/src/__tests__/testUtils.ts
+++ b/packages/state/core/src/__tests__/testUtils.ts
@@ -44,6 +44,7 @@ export function createTestApp(
       },
       isTestMode: config.isTestMode ?? true,
       logger: config.logger ?? consoleLogger({}),
+      ontologyRid: config.ontologyRid ?? Promise.resolve("ri.ontology...test"),
       osdkClient: mockClient,
       remote: {
         packWsPath: "/api/v2/packSubscriptions",

--- a/packages/state/core/src/index.ts
+++ b/packages/state/core/src/index.ts
@@ -17,6 +17,7 @@
 export { createDocumentServiceConfig, getDocumentService } from "./DocumentServiceModule.js";
 export { BaseYjsDocumentService, type InternalYjsDoc } from "./service/BaseYjsDocumentService.js";
 export { createInMemoryDocumentServiceConfig } from "./service/InMemoryDocumentService.js";
+export type { CreateDocumentMetadata } from "./types/CreateDocumentMetadata.js";
 export { createDocRef, invalidDocRef, isValidDocRef } from "./types/DocumentRefImpl.js";
 export { DocumentLiveStatus, DocumentLoadStatus } from "./types/DocumentService.js";
 export type {

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -37,6 +37,7 @@ import {
 import { isDeepEqual } from "remeda";
 import invariant from "tiny-invariant";
 import * as Y from "yjs";
+import type { CreateDocumentMetadata } from "../types/CreateDocumentMetadata.js";
 import { createDocRef } from "../types/DocumentRefImpl.js";
 import type {
   DocumentMetadataChangeCallback,
@@ -124,7 +125,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
   abstract get hasMetadataSubscriptions(): boolean;
   abstract get hasStateSubscriptions(): boolean;
   abstract readonly createDocument: <T extends DocumentSchema>(
-    metadata: DocumentMetadata,
+    metadata: CreateDocumentMetadata,
     schema: T,
   ) => Promise<DocumentRef<T>>;
   abstract readonly searchDocuments: <T extends DocumentSchema>(
@@ -190,7 +191,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
 
   protected abstract createInternalDoc(
     ref: DocumentRef,
-    metadata?: DocumentMetadata,
+    metadata?: CreateDocumentMetadata,
     yDoc?: Y.Doc,
   ): TDoc;
 
@@ -374,7 +375,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
    */
   protected getCreateInternalDoc<T extends DocumentSchema>(
     ref: DocumentRef<T>,
-    metadata?: DocumentMetadata,
+    metadata?: CreateDocumentMetadata,
     initialYDoc?: Y.Doc,
   ): { internalDocRef: DocumentRef<T>; internalDoc: TDoc; wasExisting: boolean } {
     const { id, schema } = ref;

--- a/packages/state/core/src/service/InMemoryDocumentService.ts
+++ b/packages/state/core/src/service/InMemoryDocumentService.ts
@@ -28,6 +28,7 @@ import type {
   PresenceSubscriptionOptions,
 } from "@palantir/pack.document-schema.model-types";
 import { createDocumentServiceConfig } from "../DocumentServiceModule.js";
+import type { CreateDocumentMetadata } from "../types/CreateDocumentMetadata.js";
 import { createDocRef } from "../types/DocumentRefImpl.js";
 import type { DocumentService } from "../types/DocumentService.js";
 import { DocumentLoadStatus } from "../types/DocumentService.js";
@@ -90,7 +91,7 @@ class InMemoryDocumentService extends BaseYjsDocumentService {
   }
 
   readonly createDocument = <T extends DocumentSchema>(
-    metadata: DocumentMetadata,
+    metadata: CreateDocumentMetadata,
     schema: T,
   ): Promise<DocumentRef<T>> => {
     const id = generateDocumentId();

--- a/packages/state/core/src/types/CreateDocumentMetadata.ts
+++ b/packages/state/core/src/types/CreateDocumentMetadata.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DocumentSecurity } from "@palantir/pack.document-schema.model-types";
+
+export interface CreateDocumentMetadata {
+  readonly name: string;
+  readonly documentTypeName: string;
+  readonly security?: DocumentSecurity;
+}

--- a/packages/state/core/src/types/DocumentService.ts
+++ b/packages/state/core/src/types/DocumentService.ts
@@ -31,6 +31,7 @@ import type {
   RecordId,
   RecordRef,
 } from "@palantir/pack.document-schema.model-types";
+import type { CreateDocumentMetadata } from "./CreateDocumentMetadata.js";
 
 export const DocumentLoadStatus = {
   UNLOADED: "unloaded", // Not yet loaded
@@ -99,7 +100,7 @@ export interface DocumentService {
   readonly hasStateSubscriptions: boolean;
 
   readonly createDocument: <T extends DocumentSchema>(
-    metadata: DocumentMetadata,
+    metadata: CreateDocumentMetadata,
     schema: T,
   ) => Promise<DocumentRef<T>>;
 

--- a/packages/state/core/src/types/StateModule.ts
+++ b/packages/state/core/src/types/StateModule.ts
@@ -33,6 +33,7 @@ import type {
   RecordRef,
 } from "@palantir/pack.document-schema.model-types";
 import { DOCUMENT_SERVICE_MODULE_KEY } from "../DocumentServiceModule.js";
+import type { CreateDocumentMetadata } from "./CreateDocumentMetadata.js";
 import type {
   DocumentService,
   RecordChangeCallback,
@@ -65,7 +66,7 @@ export interface StateModule {
   ) => RecordRef<M>;
 
   readonly createDocument: <T extends DocumentSchema>(
-    metadata: DocumentMetadata,
+    metadata: CreateDocumentMetadata,
     schema: T,
   ) => Promise<DocumentRef<T>>;
 
@@ -198,7 +199,7 @@ export class StateModuleImpl implements StateModule {
   }
 
   async createDocument<T extends DocumentSchema>(
-    metadata: DocumentMetadata,
+    metadata: CreateDocumentMetadata,
     schema: T,
   ): Promise<DocumentRef<T>> {
     return this.documentService.createDocument(metadata, schema);

--- a/packages/state/demo/src/__tests__/DemoDocumentService.test.ts
+++ b/packages/state/demo/src/__tests__/DemoDocumentService.test.ts
@@ -27,7 +27,6 @@ import type {
 import { getMetadata, Metadata } from "@palantir/pack.document-schema.model-types";
 import { DocumentLiveStatus, DocumentLoadStatus, getStateModule } from "@palantir/pack.state.core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
 import { z } from "zod";
 import { createDemoDocumentServiceConfig } from "../index.js";
 
@@ -56,7 +55,9 @@ function createTestApp(
     ...config.moduleConfigs,
   };
 
-  const mockClient = config.osdkClient ?? mock<Client>();
+  const osdkClient = {
+    ontologyRid: "ri.ontology...test",
+  } as unknown as Client;
 
   const app: PackAppInternal = {
     config: {
@@ -66,7 +67,8 @@ function createTestApp(
       },
       isTestMode: config.isTestMode ?? true,
       logger: config.logger ?? consoleLogger({}),
-      osdkClient: mockClient,
+      ontologyRid: Promise.resolve("ri.ontology...test"),
+      osdkClient,
       remote: {
         baseUrl: "http://localhost",
         fetchFn: fetch,


### PR DESCRIPTION
Part of this requires an ontologyRid configured in the pack config. This would ideally come from the osdkClient but it is hidden in the client and not accessible, but we can ensure it is set in pack config (by default pulling from the page env like osdk).

Separate loaded `DocumentMetadata` from the create request `CreateDocumentMetadata`
Allow omit security for fully default security.
Fixed wire types used for security.
