### PR TITLE
Schema types update and schema wire converter

### DIFF
--- a/.changeset/huge-dodos-jog.md
+++ b/.changeset/huge-dodos-jog.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.document-schema.type-gen": minor
+---
+
+refactor schema types

--- a/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import type { DocumentTypeSchema } from "@osdk/foundry.pack";
 import { CommanderError } from "commander";
 import { consola } from "consola";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
 import type { IRealTimeDocumentSchema } from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import { convertIrToWireSchema } from "../../utils/ir/convertIrToWireSchema.js";
 
 type FileSystemType = "ARTIFACTS" | "COMPASS";
 
@@ -32,7 +34,7 @@ interface DocumentTypeAsset {
   readonly documentTypeName: string;
   readonly documentStorageType: {
     readonly type: "yjs";
-    readonly yjs: Omit<IRealTimeDocumentSchema, "name" | "description" | "version">;
+    readonly yjs: DocumentTypeSchema;
   };
   readonly fileSystemType: FileSystemType;
   readonly schemaVersion: number;
@@ -58,14 +60,12 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
     }
 
     consola.info(`Reading IR schema from: ${irPath}`);
-    const {
-      name: documentTypeName,
-      description: _description,
-      version: schemaVersion,
-      ...irSchema
-    } = JSON.parse(
+    const irSchema = JSON.parse(
       readFileSync(irPath, "utf8"),
     ) as IRealTimeDocumentSchema;
+
+    const { name: documentTypeName, version: schemaVersion } = irSchema;
+    const wireSchema = convertIrToWireSchema(irSchema);
 
     const fileSystemType = options.fileSystemType ?? "ARTIFACTS";
     if (fileSystemType !== "ARTIFACTS" && fileSystemType !== "COMPASS") {
@@ -80,7 +80,7 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
       documentTypeName,
       documentStorageType: {
         type: "yjs",
-        yjs: irSchema,
+        yjs: wireSchema,
       },
       fileSystemType,
       schemaVersion,

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldDef.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldDef.ts
@@ -22,6 +22,6 @@ export interface IFieldDef {
   readonly "name": string;
   readonly "description"?: string | null;
   readonly "isOptional"?: boolean | null;
-  readonly "value": IFieldTypeUnion.IFieldTypeUnion;
-  readonly "meta": ISchemaMeta;
+  readonly "fieldType": IFieldTypeUnion.IFieldTypeUnion;
+  readonly "metadata": ISchemaMeta;
 }

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldValueDatetime.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldValueDatetime.ts
@@ -15,5 +15,5 @@
  */
 
 export interface IFieldValueDatetime {
-  readonly "value"?: any;
+  readonly "value"?: string;
 }

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldValueDatetime.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldValueDatetime.ts
@@ -15,4 +15,5 @@
  */
 
 export interface IFieldValueDatetime {
+  readonly "value"?: any;
 }

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldValueMediaRef.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldValueMediaRef.ts
@@ -15,4 +15,5 @@
  */
 
 export interface IFieldValueMediaRef {
+  readonly "value"?: any;
 }

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldValueText.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/fieldValueText.ts
@@ -15,4 +15,7 @@
  */
 
 export interface IFieldValueText {
+  readonly "defaultValue"?: string | null;
+  readonly "minLength"?: number | null;
+  readonly "maxLength"?: number | null;
 }

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/index.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/index.ts
@@ -18,7 +18,6 @@ export * from "./fieldDef.js";
 export * from "./fieldTypeCollection.js";
 export * from "./fieldTypeMap.js";
 export * from "./fieldTypeUnion.js";
-export * from "./fieldValueBoolean.js";
 export * from "./fieldValueDatetime.js";
 export * from "./fieldValueDocumentRef.js";
 export * from "./fieldValueDouble.js";

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/index.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/index.ts
@@ -18,6 +18,7 @@ export * from "./fieldDef.js";
 export * from "./fieldTypeCollection.js";
 export * from "./fieldTypeMap.js";
 export * from "./fieldTypeUnion.js";
+export * from "./fieldValueBoolean.js";
 export * from "./fieldValueDatetime.js";
 export * from "./fieldValueDocumentRef.js";
 export * from "./fieldValueDouble.js";

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/recordDef.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/recordDef.ts
@@ -22,5 +22,5 @@ export interface IRecordDef {
   readonly "name": string;
   readonly "description"?: string | null;
   readonly "fields": ReadonlyArray<IFieldDef>;
-  readonly "meta": ISchemaMeta;
+  readonly "metadata": ISchemaMeta;
 }

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/schemaMeta.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/schemaMeta.ts
@@ -16,7 +16,7 @@
 
 import type { ISchemaVersion } from "../pack-docschema-api/schemaVersion.js";
 export interface ISchemaMeta {
-  readonly "addedIn": ISchemaVersion;
-  readonly "deprecated"?: ISchemaVersion | null;
+  readonly "addedInVersion": ISchemaVersion;
+  readonly "deprecatedFromVersion"?: ISchemaVersion | null;
   readonly "deprecatedMessage"?: string | null;
 }

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/unionDef.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/unionDef.ts
@@ -26,5 +26,5 @@ export interface IUnionDef {
   readonly "variants": {
     readonly [key: IUnionVariantKey]: IModelTypeKey;
   };
-  readonly "meta": ISchemaMeta;
+  readonly "metadata": ISchemaMeta;
 }

--- a/packages/document-schema/type-gen/src/utils/ir/__tests__/convertIrToWireSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/__tests__/convertIrToWireSchema.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { FieldValueType, RecordDef, UnionDef } from "@osdk/foundry.pack";
 import { describe, expect, it } from "vitest";
 import type {
   IModelDef,
@@ -61,14 +62,16 @@ describe("convertIrToWireSchema", () => {
     expect(wire.models).toBeDefined();
 
     // Model is flattened (no .record wrapper)
-    const personModel = wire.models["Person"] as any;
-    expect(personModel.type).toBe("record");
-    expect(personModel.key).toBe("Person");
-    expect(personModel.name).toBe("Person");
-    expect(personModel.record).toBeUndefined(); // no conjure nesting
+    const personModel = wire.models["Person"];
+    expect(personModel).toBeDefined();
+    expect(personModel!.type).toBe("record");
+    const person = personModel as { type: "record" } & RecordDef;
+    expect(person.key).toBe("Person");
+    expect(person.name).toBe("Person");
+    expect("record" in person).toBe(false); // no conjure nesting
 
     // Field uses wire field names
-    const nameField = personModel.fields[0];
+    const nameField = person.fields[0]!;
     expect(nameField.key).toBe("name");
     expect(nameField.fieldType).toBeDefined();
     expect(nameField.metadata).toEqual({ addedInVersion: 1 });
@@ -94,13 +97,15 @@ describe("convertIrToWireSchema", () => {
     };
 
     const wire = convertIrToWireSchema(ir);
-    const shapeModel = wire.models["Shape"] as any;
+    const shapeModel = wire.models["Shape"];
+    expect(shapeModel).toBeDefined();
+    expect(shapeModel!.type).toBe("union");
+    const shape = shapeModel as { type: "union" } & UnionDef;
 
-    expect(shapeModel.type).toBe("union");
-    expect(shapeModel.key).toBe("Shape");
-    expect(shapeModel.discriminant).toBe("shapeType");
-    expect(shapeModel.variants).toEqual({ circle: "Circle", square: "Square" });
-    expect(shapeModel.union).toBeUndefined(); // no conjure nesting
+    expect(shape.key).toBe("Shape");
+    expect(shape.discriminant).toBe("shapeType");
+    expect(shape.variants).toEqual({ circle: "Circle", square: "Square" });
+    expect("union" in shape).toBe(false); // no conjure nesting
   });
 
   it("should convert value field type with FieldValueType wrapper", () => {
@@ -130,7 +135,10 @@ describe("convertIrToWireSchema", () => {
     };
 
     const wire = convertIrToWireSchema(ir);
-    const field = (wire.models["R"] as any).fields[0];
+    expect(wire.models["R"]).toBeDefined();
+    expect(wire.models["R"]!.type).toBe("record");
+    const recordModel = wire.models["R"] as { type: "record" } & RecordDef;
+    const field = recordModel.fields[0]!;
 
     // Wire format wraps in { valueType: { type: "string", defaultValue: "abc" } }
     expect(field.fieldType).toEqual({
@@ -172,7 +180,10 @@ describe("convertIrToWireSchema", () => {
     };
 
     const wire = convertIrToWireSchema(ir);
-    const field = (wire.models["R"] as any).fields[0];
+    expect(wire.models["R"]).toBeDefined();
+    expect(wire.models["R"]!.type).toBe("record");
+    const recordModel = wire.models["R"] as { type: "record" } & RecordDef;
+    const field = recordModel.fields[0]!;
 
     expect(field.fieldType).toEqual({
       type: "array",
@@ -186,7 +197,11 @@ describe("convertIrToWireSchema", () => {
   });
 
   it("should flatten all field value union variants", () => {
-    const variants = [
+    const variants: Array<{
+      fn: (payload: never) => IFieldValueUnion;
+      type: string;
+      payload: Record<string, unknown>;
+    }> = [
       { fn: IFieldValueUnion.boolean, type: "boolean", payload: {} },
       { fn: IFieldValueUnion.datetime, type: "datetime", payload: {} },
       { fn: IFieldValueUnion.docRef, type: "docRef", payload: { documentTypeRids: ["rid1"] } },
@@ -203,7 +218,7 @@ describe("convertIrToWireSchema", () => {
       { fn: IFieldValueUnion.text, type: "text", payload: {} },
       { fn: IFieldValueUnion.unmanagedJson, type: "unmanagedJson", payload: {} },
       { fn: IFieldValueUnion.userRef, type: "userRef", payload: {} },
-    ] as const;
+    ];
 
     for (const { fn, type, payload } of variants) {
       const record: IRecordDef = {
@@ -215,7 +230,7 @@ describe("convertIrToWireSchema", () => {
             name: "f",
             fieldType: {
               type: "value",
-              value: (fn as any)(payload),
+              value: fn(payload as never),
             },
             metadata: { addedInVersion: 1 },
           },
@@ -232,15 +247,18 @@ describe("convertIrToWireSchema", () => {
       };
 
       const wire = convertIrToWireSchema(ir);
-      const fieldType = (wire.models["R"] as any).fields[0].fieldType;
-
-      // Value should be flat: { type: "string", maxLength: 255 } not { type: "string", string: { maxLength: 255 } }
-      const wireValue = fieldType.valueType;
+      expect(wire.models["R"]).toBeDefined();
+      expect(wire.models["R"]!.type).toBe("record");
+      const recordModel = wire.models["R"] as { type: "record" } & RecordDef;
+      const fieldType = recordModel.fields[0]!.fieldType;
+      expect(fieldType.type).toBe("value");
+      const wireValue = (fieldType as { type: "value" } & FieldValueType).valueType;
       expect(wireValue.type).toBe(type);
-      expect(wireValue[type]).toBeUndefined(); // no conjure nesting key
+      // no conjure nesting key
+      expect((wireValue as unknown as Record<string, unknown>)[type]).toBeUndefined();
       // Payload fields should be at top level
       for (const [key, val] of Object.entries(payload)) {
-        expect(wireValue[key]).toEqual(val);
+        expect((wireValue as unknown as Record<string, unknown>)[key]).toEqual(val);
       }
     }
   });
@@ -256,9 +274,9 @@ describe("convertIrToWireSchema", () => {
 
     const wire = convertIrToWireSchema(ir);
 
-    expect((wire as any).name).toBeUndefined();
-    expect((wire as any).description).toBeUndefined();
-    expect((wire as any).version).toBeUndefined();
+    expect("name" in wire).toBe(false);
+    expect("description" in wire).toBe(false);
+    expect("version" in wire).toBe(false);
     expect(wire.primaryModelKeys).toEqual([]);
     expect(wire.models).toEqual({});
   });

--- a/packages/document-schema/type-gen/src/utils/ir/__tests__/convertIrToWireSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/__tests__/convertIrToWireSchema.test.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  IModelDef,
+  IRealTimeDocumentSchema,
+  IRecordDef,
+  IUnionDef,
+} from "../../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import { IFieldValueUnion } from "../../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import { convertIrToWireSchema } from "../convertIrToWireSchema.js";
+
+describe("convertIrToWireSchema", () => {
+  it("should flatten record model and rename fields correctly", () => {
+    const record: IRecordDef = {
+      key: "Person",
+      name: "Person",
+      description: "A person",
+      fields: [
+        {
+          key: "name",
+          name: "Name",
+          fieldType: {
+            type: "value",
+            value: IFieldValueUnion.string({}),
+          },
+          metadata: { addedInVersion: 1 },
+        },
+      ],
+      metadata: { addedInVersion: 1 },
+    };
+
+    const ir: IRealTimeDocumentSchema = {
+      name: "Test",
+      description: "Test schema",
+      version: 1,
+      primaryModelKeys: ["Person"],
+      models: {
+        Person: { type: "record", record } as IModelDef,
+      },
+    };
+
+    const wire = convertIrToWireSchema(ir);
+
+    // Top-level structure
+    expect(wire.primaryModelKeys).toEqual(["Person"]);
+    expect(wire.models).toBeDefined();
+
+    // Model is flattened (no .record wrapper)
+    const personModel = wire.models["Person"] as any;
+    expect(personModel.type).toBe("record");
+    expect(personModel.key).toBe("Person");
+    expect(personModel.name).toBe("Person");
+    expect(personModel.record).toBeUndefined(); // no conjure nesting
+
+    // Field uses wire field names
+    const nameField = personModel.fields[0];
+    expect(nameField.key).toBe("name");
+    expect(nameField.fieldType).toBeDefined();
+    expect(nameField.metadata).toEqual({ addedInVersion: 1 });
+  });
+
+  it("should flatten union model", () => {
+    const union: IUnionDef = {
+      key: "Shape",
+      discriminant: "shapeType",
+      name: "Shape",
+      variants: { circle: "Circle", square: "Square" },
+      metadata: { addedInVersion: 1 },
+    };
+
+    const ir: IRealTimeDocumentSchema = {
+      name: "Test",
+      description: "Test",
+      version: 1,
+      primaryModelKeys: ["Shape"],
+      models: {
+        Shape: { type: "union", union } as IModelDef,
+      },
+    };
+
+    const wire = convertIrToWireSchema(ir);
+    const shapeModel = wire.models["Shape"] as any;
+
+    expect(shapeModel.type).toBe("union");
+    expect(shapeModel.key).toBe("Shape");
+    expect(shapeModel.discriminant).toBe("shapeType");
+    expect(shapeModel.variants).toEqual({ circle: "Circle", square: "Square" });
+    expect(shapeModel.union).toBeUndefined(); // no conjure nesting
+  });
+
+  it("should convert value field type with FieldValueType wrapper", () => {
+    const record: IRecordDef = {
+      key: "R",
+      name: "R",
+      fields: [
+        {
+          key: "f",
+          name: "f",
+          fieldType: {
+            type: "value",
+            value: IFieldValueUnion.string({ defaultValue: "abc" }),
+          },
+          metadata: { addedInVersion: 1 },
+        },
+      ],
+      metadata: { addedInVersion: 1 },
+    };
+
+    const ir: IRealTimeDocumentSchema = {
+      name: "Test",
+      description: "Test",
+      version: 1,
+      primaryModelKeys: ["R"],
+      models: { R: { type: "record", record } as IModelDef },
+    };
+
+    const wire = convertIrToWireSchema(ir);
+    const field = (wire.models["R"] as any).fields[0];
+
+    // Wire format wraps in { valueType: { type: "string", defaultValue: "abc" } }
+    expect(field.fieldType).toEqual({
+      type: "value",
+      valueType: {
+        type: "string",
+        defaultValue: "abc",
+      },
+    });
+  });
+
+  it("should convert array field type with FieldValueType wrapper on elements", () => {
+    const record: IRecordDef = {
+      key: "R",
+      name: "R",
+      fields: [
+        {
+          key: "tags",
+          name: "Tags",
+          fieldType: {
+            type: "array",
+            array: {
+              allowNullValue: false,
+              value: IFieldValueUnion.string({}),
+            },
+          },
+          metadata: { addedInVersion: 1 },
+        },
+      ],
+      metadata: { addedInVersion: 1 },
+    };
+
+    const ir: IRealTimeDocumentSchema = {
+      name: "Test",
+      description: "Test",
+      version: 1,
+      primaryModelKeys: ["R"],
+      models: { R: { type: "record", record } as IModelDef },
+    };
+
+    const wire = convertIrToWireSchema(ir);
+    const field = (wire.models["R"] as any).fields[0];
+
+    expect(field.fieldType).toEqual({
+      type: "array",
+      allowNullValue: false,
+      value: {
+        valueType: {
+          type: "string",
+        },
+      },
+    });
+  });
+
+  it("should flatten all field value union variants", () => {
+    const variants = [
+      { fn: IFieldValueUnion.boolean, type: "boolean", payload: {} },
+      { fn: IFieldValueUnion.datetime, type: "datetime", payload: {} },
+      { fn: IFieldValueUnion.docRef, type: "docRef", payload: { documentTypeRids: ["rid1"] } },
+      { fn: IFieldValueUnion.double, type: "double", payload: { minValue: 0, maxValue: 100 } },
+      { fn: IFieldValueUnion.integer, type: "integer", payload: { defaultValue: 42 } },
+      { fn: IFieldValueUnion.mediaRef, type: "mediaRef", payload: {} },
+      { fn: IFieldValueUnion.modelRef, type: "modelRef", payload: { modelTypes: ["Foo"] } },
+      {
+        fn: IFieldValueUnion.object,
+        type: "object",
+        payload: { interfaceTypeRids: [], objectTypeRids: ["rid2"] },
+      },
+      { fn: IFieldValueUnion.string, type: "string", payload: { maxLength: 255 } },
+      { fn: IFieldValueUnion.text, type: "text", payload: {} },
+      { fn: IFieldValueUnion.unmanagedJson, type: "unmanagedJson", payload: {} },
+      { fn: IFieldValueUnion.userRef, type: "userRef", payload: {} },
+    ] as const;
+
+    for (const { fn, type, payload } of variants) {
+      const record: IRecordDef = {
+        key: "R",
+        name: "R",
+        fields: [
+          {
+            key: "f",
+            name: "f",
+            fieldType: {
+              type: "value",
+              value: (fn as any)(payload),
+            },
+            metadata: { addedInVersion: 1 },
+          },
+        ],
+        metadata: { addedInVersion: 1 },
+      };
+
+      const ir: IRealTimeDocumentSchema = {
+        name: "Test",
+        description: "Test",
+        version: 1,
+        primaryModelKeys: ["R"],
+        models: { R: { type: "record", record } as IModelDef },
+      };
+
+      const wire = convertIrToWireSchema(ir);
+      const fieldType = (wire.models["R"] as any).fields[0].fieldType;
+
+      // Value should be flat: { type: "string", maxLength: 255 } not { type: "string", string: { maxLength: 255 } }
+      const wireValue = fieldType.valueType;
+      expect(wireValue.type).toBe(type);
+      expect(wireValue[type]).toBeUndefined(); // no conjure nesting key
+      // Payload fields should be at top level
+      for (const [key, val] of Object.entries(payload)) {
+        expect(wireValue[key]).toEqual(val);
+      }
+    }
+  });
+
+  it("should strip name, description, version from output", () => {
+    const ir: IRealTimeDocumentSchema = {
+      name: "My Schema",
+      description: "My description",
+      version: 5,
+      primaryModelKeys: [],
+      models: {},
+    };
+
+    const wire = convertIrToWireSchema(ir);
+
+    expect((wire as any).name).toBeUndefined();
+    expect((wire as any).description).toBeUndefined();
+    expect((wire as any).version).toBeUndefined();
+    expect(wire.primaryModelKeys).toEqual([]);
+    expect(wire.models).toEqual({});
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/ir/__tests__/generateModelsFromIr.test.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/__tests__/generateModelsFromIr.test.ts
@@ -34,28 +34,28 @@ describe("generateModelsFromIr", () => {
       key: "name",
       name: "Name",
       description: "Person name",
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "string",
           string: { minLength: 2, maxLength: 50 },
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const personField2: IFieldDef = {
       key: "age",
       name: "Age",
       description: "Person age",
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "integer",
           integer: { minValue: 0, maxValue: 150 },
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const personRecord: IRecordDef = {
@@ -63,7 +63,7 @@ describe("generateModelsFromIr", () => {
       name: "Person",
       description: "A person record",
       fields: [personField1, personField2],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -99,7 +99,7 @@ describe("generateModelsFromIr", () => {
       key: "documentRef",
       name: "Document Reference",
       description: "Reference to a document",
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "docRef",
@@ -108,35 +108,35 @@ describe("generateModelsFromIr", () => {
           },
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const eventField2: IFieldDef = {
       key: "userRef",
       name: "User Reference",
       description: "Reference to a user",
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "userRef",
           userRef: {},
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const eventField3: IFieldDef = {
       key: "timestamp",
       name: "Timestamp",
       description: "Event timestamp",
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "datetime",
           datetime: {},
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const eventRecord: IRecordDef = {
@@ -144,7 +144,7 @@ describe("generateModelsFromIr", () => {
       name: "Event",
       description: "An event record with external refs",
       fields: [eventField1, eventField2, eventField3],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -182,30 +182,30 @@ describe("generateModelsFromIr", () => {
           key: "x",
           name: "X",
           description: "X coordinate",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "double",
               double: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
         {
           key: "y",
           name: "Y",
           description: "Y coordinate",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "double",
               double: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     // Define the TextBox record
@@ -218,30 +218,30 @@ describe("generateModelsFromIr", () => {
           key: "x",
           name: "X",
           description: "X coordinate",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "double",
               double: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
         {
           key: "text",
           name: "Text",
           description: "Text content",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "string",
               string: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     // Define the Node union
@@ -254,7 +254,7 @@ describe("generateModelsFromIr", () => {
         object: "ObjectNode",
         "text-box": "TextBox",
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -309,17 +309,17 @@ describe("generateModelsFromIr", () => {
           key: "meow",
           name: "Meow",
           description: "Cat sound",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "string",
               string: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const dogRecord: IRecordDef = {
@@ -331,17 +331,17 @@ describe("generateModelsFromIr", () => {
           key: "bark",
           name: "Bark",
           description: "Dog sound",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "string",
               string: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const animalUnion: IUnionDef = {
@@ -353,7 +353,7 @@ describe("generateModelsFromIr", () => {
         cat: "Cat",
         dog: "Dog",
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {

--- a/packages/document-schema/type-gen/src/utils/ir/__tests__/generateZodSchemasFromIr.test.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/__tests__/generateZodSchemasFromIr.test.ts
@@ -33,28 +33,28 @@ describe("generateZodSchemasFromIr", () => {
       key: "name",
       name: "Name",
       description: "Person name",
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "string",
           string: { minLength: 2, maxLength: 50 },
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const personField2: IFieldDef = {
       key: "age",
       name: "Age",
       description: "Person age",
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "integer",
           integer: { minValue: 0, maxValue: 150 },
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const personField3: IFieldDef = {
@@ -62,14 +62,14 @@ describe("generateZodSchemasFromIr", () => {
       name: "Email",
       description: "Person email",
       isOptional: true,
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "string",
           string: {},
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const personRecord: IRecordDef = {
@@ -77,7 +77,7 @@ describe("generateZodSchemasFromIr", () => {
       name: "Person",
       description: "A person record",
       fields: [personField1, personField2, personField3],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -104,7 +104,7 @@ describe("generateZodSchemasFromIr", () => {
       key: "tags",
       name: "Tags",
       description: "List of tags",
-      value: {
+      fieldType: {
         type: "array",
         array: {
           allowNullValue: false,
@@ -114,14 +114,14 @@ describe("generateZodSchemasFromIr", () => {
           },
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const mapField: IFieldDef = {
       key: "metadata",
       name: "Metadata",
       description: "Key-value metadata",
-      value: {
+      fieldType: {
         type: "map",
         map: {
           allowNullValue: false,
@@ -135,7 +135,7 @@ describe("generateZodSchemasFromIr", () => {
           },
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const containerRecord: IRecordDef = {
@@ -143,7 +143,7 @@ describe("generateZodSchemasFromIr", () => {
       name: "Container",
       description: "A container record",
       fields: [arrayField, mapField],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -170,14 +170,14 @@ describe("generateZodSchemasFromIr", () => {
       key: "timestamp",
       name: "Timestamp",
       description: "Event timestamp",
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "datetime",
           datetime: {},
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const eventRecord: IRecordDef = {
@@ -185,7 +185,7 @@ describe("generateZodSchemasFromIr", () => {
       name: "Event",
       description: "An event record",
       fields: [datetimeField],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -212,14 +212,14 @@ describe("generateZodSchemasFromIr", () => {
       key: "enabled",
       name: "Enabled",
       description: "Whether feature is enabled",
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "boolean",
           boolean: {},
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const optionalBooleanField: IFieldDef = {
@@ -227,21 +227,21 @@ describe("generateZodSchemasFromIr", () => {
       name: "IsPublic",
       description: "Whether feature is public",
       isOptional: true,
-      value: {
+      fieldType: {
         type: "value",
         value: {
           type: "boolean",
           boolean: {},
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const booleanArrayField: IFieldDef = {
       key: "flags",
       name: "Flags",
       description: "Array of boolean flags",
-      value: {
+      fieldType: {
         type: "array",
         array: {
           allowNullValue: false,
@@ -251,7 +251,7 @@ describe("generateZodSchemasFromIr", () => {
           },
         },
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const featureRecord: IRecordDef = {
@@ -259,7 +259,7 @@ describe("generateZodSchemasFromIr", () => {
       name: "Feature",
       description: "A feature toggle record",
       fields: [booleanField, optionalBooleanField, booleanArrayField],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -292,44 +292,44 @@ describe("generateZodSchemasFromIr", () => {
           key: "x",
           name: "X",
           description: "X coordinate",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "double",
               double: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
         {
           key: "y",
           name: "Y",
           description: "Y coordinate",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "double",
               double: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
         {
           key: "label",
           name: "Label",
           description: "Node label",
           isOptional: true,
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "string",
               string: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     // Define the TextBox record
@@ -342,43 +342,43 @@ describe("generateZodSchemasFromIr", () => {
           key: "x",
           name: "X",
           description: "X coordinate",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "double",
               double: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
         {
           key: "y",
           name: "Y",
           description: "Y coordinate",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "double",
               double: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
         {
           key: "text",
           name: "Text",
           description: "Text content",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "string",
               string: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     // Define the Node union
@@ -391,7 +391,7 @@ describe("generateZodSchemasFromIr", () => {
         object: "ObjectNode",
         "text-box": "TextBox",
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -432,17 +432,17 @@ describe("generateZodSchemasFromIr", () => {
           key: "value",
           name: "Value",
           description: "A value",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "string",
               string: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const barRecord: IRecordDef = {
@@ -454,17 +454,17 @@ describe("generateZodSchemasFromIr", () => {
           key: "count",
           name: "Count",
           description: "A count",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "integer",
               integer: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     // Define union that references the records
@@ -477,7 +477,7 @@ describe("generateZodSchemasFromIr", () => {
         foo: "Foo",
         bar: "Bar",
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     // Intentionally put union BEFORE its variant records in primaryModelKeys
@@ -532,17 +532,17 @@ describe("generateZodSchemasFromIr", () => {
           key: "meow",
           name: "Meow",
           description: "Cat sound",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "string",
               string: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const dogRecord: IRecordDef = {
@@ -554,17 +554,17 @@ describe("generateZodSchemasFromIr", () => {
           key: "bark",
           name: "Bark",
           description: "Dog sound",
-          value: {
+          fieldType: {
             type: "value",
             value: {
               type: "string",
               string: {},
             },
           },
-          meta: { addedIn: 1 },
+          metadata: { addedInVersion: 1 },
         },
       ],
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const animalUnion: IUnionDef = {
@@ -576,7 +576,7 @@ describe("generateZodSchemasFromIr", () => {
         cat: "Cat",
         dog: "Dog",
       },
-      meta: { addedIn: 1 },
+      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {

--- a/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DocumentTypeSchema } from "@osdk/foundry.pack";
+import type {
+  IFieldDef,
+  IFieldTypeUnion,
+  IFieldValueUnion,
+  IModelDef,
+  IRealTimeDocumentSchema,
+  ISchemaMeta,
+} from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+
+/**
+ * Converts the internal IR schema to the wire format expected by the Foundry API.
+ *
+ * The IR uses conjure-style tagged unions where the payload is nested under a key
+ * matching the discriminant (e.g. `{ type: "record", record: { ... } }`).
+ *
+ * The Foundry API (DocumentTypeSchema from @osdk/foundry.pack) uses flat discriminated
+ * unions where payload fields are spread alongside the type discriminant
+ * (e.g. `{ type: "record", key: "...", name: "...", ... }`).
+ *
+ * This function performs that structural conversion. Field names already match between
+ * the IR and wire format.
+ */
+export function convertIrToWireSchema(ir: IRealTimeDocumentSchema): DocumentTypeSchema {
+  const wireModels: Record<string, unknown> = {};
+
+  for (const [key, model] of Object.entries(ir.models)) {
+    wireModels[key] = convertModelDef(model);
+  }
+
+  return {
+    primaryModelKeys: [...ir.primaryModelKeys],
+    models: wireModels as DocumentTypeSchema["models"],
+  };
+}
+
+function convertModelDef(model: IModelDef): unknown {
+  switch (model.type) {
+    case "record":
+      return {
+        type: "record",
+        key: model.record.key,
+        name: model.record.name,
+        description: model.record.description,
+        fields: model.record.fields.map(convertFieldDef),
+        metadata: convertSchemaMeta(model.record.metadata),
+      };
+    case "union":
+      return {
+        type: "union",
+        key: model.union.key,
+        discriminant: model.union.discriminant,
+        name: model.union.name,
+        description: model.union.description,
+        variants: { ...model.union.variants },
+        metadata: convertSchemaMeta(model.union.metadata),
+      };
+  }
+}
+
+function convertFieldDef(field: IFieldDef): unknown {
+  return {
+    key: field.key,
+    name: field.name,
+    description: field.description,
+    isOptional: field.isOptional,
+    fieldType: convertFieldTypeUnion(field.fieldType),
+    metadata: convertSchemaMeta(field.metadata),
+  };
+}
+
+function convertFieldTypeUnion(fieldType: IFieldTypeUnion): unknown {
+  switch (fieldType.type) {
+    case "array":
+      return {
+        type: "array",
+        allowNullValue: fieldType.array.allowNullValue,
+        value: convertFieldValueType(fieldType.array.value),
+      };
+    case "map":
+      return {
+        type: "map",
+        allowNullValue: fieldType.map.allowNullValue,
+        key: convertFieldValueType(fieldType.map.key),
+        value: convertFieldValueType(fieldType.map.value),
+      };
+    case "set":
+      return {
+        type: "set",
+        allowNullValue: fieldType.set.allowNullValue,
+        value: convertFieldValueType(fieldType.set.value),
+      };
+    case "value":
+      return {
+        type: "value",
+        valueType: convertFieldValueUnion(fieldType.value),
+      };
+  }
+}
+
+/**
+ * Wraps a field value union in the FieldValueType wrapper expected by the wire format.
+ * Wire format: `{ valueType: { type: "string", ... } }`
+ */
+function convertFieldValueType(value: IFieldValueUnion): unknown {
+  return {
+    valueType: convertFieldValueUnion(value),
+  };
+}
+
+/**
+ * Converts a conjure-tagged field value union to a flat discriminated union.
+ * IR: `{ type: "string", string: { defaultValue: "abc" } }`
+ * Wire: `{ type: "string", defaultValue: "abc" }`
+ */
+function convertFieldValueUnion(value: IFieldValueUnion): unknown {
+  switch (value.type) {
+    case "boolean":
+      return { type: "boolean", ...value.boolean };
+    case "datetime":
+      return { type: "datetime", ...value.datetime };
+    case "docRef":
+      return { type: "docRef", ...value.docRef };
+    case "double":
+      return { type: "double", ...value.double };
+    case "integer":
+      return { type: "integer", ...value.integer };
+    case "mediaRef":
+      return { type: "mediaRef", ...value.mediaRef };
+    case "modelRef":
+      return { type: "modelRef", ...value.modelRef };
+    case "object":
+      return { type: "object", ...value.object };
+    case "string":
+      return { type: "string", ...value.string };
+    case "text":
+      return { type: "text", ...value.text };
+    case "unmanagedJson":
+      return { type: "unmanagedJson", ...value.unmanagedJson };
+    case "userRef":
+      return { type: "userRef", ...value.userRef };
+  }
+}
+
+function convertSchemaMeta(meta: ISchemaMeta): unknown {
+  return {
+    addedInVersion: meta.addedInVersion,
+    deprecatedFromVersion: meta.deprecatedFromVersion,
+    deprecatedMessage: meta.deprecatedMessage,
+  };
+}

--- a/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import type { DocumentTypeSchema } from "@osdk/foundry.pack";
+import type {
+  DocumentTypeSchema,
+  FieldDef,
+  FieldTypeUnion,
+  FieldValueType,
+  FieldValueUnion,
+  ModelDef,
+  SchemaMetadata,
+} from "@osdk/foundry.pack";
 import type {
   IFieldDef,
   IFieldTypeUnion,
@@ -38,7 +46,7 @@ import type {
  * the IR and wire format.
  */
 export function convertIrToWireSchema(ir: IRealTimeDocumentSchema): DocumentTypeSchema {
-  const wireModels: Record<string, unknown> = {};
+  const wireModels: DocumentTypeSchema["models"] = {};
 
   for (const [key, model] of Object.entries(ir.models)) {
     wireModels[key] = convertModelDef(model);
@@ -46,19 +54,19 @@ export function convertIrToWireSchema(ir: IRealTimeDocumentSchema): DocumentType
 
   return {
     primaryModelKeys: [...ir.primaryModelKeys],
-    models: wireModels as DocumentTypeSchema["models"],
+    models: wireModels,
   };
 }
 
-function convertModelDef(model: IModelDef): unknown {
+function convertModelDef(model: IModelDef): ModelDef {
   switch (model.type) {
     case "record":
       return {
         type: "record",
         key: model.record.key,
         name: model.record.name,
-        description: model.record.description,
-        fields: model.record.fields.map(convertFieldDef),
+        description: orUndefined(model.record.description),
+        fields: [...model.record.fields.map(convertFieldDef)],
         metadata: convertSchemaMeta(model.record.metadata),
       };
     case "union":
@@ -67,25 +75,25 @@ function convertModelDef(model: IModelDef): unknown {
         key: model.union.key,
         discriminant: model.union.discriminant,
         name: model.union.name,
-        description: model.union.description,
+        description: orUndefined(model.union.description),
         variants: { ...model.union.variants },
         metadata: convertSchemaMeta(model.union.metadata),
       };
   }
 }
 
-function convertFieldDef(field: IFieldDef): unknown {
+function convertFieldDef(field: IFieldDef): FieldDef {
   return {
     key: field.key,
     name: field.name,
-    description: field.description,
-    isOptional: field.isOptional,
+    description: orUndefined(field.description),
+    isOptional: orUndefined(field.isOptional),
     fieldType: convertFieldTypeUnion(field.fieldType),
     metadata: convertSchemaMeta(field.metadata),
   };
 }
 
-function convertFieldTypeUnion(fieldType: IFieldTypeUnion): unknown {
+function convertFieldTypeUnion(fieldType: IFieldTypeUnion): FieldTypeUnion {
   switch (fieldType.type) {
     case "array":
       return {
@@ -114,54 +122,77 @@ function convertFieldTypeUnion(fieldType: IFieldTypeUnion): unknown {
   }
 }
 
-/**
- * Wraps a field value union in the FieldValueType wrapper expected by the wire format.
- * Wire format: `{ valueType: { type: "string", ... } }`
- */
-function convertFieldValueType(value: IFieldValueUnion): unknown {
+function convertFieldValueType(value: IFieldValueUnion): FieldValueType {
   return {
     valueType: convertFieldValueUnion(value),
   };
 }
 
-/**
- * Converts a conjure-tagged field value union to a flat discriminated union.
- * IR: `{ type: "string", string: { defaultValue: "abc" } }`
- * Wire: `{ type: "string", defaultValue: "abc" }`
- */
-function convertFieldValueUnion(value: IFieldValueUnion): unknown {
+function convertFieldValueUnion(value: IFieldValueUnion): FieldValueUnion {
   switch (value.type) {
     case "boolean":
-      return { type: "boolean", ...value.boolean };
+      return { type: "boolean", defaultValue: orUndefined(value.boolean.defaultValue) };
     case "datetime":
-      return { type: "datetime", ...value.datetime };
+      return { type: "datetime", value: value.datetime.value };
     case "docRef":
-      return { type: "docRef", ...value.docRef };
+      return { type: "docRef", documentTypeRids: [...value.docRef.documentTypeRids] };
     case "double":
-      return { type: "double", ...value.double };
+      return {
+        type: "double",
+        defaultValue: nanToNumber(orUndefined(value.double.defaultValue)),
+        minValue: nanToNumber(orUndefined(value.double.minValue)),
+        maxValue: nanToNumber(orUndefined(value.double.maxValue)),
+      };
     case "integer":
-      return { type: "integer", ...value.integer };
+      return {
+        type: "integer",
+        defaultValue: orUndefined(value.integer.defaultValue),
+        minValue: orUndefined(value.integer.minValue),
+        maxValue: orUndefined(value.integer.maxValue),
+      };
     case "mediaRef":
-      return { type: "mediaRef", ...value.mediaRef };
+      return { type: "mediaRef", value: value.mediaRef.value };
     case "modelRef":
-      return { type: "modelRef", ...value.modelRef };
+      return { type: "modelRef", modelTypes: [...value.modelRef.modelTypes] };
     case "object":
-      return { type: "object", ...value.object };
+      return {
+        type: "object",
+        interfaceTypeRids: [...value.object.interfaceTypeRids],
+        objectTypeRids: [...value.object.objectTypeRids],
+      };
     case "string":
-      return { type: "string", ...value.string };
+      return {
+        type: "string",
+        defaultValue: orUndefined(value.string.defaultValue),
+        minLength: orUndefined(value.string.minLength),
+        maxLength: orUndefined(value.string.maxLength),
+      };
     case "text":
-      return { type: "text", ...value.text };
+      return {
+        type: "text",
+        defaultValue: orUndefined(value.text.defaultValue),
+        minLength: orUndefined(value.text.minLength),
+        maxLength: orUndefined(value.text.maxLength),
+      };
     case "unmanagedJson":
-      return { type: "unmanagedJson", ...value.unmanagedJson };
+      return { type: "unmanagedJson" };
     case "userRef":
-      return { type: "userRef", ...value.userRef };
+      return { type: "userRef" };
   }
 }
 
-function convertSchemaMeta(meta: ISchemaMeta): unknown {
+function convertSchemaMeta(meta: ISchemaMeta): SchemaMetadata {
   return {
     addedInVersion: meta.addedInVersion,
-    deprecatedFromVersion: meta.deprecatedFromVersion,
-    deprecatedMessage: meta.deprecatedMessage,
+    deprecatedFromVersion: orUndefined(meta.deprecatedFromVersion),
+    deprecatedMessage: orUndefined(meta.deprecatedMessage),
   };
+}
+
+function orUndefined<T>(value: T | null | undefined): T | undefined {
+  return value ?? undefined;
+}
+
+function nanToNumber(value: number | "NaN" | undefined): number | undefined {
+  return value === "NaN" ? NaN : value;
 }

--- a/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
@@ -79,6 +79,10 @@ function convertModelDef(model: IModelDef): ModelDef {
         variants: { ...model.union.variants },
         metadata: convertSchemaMeta(model.union.metadata),
       };
+    default: {
+      const _exhaustive: never = model;
+      throw new Error(`Unknown model type: ${(_exhaustive as IModelDef).type}`);
+    }
   }
 }
 

--- a/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
@@ -143,9 +143,9 @@ function convertFieldValueUnion(value: IFieldValueUnion): FieldValueUnion {
     case "double":
       return {
         type: "double",
-        defaultValue: nanToNumber(orUndefined(value.double.defaultValue)),
-        minValue: nanToNumber(orUndefined(value.double.minValue)),
-        maxValue: nanToNumber(orUndefined(value.double.maxValue)),
+        defaultValue: rejectNaN(orUndefined(value.double.defaultValue)),
+        minValue: rejectNaN(orUndefined(value.double.minValue)),
+        maxValue: rejectNaN(orUndefined(value.double.maxValue)),
       };
     case "integer":
       return {
@@ -197,6 +197,9 @@ function orUndefined<T>(value: T | null | undefined): T | undefined {
   return value ?? undefined;
 }
 
-function nanToNumber(value: number | "NaN" | undefined): number | undefined {
-  return value === "NaN" ? NaN : value;
+function rejectNaN(value: number | "NaN" | undefined): number | undefined {
+  if (value === "NaN") {
+    throw new Error("NaN is not a valid double value for wire serialization");
+  }
+  return value;
 }

--- a/packages/document-schema/type-gen/src/utils/ir/generateModelsFromIr.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/generateModelsFromIr.ts
@@ -168,8 +168,8 @@ export const ${modelName}Model: ${modelName}Model = {
 
     const externalRefFields: Array<[string, string]> = [];
     for (const field of model.record.fields) {
-      if (field.value.type === "value") {
-        const valueType = field.value.value.type;
+      if (field.fieldType.type === "value") {
+        const valueType = field.fieldType.value.type;
         if (valueType === "docRef") {
           externalRefFields.push([field.key, "docRef"]);
         } else if (valueType === "mediaRef") {

--- a/packages/document-schema/type-gen/src/utils/ir/generateZodSchemasFromIr.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/generateZodSchemasFromIr.ts
@@ -266,7 +266,7 @@ class ZodSchemaGenerator {
   private generateFieldSchema(
     field: IFieldDef,
   ): string {
-    const fieldValueSchemaStr = this.generateFieldTypeSchema(field.value);
+    const fieldValueSchemaStr = this.generateFieldTypeSchema(field.fieldType);
 
     if (field.isOptional) {
       return `${fieldValueSchemaStr}.optional()`;

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToIr.test.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToIr.test.ts
@@ -59,7 +59,7 @@ describe("convertStepsToIr", () => {
     const nameField = personRecord.fields.find(f => f.key === "name");
     expect(nameField).toBeDefined();
     expect(nameField?.isOptional).toBeUndefined();
-    expect(nameField?.value).toEqual({
+    expect(nameField?.fieldType).toEqual({
       type: "value",
       value: {
         type: "string",
@@ -70,7 +70,7 @@ describe("convertStepsToIr", () => {
     // Check age field
     const ageField = personRecord.fields.find(f => f.key === "age");
     expect(ageField).toBeDefined();
-    expect(ageField?.value).toEqual({
+    expect(ageField?.fieldType).toEqual({
       type: "value",
       value: {
         type: "double",
@@ -82,7 +82,7 @@ describe("convertStepsToIr", () => {
     const emailField = personRecord.fields.find(f => f.key === "email");
     expect(emailField).toBeDefined();
     expect(emailField?.isOptional).toBe(true);
-    expect(emailField?.value).toEqual({
+    expect(emailField?.fieldType).toEqual({
       type: "value",
       value: {
         type: "string",
@@ -115,7 +115,7 @@ describe("convertStepsToIr", () => {
 
     // Check tags array field
     const tagsField = containerRecord.fields.find(f => f.key === "tags");
-    expect(tagsField?.value).toEqual({
+    expect(tagsField?.fieldType).toEqual({
       type: "array",
       array: {
         allowNullValue: false,
@@ -128,7 +128,7 @@ describe("convertStepsToIr", () => {
 
     // Check numbers list field (treated as array)
     const numbersField = containerRecord.fields.find(f => f.key === "numbers");
-    expect(numbersField?.value).toEqual({
+    expect(numbersField?.fieldType).toEqual({
       type: "array",
       array: {
         allowNullValue: false,
@@ -168,7 +168,7 @@ describe("convertStepsToIr", () => {
     const personRecord = personModel.record;
 
     const addressField = personRecord.fields.find(f => f.key === "address");
-    expect(addressField?.value).toEqual(
+    expect(addressField?.fieldType).toEqual(
       {
         type: "value",
         value: {
@@ -216,7 +216,7 @@ describe("convertStepsToIr", () => {
     // Check inherited fields from fragment
     const xField = objectNode.fields.find(f => f.key === "x");
     expect(xField).toBeDefined();
-    expect(xField?.value).toEqual({
+    expect(xField?.fieldType).toEqual({
       type: "value",
       value: {
         type: "double",
@@ -275,7 +275,7 @@ describe("convertStepsToIr", () => {
     const graphRecord = graphModel.record;
 
     const nodesField = graphRecord.fields.find(f => f.key === "nodes");
-    expect(nodesField?.value).toEqual({
+    expect(nodesField?.fieldType).toEqual({
       type: "array",
       array: {
         allowNullValue: false,

--- a/packages/document-schema/type-gen/src/utils/steps/convertStepsToIr.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/convertStepsToIr.ts
@@ -112,8 +112,8 @@ export function convertRecordDefToIr(recordDef: P.RecordDef): IRecordDef {
     key: fieldKey,
     name: fieldKey,
     description: undefined,
-    value: convertTypeToFieldTypeUnion(fieldType),
-    meta: { addedIn: 1 },
+    fieldType: convertTypeToFieldTypeUnion(fieldType),
+    metadata: { addedInVersion: 1 },
     isOptional: fieldType.type === "optional" ? true : undefined,
   }));
 
@@ -122,7 +122,7 @@ export function convertRecordDefToIr(recordDef: P.RecordDef): IRecordDef {
     name: recordDef.name,
     description: recordDef.docs || undefined,
     fields,
-    meta: { addedIn: 1 },
+    metadata: { addedInVersion: 1 },
   };
 }
 
@@ -142,7 +142,7 @@ export function convertUnionDefToIr(unionDef: P.UnionDef): IUnionDef {
     description: unionDef.docs,
     discriminant: unionDef.discriminant,
     variants: Object.fromEntries(variantEntries),
-    meta: { addedIn: 1 },
+    metadata: { addedInVersion: 1 },
   };
 }
 
@@ -201,9 +201,7 @@ function convertTypeToFieldValueUnion(schemaType: P.Type): IFieldValueUnion {
       return IFieldValueUnion.double({});
 
     case "mediaRef":
-      return IFieldValueUnion.mediaRef({
-        mediaTypeRids: [], // FIXME: confirm whether we will use rids in the deployed schema.
-      });
+      return IFieldValueUnion.mediaRef({});
 
     case "objectRef":
       return IFieldValueUnion.object({


### PR DESCRIPTION
Updates schema types to match public api types, and converts IR conjure nested union types to wire flattened union types.

IR now outputs:
```
{
  "name": "Generated Schema",
  "description": "Schema generated from migration steps",
  "version": 1,
  "primaryModelKeys": [
    "ActivityShapeAddEvent",
  ],
  "models": {
    "ActivityShapeAddEvent": {
      "record": {
        "key": "ActivityShapeAddEvent",
        "name": "ActivityShapeAddEvent",
        "description": "An event representing the addition of a shape node.",
        "fields": [
          {
            "key": "nodeId",
            "name": "nodeId",
            "fieldType": {
              "value": {
                "string": {},
                "type": "string"
              },
              "type": "value"
            },
            "metadata": {
              "addedInVersion": 1
            }
          }
        ],
        "metadata": {
          "addedInVersion": 1
        }
      },
      "type": "record"
    },
...
}
```

Asset with wire format:
```
{
  "documentTypeName": "Generated Schema",
  "documentStorageType": {
    "type": "yjs",
    "yjs": {
      "primaryModelKeys": [
        "ActivityShapeAddEvent",
      ],
      "models": {
        "ActivityShapeAddEvent": {
          "type": "record",
          "key": "ActivityShapeAddEvent",
          "name": "ActivityShapeAddEvent",
          "description": "An event representing the addition of a shape node.",
          "fields": [
            {
              "key": "nodeId",
              "name": "nodeId",
              "fieldType": {
                "type": "value",
                "valueType": {
                  "type": "string"
                }
              },
              "metadata": {
                "addedInVersion": 1
              }
            }
          ],
          "metadata": {
            "addedInVersion": 1
          }
        },
}

```