### PR TITLE
Use client supported version range instead of version

### DIFF
--- a/.changeset/shaky-jokes-vanish.md
+++ b/.changeset/shaky-jokes-vanish.md
@@ -1,0 +1,6 @@
+---
+"@palantir/pack.state.foundry-event": major
+"@palantir/pack.state.foundry": major
+---
+
+Switch to use client supported version range instead of single client version

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -17,6 +17,7 @@
 import type { Logger } from "@osdk/api";
 import type {
   ActivityCollaborativeUpdate,
+  ClientSupportedVersionRange,
   DocumentActivitySubscriptionRequest,
   DocumentEditDescription,
   DocumentMetadataUpdate,
@@ -117,14 +118,14 @@ export interface FoundryEventService {
     documentId: DocumentId,
     eventType: string,
     eventData: unknown,
-    clientVersion: number,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     options?: PresencePublishOptions,
   ): Promise<void>;
 
   startDocumentSync(
     documentId: DocumentId,
     yDoc: y.Doc,
-    clientVersion: number,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
   ): SyncSession;
 
@@ -132,7 +133,7 @@ export interface FoundryEventService {
 
   subscribeToActivityUpdates(
     documentId: DocumentId,
-    clientVersion: number,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     callback: (event: ActivityCollaborativeUpdate) => void,
   ): Promise<SubscriptionId>;
 
@@ -143,7 +144,7 @@ export interface FoundryEventService {
 
   subscribeToPresenceUpdates(
     documentId: DocumentId,
-    clientVersion: number,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     callback: (update: PresenceCollaborativeUpdate) => void,
     options?: PresenceSubscriptionOptions,
   ): Promise<SubscriptionId>;
@@ -189,7 +190,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
   startDocumentSync(
     documentId: DocumentId,
     yDoc: y.Doc,
-    clientVersion: number,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
   ): SyncSession {
     const session = this.getOrCreateSession(documentId, yDoc);
@@ -221,7 +222,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         publishChannelId,
         {
           clientId: session.clientId,
-          clientVersion,
+          clientSupportedVersionRange,
           description,
           editId,
           yjsUpdate: {
@@ -254,7 +255,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
       },
       () => ({
         clientId: session.clientId,
-        clientVersion,
+        clientSupportedVersionRange,
         lastRevisionId: session.lastRevisionId?.toString(),
       } satisfies DocumentUpdateSubscriptionRequest),
     ).then(subscriptionId => {
@@ -287,7 +288,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
   subscribeToActivityUpdates(
     documentId: DocumentId,
-    clientVersion: number,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     callback: (event: ActivityCollaborativeUpdate) => void,
   ): Promise<SubscriptionId> {
     const session = this.getOrCreateSession(documentId);
@@ -305,7 +306,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
       },
       () => ({
         clientId: session.clientId,
-        clientVersion,
+        clientSupportedVersionRange,
       } satisfies DocumentActivitySubscriptionRequest),
     ).then(subscriptionId => {
       session.activitySubscriptionId = subscriptionId;
@@ -348,7 +349,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
   subscribeToPresenceUpdates(
     documentId: DocumentId,
-    clientVersion: number,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     callback: (update: PresenceCollaborativeUpdate) => void,
     options: PresenceSubscriptionOptions = {},
   ): Promise<SubscriptionId> {
@@ -390,7 +391,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
       },
       () => ({
         clientId: session.clientId,
-        clientVersion,
+        clientSupportedVersionRange,
       } satisfies DocumentPresenceSubscriptionRequest),
     ).then(subscriptionId => {
       session.presenceSubscriptionId = subscriptionId;
@@ -407,7 +408,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     documentId: DocumentId,
     eventType: string,
     eventData: unknown,
-    clientVersion: number,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     options?: PresencePublishOptions,
   ): Promise<void> {
     const { isEphemeral = true } = options ?? {};
@@ -422,14 +423,16 @@ class FoundryEventServiceImpl implements FoundryEventService {
     }
 
     return this.eventService.publish(channelId, {
-      clientId: session.clientId,
-      clientVersion,
-      // FIXME: why do we have to send this, we are authenticated
-      eventData,
-      eventType,
-      isEphemeral,
-      userId,
-      type: "custom",
+      clientSupportedVersionRange,
+      messageType: {
+        type: "custom",
+        clientId: session.clientId,
+        // FIXME: why do we have to send this, we are authenticated
+        eventData,
+        eventType,
+        isEphemeral,
+        userId,
+      },
     }).catch((error: unknown) => {
       this.logger.error("Failed to publish custom presence", error, {
         docId: documentId,

--- a/packages/state/foundry-event/src/index.ts
+++ b/packages/state/foundry-event/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export type { ClientSupportedVersionRange } from "@osdk/foundry.pack";
 export { createFoundryEventService } from "./FoundryEventService.js";
 export type {
   FoundryEventService,

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -15,6 +15,7 @@
  */
 
 import type {
+  ClientSupportedVersionRange,
   CreateDocumentRequest,
   DiscretionaryPrincipal,
   DiscretionaryPrincipal as WireDiscretionaryPrincipal,
@@ -326,7 +327,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     internalDoc.syncSession = this.eventService.startDocumentSync(
       docRef.id,
       internalDoc.yDoc,
-      getMetadata(docRef.schema).version,
+      getClientSupportedVersionRange(docRef.schema),
       status => {
         this.updateDataStatus(internalDoc, docRef, status);
       },
@@ -360,14 +361,18 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     };
 
     this.eventService
-      .subscribeToActivityUpdates(docRef.id, getMetadata(docRef.schema).version, foundryEvent => {
-        if (!unsubscribed) {
-          const localEvent = getActivityEvent(docRef.schema, foundryEvent);
-          if (localEvent != null) {
-            callback(docRef, localEvent);
+      .subscribeToActivityUpdates(
+        docRef.id,
+        getClientSupportedVersionRange(docRef.schema),
+        foundryEvent => {
+          if (!unsubscribed) {
+            const localEvent = getActivityEvent(docRef.schema, foundryEvent);
+            if (localEvent != null) {
+              callback(docRef, localEvent);
+            }
           }
-        }
-      })
+        },
+      )
       .catch((e: unknown) => {
         this.logger.error("Failed to subscribe to activity updates", e, {
           docId: docRef.id,
@@ -422,7 +427,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     this.eventService
       .subscribeToPresenceUpdates(
         docRef.id,
-        getMetadata(docRef.schema).version,
+        getClientSupportedVersionRange(docRef.schema),
         foundryUpdate => {
           if (!unsubscribed) {
             const localEvent = getPresenceEvent(docRef.schema, foundryUpdate);
@@ -453,7 +458,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         docRef.id,
         eventType,
         eventData,
-        getMetadata(docRef.schema).version,
+        getClientSupportedVersionRange(docRef.schema),
         options,
       )
       .catch((e: unknown) => {
@@ -462,6 +467,12 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         });
       });
   }
+}
+
+function getClientSupportedVersionRange(schema: DocumentSchema): ClientSupportedVersionRange {
+  const version = getMetadata(schema).version;
+  // TODO: Placeholder versions from schema now, update when migration story is complete and implemented
+  return { minVersion: version, maxVersion: version };
 }
 
 function getWireSecurity({

--- a/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
@@ -109,7 +109,7 @@ describe("Foundry Security Conversion", () => {
     vi.mocked(Documents.get).mockResolvedValue(WIRE_DOCUMENT_WITH_SECURITY);
 
     mockEventService.startDocumentSync.mockImplementation(
-      (documentId, _yDoc, _clientVersion, onStatusChange) => {
+      (documentId, _yDoc, _clientSupportedVersionRange, onStatusChange) => {
         const session: SyncSession = {
           clientId: `test-client-${++sessionCounter}`,
           documentId,

--- a/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
@@ -118,7 +118,7 @@ describe("Foundry Document Status Tracking", () => {
     vi.mocked(Documents.get).mockResolvedValue(mockDocument);
 
     mockEventService.startDocumentSync.mockImplementation(
-      (documentId, _yDoc, _clientVersion, onStatusChange) => {
+      (documentId, _yDoc, _clientSupportedVersionRange, onStatusChange) => {
         const session: SyncSession = {
           clientId: `test-client-${++sessionCounter}`,
           documentId,
@@ -303,7 +303,7 @@ describe("Foundry Document Status Tracking", () => {
 
     it("should handle websocket subscription errors and update data status to ERROR", async () => {
       mockEventService.startDocumentSync.mockImplementationOnce(
-        (documentId, _yDoc, _clientVersion, onStatusChange) => {
+        (documentId, _yDoc, _clientSupportedVersionRange, onStatusChange) => {
           const session: SyncSession = {
             clientId: `test-client-${++sessionCounter}`,
             documentId,
@@ -339,7 +339,7 @@ describe("Foundry Document Status Tracking", () => {
 
     it("should handle error messages from websocket and update data status", async () => {
       mockEventService.startDocumentSync.mockImplementationOnce(
-        (documentId, _yDoc, _clientVersion, onStatusChange) => {
+        (documentId, _yDoc, _clientSupportedVersionRange, onStatusChange) => {
           const session: SyncSession = {
             clientId: `test-client-${++sessionCounter}`,
             documentId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^2.56.0
       version: 2.56.0
     '@osdk/foundry.pack':
-      specifier: ^2.58.0
-      version: 2.58.0
+      specifier: ^2.59.0
+      version: 2.59.0
     '@osdk/oauth':
       specifier: ^1.4.0
       version: 1.4.0
@@ -542,7 +542,7 @@ importers:
         version: 2.5.2
       '@osdk/foundry.pack':
         specifier: 'catalog:'
-        version: 2.58.0
+        version: 2.59.0
       '@palantir/pack.document-schema.model-types':
         specifier: workspace:~
         version: link:../model-types
@@ -1017,7 +1017,7 @@ importers:
         version: 2.5.2
       '@osdk/foundry.pack':
         specifier: 'catalog:'
-        version: 2.58.0
+        version: 2.59.0
       '@palantir/pack.auth':
         specifier: workspace:*
         version: link:../../auth/core
@@ -1069,7 +1069,7 @@ importers:
         version: 2.5.2
       '@osdk/foundry.pack':
         specifier: 'catalog:'
-        version: 2.58.0
+        version: 2.59.0
       '@palantir/pack.auth':
         specifier: workspace:*
         version: link:../../auth/core
@@ -2421,11 +2421,11 @@ packages:
   '@osdk/foundry.core@2.56.0':
     resolution: {integrity: sha512-lm7c5IxHfmaAhSv3FB7od+YpvA1mTGP12FBEdQYQ7FqnJTLEB+GLaHLzvX+1WsSFJA/LxnasRV3ztWfjy1Qe+w==}
 
-  '@osdk/foundry.core@2.58.0':
-    resolution: {integrity: sha512-FMUZThSXSh4Zlf3iAy2Rrh8vpw04OEPtkY9FpKGMt7ib3QKXqihPy4xjjyGv3eMyTzEQ8lJBwlxBAN+8tiw+cA==}
+  '@osdk/foundry.core@2.59.0':
+    resolution: {integrity: sha512-/KzlqwTWWoYA2Ia5FGSUjRbGPlExLA+0a19YZBXFbLNjj0xMJwybb48Z2A3l9CSzs16q6Rb9KePKuMNvoh/JKQ==}
 
-  '@osdk/foundry.filesystem@2.58.0':
-    resolution: {integrity: sha512-CtGsWkwKaOckduKAwBdzLw2XTuF/6v5K5tQK7s15BP5pBbh/hjawwzKfmsADFaqSnqMGlQENA1BjOT4S+PXYcA==}
+  '@osdk/foundry.filesystem@2.59.0':
+    resolution: {integrity: sha512-HUzvUX4NvuSjoDhJKoCiUHwCM4I1k3dxlZR/YMH5tylxJ6jeFmcCP2FRNq22TWz+BwQREn6XlO87RPKUhGw//w==}
 
   '@osdk/foundry.geo@2.30.0':
     resolution: {integrity: sha512-VsYE9vtDwUVxfHlQLKxfDq6YrknPoPt6Gf3Ui0ojY7STqT/FTJlyH8aG+D3zosUVKeTZNXZ3ybc51GhB8kuYSQ==}
@@ -2433,14 +2433,14 @@ packages:
   '@osdk/foundry.geo@2.56.0':
     resolution: {integrity: sha512-ZB7RzItE3JJSsP7MPBihz8Zq7a361MtdUfxA+zHQbdaqCwZqukZ1ghJm/0mc/rQmHkV7bt3/SVknGOcHhVj3/g==}
 
-  '@osdk/foundry.geo@2.58.0':
-    resolution: {integrity: sha512-YzfRmDvvCqfbT4xgmHlBt4cuJ5vSgp4ARnz89NIki2I/U5eg5uFqYsV4eN4q0MjVoB3DQ1feLH5whtBV8pTatw==}
+  '@osdk/foundry.geo@2.59.0':
+    resolution: {integrity: sha512-rSfpx/RxRjKuohpJpyNFkp5mrS6pmGxjXI7XZXFdIVBbSsSIfP7OMClD9XnmVCNtmA3oufi5XnvIYEkjOHJAoA==}
 
   '@osdk/foundry.ontologies@2.30.0':
     resolution: {integrity: sha512-hmUhGJ846r8FDqkDZbt9P4tSzTcYzTatwrCVr4wN43WNRMIARvPLGnKCs9lk/nL1DOoUG6AM1v2RfvfLryQngA==}
 
-  '@osdk/foundry.pack@2.58.0':
-    resolution: {integrity: sha512-B715It0AspsC1cGf9HgHuc9uHtAbx26QVs/qZv7TBv18RfZeZjoHTtAsC7ZfPG/mjjLz4R2mTQA6vR7iqhnq9Q==}
+  '@osdk/foundry.pack@2.59.0':
+    resolution: {integrity: sha512-Ca5alq/ps3uJoDjiSOdq32Hlb+UuJalbKIG0DqevM6bfK8K65sNLyVSUeiJys9qCAg6i7gkvfstYQpfg4RMORA==}
 
   '@osdk/generator-converters@2.5.2':
     resolution: {integrity: sha512-k7sJM00w70A4g6OB0LKq1Gfmka8kiiPNAPeX/CK9sT5DfwGwfJ7wIZrXJVSkSwNlEqVr6zSKSbwwgmU/FyMqQQ==}
@@ -7184,16 +7184,16 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.core@2.58.0':
+  '@osdk/foundry.core@2.59.0':
     dependencies:
-      '@osdk/foundry.geo': 2.58.0
+      '@osdk/foundry.geo': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.filesystem@2.58.0':
+  '@osdk/foundry.filesystem@2.59.0':
     dependencies:
-      '@osdk/foundry.core': 2.58.0
+      '@osdk/foundry.core': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
@@ -7210,7 +7210,7 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.geo@2.58.0':
+  '@osdk/foundry.geo@2.59.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
@@ -7224,10 +7224,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.4.0
 
-  '@osdk/foundry.pack@2.58.0':
+  '@osdk/foundry.pack@2.59.0':
     dependencies:
-      '@osdk/foundry.core': 2.58.0
-      '@osdk/foundry.filesystem': 2.58.0
+      '@osdk/foundry.core': 2.59.0
+      '@osdk/foundry.filesystem': 2.59.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ catalog:
   "@osdk/api": ^2.5.2
   "@osdk/client": ^2.5.2
   "@osdk/foundry.admin": ^2.56.0
-  "@osdk/foundry.pack": ^2.58.0
+  "@osdk/foundry.pack": ^2.59.0
   "@osdk/oauth": ^1.4.0
   "@osdk/react": ^0.6.0
   "@osdk/shared.client2": ^1.0.0


### PR DESCRIPTION
Switching to send the client's supported schema version ranges (hardcoded for now) instead of single client version, for future migration implementation.