### PR TITLE
Add new schema builder methods

### DIFF
--- a/.changeset/shaky-dingos-study.md
+++ b/.changeset/shaky-dingos-study.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.schema": patch
+---
+
+Add new schema builder methods for schema updates

--- a/packages/schema/src/__tests__/defineSchemaUpdate.test.ts
+++ b/packages/schema/src/__tests__/defineSchemaUpdate.test.ts
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { SchemaBuilder } from "../defineMigration.js";
+import { defineRecord } from "../defineRecord.js";
+import { defineUnion } from "../defineUnion.js";
+import {
+  __previousSchema,
+  __schemaVersion,
+  defineSchemaUpdate,
+  nextSchema,
+} from "../defineSchemaUpdate.js";
+import * as P from "../primitives.js";
+import { assertExactKeys, assertHasKeys, assertTypeEquals } from "./testTypeUtils.js";
+
+describe("defineSchemaUpdate", () => {
+  it("should create a schema update and apply it via nextSchema", () => {
+    const schemaV1 = {
+      Person: defineRecord("Person", {
+        docs: "A person",
+        fields: {
+          name: P.String,
+        },
+      }),
+    };
+
+    const addAge = defineSchemaUpdate("addAge", (schema: SchemaBuilder<typeof schemaV1>) => ({
+      PersonV2: schema.Person.addField("age", P.Double).build(),
+    }));
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addAge).build();
+
+    expect(schemaV2.Person).toBe(schemaV1.Person);
+    expect(schemaV2.PersonV2.fields.name).toEqual({ type: "string" });
+    expect(schemaV2.PersonV2.fields.age).toEqual({ type: "double" });
+    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+
+    assertHasKeys<typeof schemaV2, "Person" | "PersonV2">();
+    assertExactKeys<typeof schemaV2.PersonV2.fields, "name" | "age">();
+    assertTypeEquals<typeof schemaV2.PersonV2.fields.name, P.String>();
+    assertTypeEquals<typeof schemaV2.PersonV2.fields.age, P.Double>();
+  });
+
+  it("should compose multiple schema updates in one version", () => {
+    const schemaV1 = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+      ShapeCircle: defineRecord("ShapeCircle", {
+        docs: "A circle shape",
+        fields: {
+          cx: P.Double,
+          radius: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const addFillColor = defineSchemaUpdate(
+      "addFillColor",
+      (schema: SchemaBuilder<typeof schemaV1>) => ({
+        ShapeBox: schema.ShapeBox
+          .addField("fillColor", P.Optional(P.String))
+          .build(),
+        ShapeCircle: schema.ShapeCircle
+          .addField("fillColor", P.Optional(P.String))
+          .build(),
+      }),
+    );
+
+    const addOpacity = defineSchemaUpdate(
+      "addOpacity",
+      (schema: SchemaBuilder<typeof schemaV1>) => ({
+        ShapeBox: schema.ShapeBox
+          .addField("opacity", P.Optional(P.Double))
+          .build(),
+        ShapeCircle: schema.ShapeCircle
+          .addField("opacity", P.Optional(P.Double))
+          .build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1)
+      .addSchemaUpdate(addFillColor)
+      .addSchemaUpdate(addOpacity)
+      .build();
+
+    expect(schemaV2.ShapeBox.fields.fillColor).toEqual({
+      type: "optional",
+      item: { type: "string" },
+    });
+    expect(schemaV2.ShapeBox.fields.opacity).toEqual({
+      type: "optional",
+      item: { type: "double" },
+    });
+    expect(schemaV2.ShapeBox.fields.left).toEqual({ type: "double" });
+    expect(schemaV2.ShapeCircle.fields.fillColor).toEqual({
+      type: "optional",
+      item: { type: "string" },
+    });
+    expect(schemaV2.ShapeCircle.fields.opacity).toEqual({
+      type: "optional",
+      item: { type: "double" },
+    });
+    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+  });
+
+  it("should track version advancement across multiple nextSchema calls", () => {
+    const schemaV1 = {
+      Item: defineRecord("Item", {
+        docs: "An item",
+        fields: {
+          name: P.String,
+        },
+      }),
+    };
+
+    const addDescription = defineSchemaUpdate(
+      "addDescription",
+      (schema: SchemaBuilder<typeof schemaV1>) => ({
+        Item: schema.Item.addField("description", P.Optional(P.String)).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addDescription).build();
+
+    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+
+    const addTags = defineSchemaUpdate(
+      "addTags",
+      (schema: SchemaBuilder<typeof schemaV2>) => ({
+        Item: schema.Item.addField("tags", P.Optional(P.String)).build(),
+      }),
+    );
+
+    const schemaV3 = nextSchema(schemaV2).addSchemaUpdate(addTags).build();
+
+    expect((schemaV3 as Record<symbol, unknown>)[__schemaVersion]).toBe(3);
+    expect(schemaV3.Item.fields.name).toEqual({ type: "string" });
+    expect(schemaV3.Item.fields.description).toEqual({
+      type: "optional",
+      item: { type: "string" },
+    });
+    expect(schemaV3.Item.fields.tags).toEqual({ type: "optional", item: { type: "string" } });
+  });
+
+  it("should store __previousSchema reference on built schema", () => {
+    const schemaV1 = {
+      Node: defineRecord("Node", {
+        docs: "A node",
+        fields: {
+          label: P.String,
+        },
+      }),
+    };
+
+    const addWeight = defineSchemaUpdate(
+      "addWeight",
+      (schema: SchemaBuilder<typeof schemaV1>) => ({
+        Node: schema.Node.addField("weight", P.Double).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addWeight).build();
+
+    expect((schemaV2 as Record<symbol, unknown>)[__previousSchema]).toBe(schemaV1);
+    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+  });
+
+  it("should work with union schema updates", () => {
+    const CircleRecord = defineRecord("Circle", {
+      docs: "A circle",
+      fields: { radius: P.Double },
+    });
+
+    const RectangleRecord = defineRecord("Rectangle", {
+      docs: "A rectangle",
+      fields: { width: P.Double, height: P.Double },
+    });
+
+    const TriangleRecord = defineRecord("Triangle", {
+      docs: "A triangle",
+      fields: { base: P.Double, height: P.Double },
+    });
+
+    const schemaV1 = {
+      Shape: defineUnion("Shape", {
+        docs: "A shape",
+        variants: {
+          circle: CircleRecord,
+          rectangle: RectangleRecord,
+        },
+      }),
+    };
+
+    const addTriangle = defineSchemaUpdate(
+      "addTriangle",
+      (schema: SchemaBuilder<typeof schemaV1>) => ({
+        Shape: schema.Shape.addVariant("triangle", TriangleRecord).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addTriangle).build();
+
+    expect(schemaV2.Shape.variants.circle).toEqual({
+      type: "ref",
+      name: "Circle",
+      refType: "record",
+    });
+    expect(schemaV2.Shape.variants.triangle).toEqual({
+      type: "ref",
+      name: "Triangle",
+      refType: "record",
+    });
+    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+
+    assertExactKeys<typeof schemaV2.Shape.variants, "circle" | "rectangle" | "triangle">();
+  });
+
+  it("should handle mixed record and union updates in one version", () => {
+    const PersonRecord = defineRecord("Person", {
+      docs: "A person",
+      fields: { name: P.String },
+    });
+
+    const OrganizationRecord = defineRecord("Organization", {
+      docs: "An organization",
+      fields: { orgName: P.String },
+    });
+
+    const schemaV1 = {
+      Person: PersonRecord,
+      Entity: defineUnion("Entity", {
+        docs: "An entity",
+        variants: {
+          person: PersonRecord,
+        },
+      }),
+    };
+
+    const addAge = defineSchemaUpdate(
+      "addAge",
+      (schema: SchemaBuilder<typeof schemaV1>) => ({
+        PersonV2: schema.Person.addField("age", P.Double).build(),
+      }),
+    );
+
+    const addOrgVariant = defineSchemaUpdate(
+      "addOrgVariant",
+      (schema: SchemaBuilder<typeof schemaV1>) => ({
+        Entity: schema.Entity.addVariant("organization", OrganizationRecord).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1)
+      .addSchemaUpdate(addAge)
+      .addSchemaUpdate(addOrgVariant)
+      .build();
+
+    expect(schemaV2.PersonV2.fields.name).toEqual({ type: "string" });
+    expect(schemaV2.PersonV2.fields.age).toEqual({ type: "double" });
+    expect(schemaV2.Entity.variants.person).toEqual({
+      type: "ref",
+      name: "Person",
+      refType: "record",
+    });
+    expect(schemaV2.Entity.variants.organization).toEqual({
+      type: "ref",
+      name: "Organization",
+      refType: "record",
+    });
+
+    assertHasKeys<typeof schemaV2, "Person" | "PersonV2" | "Entity">();
+    assertExactKeys<typeof schemaV2.PersonV2.fields, "name" | "age">();
+    assertExactKeys<typeof schemaV2.Entity.variants, "person" | "organization">();
+  });
+
+  it("should not affect enumerable properties with version symbols", () => {
+    const schemaV1 = {
+      Item: defineRecord("Item", {
+        docs: "An item",
+        fields: { name: P.String },
+      }),
+    };
+
+    const addPrice = defineSchemaUpdate(
+      "addPrice",
+      (schema: SchemaBuilder<typeof schemaV1>) => ({
+        Item: schema.Item.addField("price", P.Double).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addPrice).build();
+
+    // Symbols should not appear in Object.keys
+    expect(Object.keys(schemaV2)).toEqual(["Item"]);
+  });
+});

--- a/packages/schema/src/__tests__/defineSchemaUpdate.test.ts
+++ b/packages/schema/src/__tests__/defineSchemaUpdate.test.ts
@@ -17,12 +17,7 @@
 import { describe, expect, it } from "vitest";
 import type { SchemaBuilder } from "../defineMigration.js";
 import { defineRecord } from "../defineRecord.js";
-import {
-  __previousSchema,
-  __schemaVersion,
-  defineSchemaUpdate,
-  nextSchema,
-} from "../defineSchemaUpdate.js";
+import { defineSchemaUpdate, isVersionedSchema, nextSchema } from "../defineSchemaUpdate.js";
 import { defineUnion } from "../defineUnion.js";
 import * as P from "../primitives.js";
 import { assertExactKeys, assertHasKeys, assertTypeEquals } from "./testTypeUtils.js";
@@ -44,15 +39,15 @@ describe("defineSchemaUpdate", () => {
 
     const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addAge).build();
 
-    expect(schemaV2.Person).toBe(schemaV1.Person);
-    expect(schemaV2.PersonV2.fields.name).toEqual({ type: "string" });
-    expect(schemaV2.PersonV2.fields.age).toEqual({ type: "double" });
-    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+    expect(schemaV2.models.Person).toBe(schemaV1.Person);
+    expect(schemaV2.models.PersonV2.fields.name).toEqual({ type: "string" });
+    expect(schemaV2.models.PersonV2.fields.age).toEqual({ type: "double" });
+    expect(schemaV2.version).toBe(2);
 
-    assertHasKeys<typeof schemaV2, "Person" | "PersonV2">();
-    assertExactKeys<typeof schemaV2.PersonV2.fields, "name" | "age">();
-    assertTypeEquals<typeof schemaV2.PersonV2.fields.name, P.String>();
-    assertTypeEquals<typeof schemaV2.PersonV2.fields.age, P.Double>();
+    assertHasKeys<typeof schemaV2.models, "Person" | "PersonV2">();
+    assertExactKeys<typeof schemaV2.models.PersonV2.fields, "name" | "age">();
+    assertTypeEquals<typeof schemaV2.models.PersonV2.fields.name, P.String>();
+    assertTypeEquals<typeof schemaV2.models.PersonV2.fields.age, P.Double>();
   });
 
   it("should compose multiple schema updates in one version", () => {
@@ -104,24 +99,24 @@ describe("defineSchemaUpdate", () => {
       .addSchemaUpdate(addOpacity)
       .build();
 
-    expect(schemaV2.ShapeBox.fields.fillColor).toEqual({
+    expect(schemaV2.models.ShapeBox.fields.fillColor).toEqual({
       type: "optional",
       item: { type: "string" },
     });
-    expect(schemaV2.ShapeBox.fields.opacity).toEqual({
+    expect(schemaV2.models.ShapeBox.fields.opacity).toEqual({
       type: "optional",
       item: { type: "double" },
     });
-    expect(schemaV2.ShapeBox.fields.left).toEqual({ type: "double" });
-    expect(schemaV2.ShapeCircle.fields.fillColor).toEqual({
+    expect(schemaV2.models.ShapeBox.fields.left).toEqual({ type: "double" });
+    expect(schemaV2.models.ShapeCircle.fields.fillColor).toEqual({
       type: "optional",
       item: { type: "string" },
     });
-    expect(schemaV2.ShapeCircle.fields.opacity).toEqual({
+    expect(schemaV2.models.ShapeCircle.fields.opacity).toEqual({
       type: "optional",
       item: { type: "double" },
     });
-    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+    expect(schemaV2.version).toBe(2);
   });
 
   it("should track version advancement across multiple nextSchema calls", () => {
@@ -143,27 +138,30 @@ describe("defineSchemaUpdate", () => {
 
     const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addDescription).build();
 
-    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+    expect(schemaV2.version).toBe(2);
 
     const addTags = defineSchemaUpdate(
       "addTags",
-      (schema: SchemaBuilder<typeof schemaV2>) => ({
+      (schema: SchemaBuilder<typeof schemaV2.models>) => ({
         Item: schema.Item.addField("tags", P.Optional(P.String)).build(),
       }),
     );
 
     const schemaV3 = nextSchema(schemaV2).addSchemaUpdate(addTags).build();
 
-    expect((schemaV3 as Record<symbol, unknown>)[__schemaVersion]).toBe(3);
-    expect(schemaV3.Item.fields.name).toEqual({ type: "string" });
-    expect(schemaV3.Item.fields.description).toEqual({
+    expect(schemaV3.version).toBe(3);
+    expect(schemaV3.models.Item.fields.name).toEqual({ type: "string" });
+    expect(schemaV3.models.Item.fields.description).toEqual({
       type: "optional",
       item: { type: "string" },
     });
-    expect(schemaV3.Item.fields.tags).toEqual({ type: "optional", item: { type: "string" } });
+    expect(schemaV3.models.Item.fields.tags).toEqual({
+      type: "optional",
+      item: { type: "string" },
+    });
   });
 
-  it("should store __previousSchema reference on built schema", () => {
+  it("should build a walkable version chain via .previous", () => {
     const schemaV1 = {
       Node: defineRecord("Node", {
         docs: "A node",
@@ -182,8 +180,73 @@ describe("defineSchemaUpdate", () => {
 
     const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addWeight).build();
 
-    expect((schemaV2 as Record<symbol, unknown>)[__previousSchema]).toBe(schemaV1);
-    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+    // v2 points back to a synthetic v1 wrapper
+    expect(schemaV2.previous?.models).toBe(schemaV1);
+    expect(schemaV2.previous?.version).toBe(1);
+    expect(schemaV2.previous?.previous).toBeUndefined();
+    expect(schemaV2.version).toBe(2);
+  });
+
+  it("should build a multi-step version chain", () => {
+    const schemaV1 = {
+      Item: defineRecord("Item", {
+        docs: "An item",
+        fields: { name: P.String },
+      }),
+    };
+
+    const schemaV2 = nextSchema(schemaV1)
+      .addSchemaUpdate(
+        defineSchemaUpdate(
+          "addPrice",
+          schema => ({
+            Item: schema.Item.addField("price", P.Double).build(),
+          }),
+        ),
+      )
+      .build();
+
+    const schemaV3 = nextSchema(schemaV2)
+      .addSchemaUpdate(
+        defineSchemaUpdate(
+          "addTags",
+          schema => ({
+            Item: schema.Item.addField("tags", P.Optional(P.String)).build(),
+          }),
+        ),
+      )
+      .build();
+
+    // Walk the chain: v3 -> v2 -> v1 -> undefined
+    expect(schemaV3.version).toBe(3);
+    expect(schemaV3.previous).toBe(schemaV2);
+    expect(schemaV3.previous?.previous?.models).toBe(schemaV1);
+    expect(schemaV3.previous?.previous?.previous).toBeUndefined();
+  });
+
+  it("should correctly identify versioned schemas with isVersionedSchema", () => {
+    const schemaV1 = {
+      Item: defineRecord("Item", {
+        docs: "An item",
+        fields: { name: P.String },
+      }),
+    };
+
+    const schemaV2 = nextSchema(schemaV1)
+      .addSchemaUpdate(
+        defineSchemaUpdate(
+          "addPrice",
+          schema => ({
+            Item: schema.Item.addField("price", P.Double).build(),
+          }),
+        ),
+      )
+      .build();
+
+    expect(isVersionedSchema(schemaV2)).toBe(true);
+    expect(isVersionedSchema(schemaV1)).toBe(false);
+    expect(isVersionedSchema(null)).toBe(false);
+    expect(isVersionedSchema(undefined)).toBe(false);
   });
 
   it("should work with union schema updates", () => {
@@ -221,19 +284,22 @@ describe("defineSchemaUpdate", () => {
 
     const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addTriangle).build();
 
-    expect(schemaV2.Shape.variants.circle).toEqual({
+    expect(schemaV2.models.Shape.variants.circle).toEqual({
       type: "ref",
       name: "Circle",
       refType: "record",
     });
-    expect(schemaV2.Shape.variants.triangle).toEqual({
+    expect(schemaV2.models.Shape.variants.triangle).toEqual({
       type: "ref",
       name: "Triangle",
       refType: "record",
     });
-    expect((schemaV2 as Record<symbol, unknown>)[__schemaVersion]).toBe(2);
+    expect(schemaV2.version).toBe(2);
 
-    assertExactKeys<typeof schemaV2.Shape.variants, "circle" | "rectangle" | "triangle">();
+    assertExactKeys<
+      typeof schemaV2.models.Shape.variants,
+      "circle" | "rectangle" | "triangle"
+    >();
   });
 
   it("should handle mixed record and union updates in one version", () => {
@@ -276,42 +342,21 @@ describe("defineSchemaUpdate", () => {
       .addSchemaUpdate(addOrgVariant)
       .build();
 
-    expect(schemaV2.PersonV2.fields.name).toEqual({ type: "string" });
-    expect(schemaV2.PersonV2.fields.age).toEqual({ type: "double" });
-    expect(schemaV2.Entity.variants.person).toEqual({
+    expect(schemaV2.models.PersonV2.fields.name).toEqual({ type: "string" });
+    expect(schemaV2.models.PersonV2.fields.age).toEqual({ type: "double" });
+    expect(schemaV2.models.Entity.variants.person).toEqual({
       type: "ref",
       name: "Person",
       refType: "record",
     });
-    expect(schemaV2.Entity.variants.organization).toEqual({
+    expect(schemaV2.models.Entity.variants.organization).toEqual({
       type: "ref",
       name: "Organization",
       refType: "record",
     });
 
-    assertHasKeys<typeof schemaV2, "Person" | "PersonV2" | "Entity">();
-    assertExactKeys<typeof schemaV2.PersonV2.fields, "name" | "age">();
-    assertExactKeys<typeof schemaV2.Entity.variants, "person" | "organization">();
-  });
-
-  it("should not affect enumerable properties with version symbols", () => {
-    const schemaV1 = {
-      Item: defineRecord("Item", {
-        docs: "An item",
-        fields: { name: P.String },
-      }),
-    };
-
-    const addPrice = defineSchemaUpdate(
-      "addPrice",
-      (schema: SchemaBuilder<typeof schemaV1>) => ({
-        Item: schema.Item.addField("price", P.Double).build(),
-      }),
-    );
-
-    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addPrice).build();
-
-    // Symbols should not appear in Object.keys
-    expect(Object.keys(schemaV2)).toEqual(["Item"]);
+    assertHasKeys<typeof schemaV2.models, "Person" | "PersonV2" | "Entity">();
+    assertExactKeys<typeof schemaV2.models.PersonV2.fields, "name" | "age">();
+    assertExactKeys<typeof schemaV2.models.Entity.variants, "person" | "organization">();
   });
 });

--- a/packages/schema/src/__tests__/defineSchemaUpdate.test.ts
+++ b/packages/schema/src/__tests__/defineSchemaUpdate.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@
 import { describe, expect, it } from "vitest";
 import type { SchemaBuilder } from "../defineMigration.js";
 import { defineRecord } from "../defineRecord.js";
-import { defineUnion } from "../defineUnion.js";
 import {
   __previousSchema,
   __schemaVersion,
   defineSchemaUpdate,
   nextSchema,
 } from "../defineSchemaUpdate.js";
+import { defineUnion } from "../defineUnion.js";
 import * as P from "../primitives.js";
 import { assertExactKeys, assertHasKeys, assertTypeEquals } from "./testTypeUtils.js";
 

--- a/packages/schema/src/defineSchemaUpdate.ts
+++ b/packages/schema/src/defineSchemaUpdate.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/schema/src/defineSchemaUpdate.ts
+++ b/packages/schema/src/defineSchemaUpdate.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReturnedSchema, Schema, SchemaBuilder } from "./defineMigration.js";
+import { defineMigration } from "./defineMigration.js";
+
+export const __schemaVersion: unique symbol = Symbol.for("__schemaVersion") as any;
+export const __previousSchema: unique symbol = Symbol.for("__previousSchema") as any;
+
+export interface SchemaUpdate<T extends ReturnedSchema, S extends ReturnedSchema> {
+  readonly name: string;
+  readonly migration: (schema: SchemaBuilder<T>) => S;
+}
+
+export function defineSchemaUpdate<T extends ReturnedSchema, S extends ReturnedSchema>(
+  name: string,
+  migration: (schema: SchemaBuilder<T>) => S,
+): SchemaUpdate<T, S> {
+  return { name, migration };
+}
+
+export interface SchemaVersionBuilder<T extends ReturnedSchema> {
+  addSchemaUpdate<S extends ReturnedSchema>(
+    update: SchemaUpdate<T, S>,
+  ): SchemaVersionBuilder<T & S>;
+  build(): Schema<T>;
+}
+
+class SchemaVersionBuilderImpl<T extends ReturnedSchema> implements SchemaVersionBuilder<T> {
+  private readonly schema: Schema<T>;
+  private readonly version: number;
+  private readonly previous: Schema<any>;
+
+  constructor(schema: Schema<T>, version: number, previous: Schema<any>) {
+    this.schema = schema;
+    this.version = version;
+    this.previous = previous;
+  }
+
+  addSchemaUpdate<S extends ReturnedSchema>(
+    update: SchemaUpdate<T, S>,
+  ): SchemaVersionBuilder<T & S> {
+    const merged = defineMigration(this.schema, update.migration);
+    return new SchemaVersionBuilderImpl(merged, this.version, this.previous);
+  }
+
+  build(): Schema<T> {
+    const result = { ...this.schema };
+    Object.defineProperty(result, __schemaVersion, {
+      value: this.version,
+      enumerable: false,
+      writable: false,
+    });
+    Object.defineProperty(result, __previousSchema, {
+      value: this.previous,
+      enumerable: false,
+      writable: false,
+    });
+    return result;
+  }
+}
+
+export function nextSchema<T extends ReturnedSchema>(
+  previous: Schema<T>,
+): SchemaVersionBuilder<T> {
+  const previousVersion: number = (previous as Record<symbol, unknown>)[__schemaVersion] as number
+    ?? 1;
+  return new SchemaVersionBuilderImpl(previous, previousVersion + 1, previous);
+}

--- a/packages/schema/src/defineSchemaUpdate.ts
+++ b/packages/schema/src/defineSchemaUpdate.ts
@@ -17,8 +17,21 @@
 import type { ReturnedSchema, Schema, SchemaBuilder } from "./defineMigration.js";
 import { defineMigration } from "./defineMigration.js";
 
-export const __schemaVersion: unique symbol = Symbol.for("__schemaVersion") as any;
-export const __previousSchema: unique symbol = Symbol.for("__previousSchema") as any;
+export interface VersionedSchema<T extends ReturnedSchema = ReturnedSchema> {
+  readonly models: T;
+  readonly version: number;
+  readonly previous?: VersionedSchema;
+}
+
+export function isVersionedSchema(value: unknown): value is VersionedSchema {
+  return (
+    typeof value === "object"
+    && value != null
+    && "models" in value
+    && "version" in value
+    && typeof (value as VersionedSchema).version === "number"
+  );
+}
 
 export interface SchemaUpdate<T extends ReturnedSchema, S extends ReturnedSchema> {
   readonly name: string;
@@ -36,15 +49,15 @@ export interface SchemaVersionBuilder<T extends ReturnedSchema> {
   addSchemaUpdate<S extends ReturnedSchema>(
     update: SchemaUpdate<T, S>,
   ): SchemaVersionBuilder<T & S>;
-  build(): Schema<T>;
+  build(): VersionedSchema<T>;
 }
 
 class SchemaVersionBuilderImpl<T extends ReturnedSchema> implements SchemaVersionBuilder<T> {
   private readonly schema: Schema<T>;
   private readonly version: number;
-  private readonly previous: Schema<any>;
+  private readonly previous: VersionedSchema;
 
-  constructor(schema: Schema<T>, version: number, previous: Schema<any>) {
+  constructor(schema: Schema<T>, version: number, previous: VersionedSchema) {
     this.schema = schema;
     this.version = version;
     this.previous = previous;
@@ -57,26 +70,26 @@ class SchemaVersionBuilderImpl<T extends ReturnedSchema> implements SchemaVersio
     return new SchemaVersionBuilderImpl(merged, this.version, this.previous);
   }
 
-  build(): Schema<T> {
-    const result = { ...this.schema };
-    Object.defineProperty(result, __schemaVersion, {
-      value: this.version,
-      enumerable: false,
-      writable: false,
-    });
-    Object.defineProperty(result, __previousSchema, {
-      value: this.previous,
-      enumerable: false,
-      writable: false,
-    });
-    return result;
+  build(): VersionedSchema<T> {
+    return {
+      models: { ...this.schema },
+      version: this.version,
+      previous: this.previous,
+    };
   }
 }
 
 export function nextSchema<T extends ReturnedSchema>(
+  previous: VersionedSchema<T>,
+): SchemaVersionBuilder<T>;
+export function nextSchema<T extends ReturnedSchema>(
   previous: Schema<T>,
-): SchemaVersionBuilder<T> {
-  const previousVersion: number = (previous as Record<symbol, unknown>)[__schemaVersion] as number
-    ?? 1;
-  return new SchemaVersionBuilderImpl(previous, previousVersion + 1, previous);
+): SchemaVersionBuilder<T>;
+export function nextSchema(
+  previous: ReturnedSchema | VersionedSchema,
+): SchemaVersionBuilder<ReturnedSchema> {
+  if (isVersionedSchema(previous)) {
+    return new SchemaVersionBuilderImpl(previous.models, previous.version + 1, previous);
+  }
+  return new SchemaVersionBuilderImpl(previous, 2, { models: previous, version: 1 });
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -16,6 +16,7 @@
 
 export * from "./defineMigration.js";
 export * from "./defineRecord.js";
+export * from "./defineSchemaUpdate.js";
 export * from "./defineUnion.js";
 export * from "./defs.js";
 export * from "./primitives.js";


### PR DESCRIPTION
Note, at some future point we should remove/rename `defineMigration` as the primary building block for the pack schema. Doesn't match our new terminology around schema updating.