### PR TITLE
update third party deploy document type with schema

### DIFF
--- a/.changeset/gentle-turtles-chew.md
+++ b/.changeset/gentle-turtles-chew.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.document-schema.type-gen": minor
+---
+
+update third party deploy handler to include schema

--- a/packages/document-schema/type-gen/src/commands/ir/irDeployHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irDeployHandler.ts
@@ -22,6 +22,7 @@ import { consola } from "consola";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import type { IRealTimeDocumentSchema } from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import { convertIrToWireSchema } from "../../utils/ir/convertIrToWireSchema.js";
 import type { FileSystemType } from "../types.js";
 
 interface DeployOptions {
@@ -48,17 +49,19 @@ export async function irDeployHandler(options: DeployOptions): Promise<void> {
       () => Promise.resolve(options.auth),
     );
 
+    const schema = convertIrToWireSchema(ir);
+
     const request: CreateDocumentTypeRequest = {
       name: ir.name,
       parentFolderRid: options.parentFolder,
+      schema,
     };
 
     if (options.fileSystemType != null) {
       request.fileSystemType = options.fileSystemType;
     }
 
-    // PACK BE does not yet support storing schemas...
-    consola.warn("Creating document type without schema information", request);
+    consola.info("Creating document type with schema", request);
 
     await DocumentTypes.create(osdkClient, request, { preview: true });
   } catch (error) {


### PR DESCRIPTION
Update third party deploy handler for creating document types to now include schema.