### PR TITLE
fix: support nested generic types in YAML migration step parser

### DIFF
--- a/.changeset/pretty-waves-love.md
+++ b/.changeset/pretty-waves-love.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.document-schema.type-gen": minor
+---
+
+Support nested generic types in YAML migration step parser

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToIr.test.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToIr.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it } from "vitest";
 import type { IFieldTypeUnion } from "../../../lib/pack-docschema-api/pack-docschema-ir/index.js";
 import { convertStepsToIr } from "../convertStepsToIr.js";
+import { parseMigrationSteps } from "../parseMigrationSteps.js";
 import type { MigrationStep } from "../parseMigrationSteps.js";
 
 describe("convertStepsToIr", () => {
@@ -388,5 +389,39 @@ describe("convertStepsToIr", () => {
     const emailField = personRecord.fields.find(f => f.key === "email");
     expect(emailField).toBeDefined();
     expect(emailField?.isOptional).toBe(true);
+  });
+});
+
+describe("parseMigrationSteps generic type validation", () => {
+  function stepsWithField(fieldType: string): unknown {
+    return [{ "add-records": { Foo: { fields: { bar: fieldType } } } }];
+  }
+
+  it.each([
+    "optional<optional<string>>",
+    "array<array<string>>",
+    "list<list<double>>",
+    "array<optional<string>>",
+    "optional<array<array<string>>>",
+    "optional<foo<string>>",
+    "foo<string>",
+  ])("should reject invalid nested generic type: %s", fieldType => {
+    expect(() => parseMigrationSteps(stepsWithField(fieldType))).toThrow();
+  });
+
+  it.each([
+    "optional<string>",
+    "optional<double>",
+    "optional<MyType>",
+    "array<string>",
+    "list<double>",
+    "set<MyType>",
+    "map<string>",
+    "optional<array<string>>",
+    "optional<list<Tag>>",
+    "optional<set<double>>",
+    "optional<map<string>>",
+  ])("should accept valid generic type: %s", fieldType => {
+    expect(() => parseMigrationSteps(stepsWithField(fieldType))).not.toThrow();
   });
 });

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToIr.test.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToIr.test.ts
@@ -17,8 +17,8 @@
 import { describe, expect, it } from "vitest";
 import type { IFieldTypeUnion } from "../../../lib/pack-docschema-api/pack-docschema-ir/index.js";
 import { convertStepsToIr } from "../convertStepsToIr.js";
-import { parseMigrationSteps } from "../parseMigrationSteps.js";
 import type { MigrationStep } from "../parseMigrationSteps.js";
+import { parseMigrationSteps } from "../parseMigrationSteps.js";
 
 describe("convertStepsToIr", () => {
   it("should convert simple record types to IR format", () => {
@@ -320,7 +320,7 @@ describe("convertStepsToIr", () => {
     // Check optional array of references
     const tagsField = containerRecord.fields.find(f => f.key === "tags");
     expect(tagsField?.isOptional).toBe(true);
-    expect(tagsField?.value).toEqual({
+    expect(tagsField?.fieldType).toEqual({
       type: "array",
       array: {
         allowNullValue: false,
@@ -336,7 +336,7 @@ describe("convertStepsToIr", () => {
     // Check optional array of primitives
     const labelsField = containerRecord.fields.find(f => f.key === "labels");
     expect(labelsField?.isOptional).toBe(true);
-    expect(labelsField?.value).toEqual({
+    expect(labelsField?.fieldType).toEqual({
       type: "array",
       array: {
         allowNullValue: false,

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToIr.test.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToIr.test.ts
@@ -289,6 +289,64 @@ describe("convertStepsToIr", () => {
     });
   });
 
+  it("should convert optional array types to IR format", () => {
+    const steps: MigrationStep[] = [
+      {
+        "add-records": {
+          Tag: {
+            fields: {
+              name: "string",
+            },
+          },
+          Container: {
+            docs: "A container with optional collections",
+            fields: {
+              tags: "optional<array<Tag>>",
+              labels: "optional<array<string>>",
+            },
+          },
+        },
+      },
+    ];
+
+    const schema = convertStepsToIr(steps);
+    const containerModel = schema.models["Container"];
+    expect(containerModel).toBeDefined();
+    expect(containerModel?.type).toBe("record");
+    if (containerModel?.type !== "record") throw new Error("Expected record type");
+    const containerRecord = containerModel.record;
+
+    // Check optional array of references
+    const tagsField = containerRecord.fields.find(f => f.key === "tags");
+    expect(tagsField?.isOptional).toBe(true);
+    expect(tagsField?.value).toEqual({
+      type: "array",
+      array: {
+        allowNullValue: false,
+        value: {
+          type: "modelRef",
+          modelRef: {
+            modelTypes: ["Tag"],
+          },
+        },
+      },
+    });
+
+    // Check optional array of primitives
+    const labelsField = containerRecord.fields.find(f => f.key === "labels");
+    expect(labelsField?.isOptional).toBe(true);
+    expect(labelsField?.value).toEqual({
+      type: "array",
+      array: {
+        allowNullValue: false,
+        value: {
+          type: "string",
+          string: {},
+        },
+      },
+    });
+  });
+
   it("should handle modify-records step", () => {
     const steps: MigrationStep[] = [
       {

--- a/packages/document-schema/type-gen/src/utils/steps/parseMigrationSteps.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/parseMigrationSteps.ts
@@ -52,11 +52,16 @@ interface MigrationStep {
 const primitiveType: z.ZodType<PrimitiveType> = z.enum(["string", "double"]);
 
 // Define generic type patterns like "optional<T>", "list<T>", "array<T>", "optional<array<T>>"
+// Flat: (optional|list|array|set|map)<primitive_or_TypeRef>
+// Nested: optional<(list|array|set|map)<primitive_or_TypeRef>>
 const genericTypePattern: z.ZodType<string> = z
   .string()
-  .regex(/^(optional|list|array|set|map)<.+>$/, {
-    message: "Invalid generic type pattern",
-  });
+  .regex(
+    /^(?:(?:list|array|set|map)<[^<>]+>|optional<(?:[^<>]+|(?:list|array|set|map)<[^<>]+>)>)$/,
+    {
+      message: "Invalid generic type pattern",
+    },
+  );
 
 // Reference to other record/union types (capitalized names)
 const typeReference: z.ZodType<string> = z.string().regex(/^[A-Z][a-zA-Z0-9]*$/, {

--- a/packages/document-schema/type-gen/src/utils/steps/parseMigrationSteps.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/parseMigrationSteps.ts
@@ -51,10 +51,10 @@ interface MigrationStep {
 // Define allowed primitive types (matching TypeKind from document-schema-api)
 const primitiveType: z.ZodType<PrimitiveType> = z.enum(["string", "double"]);
 
-// Define generic type patterns like "optional<T>", "list<T>", "array<T>"
+// Define generic type patterns like "optional<T>", "list<T>", "array<T>", "optional<array<T>>"
 const genericTypePattern: z.ZodType<string> = z
   .string()
-  .regex(/^(optional|list|array|set|map)<[^<>]+>$/, {
+  .regex(/^(optional|list|array|set|map)<.+>$/, {
     message: "Invalid generic type pattern",
   });
 


### PR DESCRIPTION
The Zod validation regex for generic type patterns (`optional<T>`, `array<T>`, etc.) rejected nested generics like `optional<array<T>>` because `[^<>]+` disallows angle brackets inside the outer generic.

The downstream processing in `convertStepsToSchema.ts` already handles nested generics correctly via recursive `recordFieldDefinitionToSchemaType` calls — only the validation gate was too strict.

Change the regex from `[^<>]+` to `.+` so patterns like `optional<array<MyConfig>>` pass validation and reach the parser that already knows how to unwrap them.