### PR TITLE
Add new 'gen-types' command, direct from TS schema to Versioned SDK Types.

### DIFF
--- a/.changeset/gentle-bananas-wear.md
+++ b/.changeset/gentle-bananas-wear.md
@@ -1,0 +1,6 @@
+---
+"@palantir/pack.document-schema.type-gen": patch
+"@palantir/pack.schema": patch
+---
+
+Add new 'gen-types' command to create versioned SDK for Versioned Schemas

--- a/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Command } from "commander";
+import { schemaGenTypesHandler } from "./schemaGenTypesHandler.js";
 import { schemaToYamlHandler } from "./schemaToYamlHandler.js";
 
 export function registerSchemaCommands(program: Command): void {
@@ -28,4 +29,12 @@ export function registerSchemaCommands(program: Command): void {
     .requiredOption("-i, --input <file>", "Input TypeScript schema file")
     .requiredOption("-o, --output <file>", "Output YAML file")
     .action(schemaToYamlHandler);
+
+  schemaCmd
+    .command("gen-types")
+    .description("Generate per-version TypeScript types from a schema module")
+    .requiredOption("-i, --input <file>", "Input TypeScript/JavaScript schema module")
+    .requiredOption("-o, --output <dir>", "Output directory for generated type files")
+    .option("--min-version <version>", "Minimum schema version to generate types for")
+    .action(schemaGenTypesHandler);
 }

--- a/packages/document-schema/type-gen/src/commands/schema/schemaGenTypesHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/schemaGenTypesHandler.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InitialSchema, SchemaDefinition } from "@palantir/pack.schema";
+import { consola } from "consola";
+import fs from "fs-extra";
+import path from "path";
+import { pathToFileURL } from "url";
+import { generateIndexFromSchema } from "../../utils/schema/generateIndexFromSchema.js";
+import { generateInternalFromSchema } from "../../utils/schema/generateInternalFromSchema.js";
+import { generateModelMetadataFromSchema } from "../../utils/schema/generateModelMetadataFromSchema.js";
+import { generateScopeFromSchema } from "../../utils/schema/generateScopeFromSchema.js";
+import { generateVersionedTypesFromSchema } from "../../utils/schema/generateVersionedTypesFromSchema.js";
+import { generateVersionedZodFromSchema } from "../../utils/schema/generateVersionedZodFromSchema.js";
+import { generateVersionsFromSchema } from "../../utils/schema/generateVersionsFromSchema.js";
+import { extractValidSchema } from "../../utils/schema/validateSchemaModule.js";
+
+interface SchemaGenTypesOptions {
+  input: string;
+  output: string;
+  minVersion?: string;
+}
+
+/**
+ * Extract a schema from a loaded module, handling both SchemaDefinition and plain ModelDefs formats.
+ */
+function extractSchemaFromModule(schemaModule: unknown): SchemaDefinition {
+  const mod = schemaModule as Record<string, unknown>;
+  const defaultExport = mod?.default;
+
+  // If the module already exports a SchemaDefinition (tagged with type), use it directly
+  if (
+    typeof defaultExport === "object" && defaultExport != null
+    && "type" in defaultExport
+    && (defaultExport.type === "initial" || defaultExport.type === "versioned")
+  ) {
+    return defaultExport as SchemaDefinition;
+  }
+
+  // Otherwise, treat as a plain ModelDefs (v1 schema) and wrap as InitialSchema
+  const models = extractValidSchema(schemaModule);
+  return { type: "initial", models } satisfies InitialSchema;
+}
+
+export async function schemaGenTypesHandler(options: SchemaGenTypesOptions): Promise<void> {
+  const { input, output: outputDir, minVersion } = options;
+
+  const inputPath = path.resolve(input);
+
+  if (!await fs.pathExists(inputPath)) {
+    throw new Error(`Input file not found: ${inputPath}`);
+  }
+
+  consola.info(`Loading schema from: ${inputPath}`);
+
+  const schemaUrl = pathToFileURL(inputPath).href;
+  const schemaModule: unknown = await import(schemaUrl);
+
+  const schema = extractSchemaFromModule(schemaModule);
+  const minSupportedVersion = minVersion != null ? parseInt(minVersion, 10) : undefined;
+
+  consola.info("Generating versioned types...");
+
+  const result = generateVersionedTypesFromSchema(schema, minSupportedVersion);
+
+  const resolvedOutputDir = path.resolve(outputDir);
+  await fs.ensureDir(resolvedOutputDir);
+
+  // Write per-version read types
+  for (const [version, content] of result.readTypes) {
+    const filePath = path.join(resolvedOutputDir, `types_v${version}.ts`);
+    await fs.writeFile(filePath, content, "utf8");
+    consola.success(`Generated read types: ${filePath}`);
+  }
+
+  // Write per-version write types
+  for (const [version, content] of result.writeTypes) {
+    const filePath = path.join(resolvedOutputDir, `writeTypes_v${version}.ts`);
+    await fs.writeFile(filePath, content, "utf8");
+    consola.success(`Generated write types: ${filePath}`);
+  }
+
+  // Write types.ts re-export
+  const typesPath = path.join(resolvedOutputDir, "types.ts");
+  await fs.writeFile(typesPath, result.typesReExport, "utf8");
+  consola.success(`Generated types re-export: ${typesPath}`);
+
+  // Generate per-version Zod schemas
+  consola.info("Generating versioned Zod schemas...");
+  const zodResult = generateVersionedZodFromSchema(schema, minSupportedVersion);
+
+  for (const [version, content] of zodResult.zodSchemas) {
+    const filePath = path.join(resolvedOutputDir, `schema_v${version}.ts`);
+    await fs.writeFile(filePath, content, "utf8");
+    consola.success(`Generated Zod schema: ${filePath}`);
+  }
+
+  // Write schema.ts re-export
+  const schemaPath = path.join(resolvedOutputDir, "schema.ts");
+  await fs.writeFile(schemaPath, zodResult.schemaReExport, "utf8");
+  consola.success(`Generated schema re-export: ${schemaPath}`);
+
+  // Generate internal files
+  consola.info("Generating internal types and migrations...");
+  const internal = generateInternalFromSchema(schema);
+
+  const internalDir = path.join(resolvedOutputDir, "_internal");
+  await fs.ensureDir(internalDir);
+
+  const internalTypesPath = path.join(internalDir, "types.ts");
+  await fs.writeFile(internalTypesPath, internal.internalTypes, "utf8");
+  consola.success(`Generated internal types: ${internalTypesPath}`);
+
+  const migrationsPath = path.join(internalDir, "migrations.ts");
+  await fs.writeFile(migrationsPath, internal.migrations, "utf8");
+  consola.success(`Generated migrations: ${migrationsPath}`);
+
+  const internalSchemaPath = path.join(internalDir, "schema.ts");
+  await fs.writeFile(internalSchemaPath, internal.internalSchema, "utf8");
+  consola.success(`Generated internal schema: ${internalSchemaPath}`);
+
+  // Generate models.ts with version metadata
+  consola.info("Generating model metadata...");
+  const modelMetadata = generateModelMetadataFromSchema(schema, minSupportedVersion);
+
+  const modelsPath = path.join(resolvedOutputDir, "models.ts");
+  await fs.writeFile(modelsPath, modelMetadata.modelsFile, "utf8");
+  consola.success(`Generated models: ${modelsPath}`);
+
+  // Generate schema manifest for the backend
+  const manifestPath = path.join(resolvedOutputDir, "schema-manifest.json");
+  await fs.writeFile(
+    manifestPath,
+    JSON.stringify(modelMetadata.schemaManifest, null, 2) + "\n",
+    "utf8",
+  );
+  consola.success(`Generated schema manifest: ${manifestPath}`);
+
+  // Generate versions.ts
+  consola.info("Generating version types...");
+  const versionsContent = generateVersionsFromSchema(schema, minSupportedVersion);
+  const versionsPath = path.join(resolvedOutputDir, "versions.ts");
+  await fs.writeFile(versionsPath, versionsContent, "utf8");
+  consola.success(`Generated versions: ${versionsPath}`);
+
+  // Generate versionedDocRef.ts
+  consola.info("Generating versioned document ref types...");
+  const versionedDocRefContent = generateScopeFromSchema(schema, minSupportedVersion);
+  const versionedDocRefPath = path.join(resolvedOutputDir, "versionedDocRef.ts");
+  await fs.writeFile(versionedDocRefPath, versionedDocRefContent, "utf8");
+  consola.success(`Generated versioned doc ref: ${versionedDocRefPath}`);
+
+  // Generate index.ts barrel export
+  consola.info("Generating index barrel export...");
+  const indexContent = generateIndexFromSchema(schema, minSupportedVersion);
+  const indexPath = path.join(resolvedOutputDir, "index.ts");
+  await fs.writeFile(indexPath, indexContent, "utf8");
+  consola.success(`Generated index: ${indexPath}`);
+}

--- a/packages/document-schema/type-gen/src/index.ts
+++ b/packages/document-schema/type-gen/src/index.ts
@@ -23,7 +23,17 @@ export {
   convertSchemaToSteps,
   convertStepsToYamlString,
 } from "./utils/schema/convertSchemaToSteps.js";
+export { generateInternalFromSchema } from "./utils/schema/generateInternalFromSchema.js";
+export { generateModelMetadataFromSchema } from "./utils/schema/generateModelMetadataFromSchema.js";
+export {
+  generateSchemaManifest,
+  type ModelManifest,
+  type SchemaManifest,
+  type VersionManifest,
+} from "./utils/schema/generateSchemaManifest.js";
 export { generateTypesFromSchema } from "./utils/schema/generateTypesFromSchema.js";
+export { generateVersionedTypesFromSchema } from "./utils/schema/generateVersionedTypesFromSchema.js";
+export { generateVersionedZodFromSchema } from "./utils/schema/generateVersionedZodFromSchema.js";
 export { generateZodFromSchema } from "./utils/schema/generateZodFromSchema.js";
 export {
   convertRecordDefToIr,

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/generateInternalFromSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/generateInternalFromSchema.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaDefinition } from "@palantir/pack.schema";
+import { defineRecord, defineSchema } from "@palantir/pack.schema";
+import * as P from "@palantir/pack.schema";
+import { describe, expect, it } from "vitest";
+import { generateInternalFromSchema } from "../generateInternalFromSchema.js";
+
+describe("generateInternalFromSchema", () => {
+  function buildCanvasDemo(): SchemaDefinition {
+    const v1Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          top: P.Double,
+          bottom: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v2Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          top: P.Double,
+          bottom: P.Double,
+          fillColor: P.Optional(P.String),
+          strokeColor: P.Optional(P.String),
+          opacity: P.Optional(P.Double),
+        },
+      }),
+    };
+
+    return {
+      type: "versioned",
+      models: v2Models,
+      version: 2,
+      previous: { type: "initial", models: v1Models },
+    };
+  }
+
+  it("should generate internal types with all fields from all versions", () => {
+    const schemaV2 = buildCanvasDemo();
+    const result = generateInternalFromSchema(schemaV2);
+
+    // Internal types should include ALL fields from both v1 and v2
+    expect(result.internalTypes).toContain("export interface ShapeBox__Internal {");
+    expect(result.internalTypes).toContain("readonly bottom: number;");
+    expect(result.internalTypes).toContain("readonly left: number;");
+    expect(result.internalTypes).toContain("readonly right: number;");
+    expect(result.internalTypes).toContain("readonly top: number;");
+    // color was removed in v2, so it should be optional
+    expect(result.internalTypes).toContain("readonly color?: string;");
+    // fillColor, strokeColor, opacity were added in v2, so they should be optional
+    expect(result.internalTypes).toContain("readonly fillColor?: string;");
+    expect(result.internalTypes).toContain("readonly strokeColor?: string;");
+    expect(result.internalTypes).toContain("readonly opacity?: number;");
+  });
+
+  it("should generate migration registry with steps", () => {
+    const schemaV2 = buildCanvasDemo();
+    const result = generateInternalFromSchema(schemaV2);
+
+    // Should import MigrationRegistry
+    expect(result.migrations).toContain(
+      "import type { MigrationRegistry",
+    );
+
+    // Should define ShapeBoxMigrations
+    expect(result.migrations).toContain(
+      "export const ShapeBoxMigrations: MigrationRegistry<\"ShapeBox\">",
+    );
+    expect(result.migrations).toContain("modelName: \"ShapeBox\"");
+
+    // allFields should contain every field
+    expect(result.migrations).toContain("bottom: { type: { kind: ");
+    expect(result.migrations).toContain("color: { type: { kind: ");
+    expect(result.migrations).toContain("fillColor: { type: { kind: ");
+    expect(result.migrations).toContain("opacity: { type: { kind: ");
+
+    // Steps should mention added fields
+    expect(result.migrations).toContain("addedInVersion: 2");
+    expect(result.migrations).toContain("removedFields: [\"color\"]");
+  });
+
+  it("should generate internal Zod schemas", () => {
+    const schemaV2 = buildCanvasDemo();
+    const result = generateInternalFromSchema(schemaV2);
+
+    // Should import zod
+    expect(result.internalSchema).toContain("import { z } from \"zod\";");
+
+    // Should define internal schema
+    expect(result.internalSchema).toContain("export const ShapeBoxInternalSchema = z.object({");
+    expect(result.internalSchema).toContain("bottom: z.number(),");
+    expect(result.internalSchema).toContain("left: z.number(),");
+    // Optional fields
+    expect(result.internalSchema).toContain("color: z.string().optional(),");
+    expect(result.internalSchema).toContain("fillColor: z.string().optional(),");
+    expect(result.internalSchema).toContain("strokeColor: z.string().optional(),");
+    expect(result.internalSchema).toContain("opacity: z.number().optional(),");
+    // Passthrough
+    expect(result.internalSchema).toContain("}).passthrough();");
+  });
+
+  it("should handle single-version schemas (no migrations)", () => {
+    const schemaV1 = defineSchema({
+      Item: defineRecord("Item", {
+        docs: "An item",
+        fields: {
+          name: P.String,
+          count: P.Double,
+        },
+      }),
+    });
+
+    const result = generateInternalFromSchema(schemaV1);
+
+    // Internal types
+    expect(result.internalTypes).toContain("export interface Item__Internal {");
+    expect(result.internalTypes).toContain("readonly count: number;");
+    expect(result.internalTypes).toContain("readonly name: string;");
+
+    // No migration steps
+    expect(result.migrations).toContain("export const ItemMigrations: MigrationRegistry<\"Item\">");
+    expect(result.migrations).toContain("steps: [");
+    expect(result.migrations).not.toContain("addedInVersion");
+
+    // Internal schema
+    expect(result.internalSchema).toContain("export const ItemInternalSchema = z.object({");
+    expect(result.internalSchema).toContain("count: z.number(),");
+    expect(result.internalSchema).toContain("name: z.string(),");
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/generateModelMetadataFromSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/generateModelMetadataFromSchema.test.ts
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaBuilder, SchemaDefinition } from "@palantir/pack.schema";
+import { defineRecord, defineSchema, defineSchemaUpdate, nextSchema } from "@palantir/pack.schema";
+import * as P from "@palantir/pack.schema";
+import { describe, expect, it } from "vitest";
+import { generateModelMetadataFromSchema } from "../generateModelMetadataFromSchema.js";
+
+describe("generateModelMetadataFromSchema", () => {
+  it("should generate models.ts for a single-version schema", () => {
+    const schemaV1 = defineSchema({
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          top: P.Double,
+          bottom: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    });
+
+    const result = generateModelMetadataFromSchema(schemaV1);
+
+    // Should import model types
+    expect(result.modelsFile).toContain(
+      "import type { DocumentSchema, RecordModel } from \"@palantir/pack.document-schema.model-types\"",
+    );
+    expect(result.modelsFile).toContain(
+      "import { Metadata } from \"@palantir/pack.document-schema.model-types\"",
+    );
+
+    // Should import types and schemas
+    expect(result.modelsFile).toContain("import type { ShapeBox } from \"./types.js\"");
+    expect(result.modelsFile).toContain("import { ShapeBoxSchema } from \"./schema.js\"");
+
+    // Should generate model constant
+    expect(result.modelsFile).toContain(
+      "export interface ShapeBoxModel extends RecordModel<ShapeBox, typeof ShapeBoxSchema> {}",
+    );
+    expect(result.modelsFile).toContain("export const ShapeBoxModel: ShapeBoxModel = {");
+    expect(result.modelsFile).toContain("name: \"ShapeBox\"");
+
+    // Should generate DocumentModel with version: 1
+    expect(result.modelsFile).toContain("export const DocumentModel = {");
+    expect(result.modelsFile).toContain("ShapeBox: ShapeBoxModel");
+    expect(result.modelsFile).toContain("version: 1,");
+    expect(result.modelsFile).toContain("as const satisfies DocumentSchema;");
+
+    // Single-version should NOT have migrations or minSupportedVersion
+    expect(result.modelsFile).not.toContain("minSupportedVersion");
+    expect(result.modelsFile).not.toContain("migrations");
+  });
+
+  it("should generate models.ts with version metadata for multi-version schema", () => {
+    const v1Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v2Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          fillColor: P.Optional(P.String),
+          strokeColor: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const schemaV2: SchemaDefinition = {
+      type: "versioned",
+      models: v2Models,
+      version: 2,
+      previous: { type: "initial", models: v1Models },
+    };
+
+    const result = generateModelMetadataFromSchema(schemaV2, 1);
+
+    // Should have version: 2 and minSupportedVersion: 1
+    expect(result.modelsFile).toContain("version: 2,");
+    expect(result.modelsFile).toContain("minSupportedVersion: 1,");
+
+    // Should import and reference migrations
+    expect(result.modelsFile).toContain(
+      "import { ShapeBoxMigrations } from \"./_internal/migrations.js\"",
+    );
+    expect(result.modelsFile).toContain("migrations: {");
+    expect(result.modelsFile).toContain("ShapeBox: ShapeBoxMigrations,");
+  });
+
+  it("should not include minSupportedVersion when it equals latest", () => {
+    const schemaV1 = defineSchema({
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: { name: P.String },
+      }),
+    });
+
+    const addDesc = defineSchemaUpdate(
+      "addDesc",
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
+        Item: schema.Item.addField("desc", P.Optional(P.String)).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addDesc).build();
+
+    // Default: minSupportedVersion = latestVersion (2)
+    const result = generateModelMetadataFromSchema(schemaV2);
+
+    expect(result.modelsFile).toContain("version: 2,");
+    expect(result.modelsFile).not.toContain("minSupportedVersion");
+  });
+
+  it("should generate schema manifest with per-version field lists", () => {
+    const v1Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          top: P.Double,
+          bottom: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v2Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          top: P.Double,
+          bottom: P.Double,
+          fillColor: P.Optional(P.String),
+          strokeColor: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const schemaV2: SchemaDefinition = {
+      type: "versioned",
+      models: v2Models,
+      version: 2,
+      previous: { type: "initial", models: v1Models },
+    };
+
+    const result = generateModelMetadataFromSchema(schemaV2, 1);
+    const manifest = result.schemaManifest;
+
+    expect(manifest.latestVersion).toBe(2);
+    expect(manifest.minSupportedVersion).toBe(1);
+
+    // v1 fields
+    expect(manifest.models.ShapeBox!.versions["1"]!.fields).toEqual(
+      ["bottom", "color", "left", "right", "top"],
+    );
+
+    // v2 fields (color removed, fillColor + strokeColor added)
+    expect(manifest.models.ShapeBox!.versions["2"]!.fields).toEqual(
+      ["bottom", "fillColor", "left", "right", "strokeColor", "top"],
+    );
+  });
+
+  it("should handle three-version chains in manifest", () => {
+    const v1Models = {
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: {
+          name: P.String,
+          color: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v2Models = {
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: {
+          name: P.String,
+          hexColor: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v3Models = {
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: {
+          name: P.String,
+          hexColor: P.Optional(P.String),
+          tags: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const schemaV3: SchemaDefinition = {
+      type: "versioned",
+      models: v3Models,
+      version: 3,
+      previous: {
+        type: "versioned",
+        models: v2Models,
+        version: 2,
+        previous: { type: "initial", models: v1Models },
+      },
+    };
+
+    const result = generateModelMetadataFromSchema(schemaV3, 1);
+
+    expect(result.schemaManifest.latestVersion).toBe(3);
+    expect(result.schemaManifest.models.Item!.versions["1"]!.fields).toEqual(["color", "name"]);
+    expect(result.schemaManifest.models.Item!.versions["2"]!.fields).toEqual(["hexColor", "name"]);
+    expect(result.schemaManifest.models.Item!.versions["3"]!.fields).toEqual([
+      "hexColor",
+      "name",
+      "tags",
+    ]);
+
+    // models.ts should have version: 3
+    expect(result.modelsFile).toContain("version: 3,");
+    expect(result.modelsFile).toContain("minSupportedVersion: 1,");
+  });
+
+  it("should use custom import paths", () => {
+    const schemaV1 = defineSchema({
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: { name: P.String },
+      }),
+    });
+
+    const result = generateModelMetadataFromSchema(schemaV1, undefined, {
+      typeImportPath: "../types.js",
+      schemaImportPath: "../schema.js",
+      migrationsImportPath: "../_internal/migrations.js",
+    });
+
+    expect(result.modelsFile).toContain("from \"../types.js\"");
+    expect(result.modelsFile).toContain("from \"../schema.js\"");
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/generateScopeFromSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/generateScopeFromSchema.test.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaBuilder, SchemaDefinition } from "@palantir/pack.schema";
+import {
+  defineRecord,
+  defineSchema,
+  defineSchemaUpdate,
+  defineUnion,
+  nextSchema,
+} from "@palantir/pack.schema";
+import * as P from "@palantir/pack.schema";
+import { describe, expect, it } from "vitest";
+import { generateScopeFromSchema } from "../generateScopeFromSchema.js";
+
+describe("generateScopeFromSchema", () => {
+  it("should generate versioned doc ref for a single-version schema", () => {
+    const schemaV1 = defineSchema({
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "",
+        fields: {
+          left: P.Double,
+          top: P.Double,
+        },
+      }),
+    });
+
+    const result = generateScopeFromSchema(schemaV1);
+
+    // Should extend DocumentRef
+    expect(result).toContain(
+      "export interface VersionedDocRef_v1 extends DocumentRef<DocumentModel> {",
+    );
+    expect(result).toContain("readonly version: 1;");
+
+    // Since it's the first version, all models are "changed"
+    expect(result).toContain(
+      "updateRecord(ref: RecordRef<typeof ShapeBoxModel>, data: ShapeBoxUpdate_v1)",
+    );
+    expect(result).toContain(
+      "setCollectionRecord(model: typeof ShapeBoxModel, id: RecordId, data: ShapeBox_v1)",
+    );
+
+    // Generic fallback
+    expect(result).toContain(
+      "updateRecord<M extends Model>(ref: RecordRef<M>, data: Partial<ModelData<M>>)",
+    );
+    expect(result).toContain(
+      "setCollectionRecord<M extends Model>(model: M, id: RecordId, data: ModelData<M>)",
+    );
+
+    // Single version = no union, just alias
+    expect(result).toContain("export type VersionedDocRef = VersionedDocRef_v1;");
+    expect(result).not.toContain(" | ");
+
+    // asVersioned identity function
+    expect(result).toContain(
+      "export function asVersioned(docRef: DocumentRef<DocumentModel>): VersionedDocRef {",
+    );
+    expect(result).toContain("return docRef as VersionedDocRef;");
+  });
+
+  it("should generate versioned doc ref with changed model overloads for multi-version schema", () => {
+    const v1Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "",
+        fields: {
+          left: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v2Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "",
+        fields: {
+          left: P.Double,
+          fillColor: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const schemaV2: SchemaDefinition = {
+      type: "versioned",
+      models: v2Models,
+      version: 2,
+      previous: { type: "initial", models: v1Models },
+    };
+
+    const result = generateScopeFromSchema(schemaV2, 1);
+
+    // Both version interfaces
+    expect(result).toContain(
+      "export interface VersionedDocRef_v1 extends DocumentRef<DocumentModel> {",
+    );
+    expect(result).toContain("readonly version: 1;");
+    expect(result).toContain(
+      "export interface VersionedDocRef_v2 extends DocumentRef<DocumentModel> {",
+    );
+    expect(result).toContain("readonly version: 2;");
+
+    // v1 has ShapeBox overload (first version, all models are new)
+    expect(result).toContain(
+      "updateRecord(ref: RecordRef<typeof ShapeBoxModel>, data: ShapeBoxUpdate_v1)",
+    );
+
+    // v2 has ShapeBox overload because fields changed (color -> fillColor)
+    expect(result).toContain(
+      "updateRecord(ref: RecordRef<typeof ShapeBoxModel>, data: ShapeBoxUpdate_v2)",
+    );
+    expect(result).toContain(
+      "setCollectionRecord(model: typeof ShapeBoxModel, id: RecordId, data: ShapeBox_v2)",
+    );
+
+    // Union type
+    expect(result).toContain(
+      "export type VersionedDocRef = VersionedDocRef_v1 | VersionedDocRef_v2;",
+    );
+
+    // Imports
+    expect(result).toContain("from \"./types_v1.js\"");
+    expect(result).toContain("from \"./types_v2.js\"");
+    expect(result).toContain("from \"./writeTypes_v1.js\"");
+    expect(result).toContain("from \"./writeTypes_v2.js\"");
+    expect(result).toContain("from \"./models.js\"");
+  });
+
+  it("should generate setCollectionRecord overloads for union models referencing changed records", () => {
+    const ShapeBox = defineRecord("ShapeBox", {
+      docs: "",
+      fields: {
+        left: P.Double,
+        color: P.Optional(P.String),
+      },
+    });
+    const ShapeCircle = defineRecord("ShapeCircle", {
+      docs: "",
+      fields: {
+        radius: P.Double,
+        color: P.Optional(P.String),
+      },
+    });
+    const schemaV1 = defineSchema({
+      ShapeBox,
+      ShapeCircle,
+      NodeShape: defineUnion("NodeShape", {
+        docs: "",
+        discriminant: "shapeType",
+        variants: {
+          box: ShapeBox,
+          circle: ShapeCircle,
+        },
+      }),
+    });
+
+    const result = generateScopeFromSchema(schemaV1);
+
+    // Union model should have setCollectionRecord overload
+    expect(result).toContain(
+      "setCollectionRecord(model: typeof NodeShapeModel, id: RecordId, data: NodeShape_v1)",
+    );
+
+    // Record model variants should have updateRecord overloads
+    expect(result).toContain(
+      "updateRecord(ref: RecordRef<typeof ShapeBoxModel>, data: ShapeBoxUpdate_v1)",
+    );
+    expect(result).toContain(
+      "updateRecord(ref: RecordRef<typeof ShapeCircleModel>, data: ShapeCircleUpdate_v1)",
+    );
+  });
+
+  it("should generate generic fallback for models with only additive changes", () => {
+    const schemaV1 = defineSchema({
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "",
+        fields: {
+          left: P.Double,
+          top: P.Double,
+        },
+      }),
+      Label: defineRecord("Label", {
+        docs: "",
+        fields: {
+          text: P.String,
+        },
+      }),
+    });
+
+    // Only change ShapeBox; Label stays the same
+    const addColor = defineSchemaUpdate(
+      "addColor",
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
+        ShapeBox: schema.ShapeBox
+          .addField("color", P.Optional(P.String))
+          .build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addColor).build();
+
+    const result = generateScopeFromSchema(schemaV2, 1);
+
+    // v2: ShapeBox changed (gained a field), Label did NOT change
+    // ShapeBox should have specific overloads in v2
+    expect(result).toContain(
+      "updateRecord(ref: RecordRef<typeof ShapeBoxModel>, data: ShapeBoxUpdate_v2)",
+    );
+
+    // Label should NOT have specific overloads in v2 (it didn't change)
+    expect(result).not.toContain(
+      "updateRecord(ref: RecordRef<typeof LabelModel>, data: LabelUpdate_v2)",
+    );
+
+    // Both should be covered by the generic fallback
+    expect(result).toContain(
+      "updateRecord<M extends Model>(ref: RecordRef<M>, data: Partial<ModelData<M>>)",
+    );
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/generateVersionedTypesFromSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/generateVersionedTypesFromSchema.test.ts
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaBuilder, SchemaDefinition } from "@palantir/pack.schema";
+import { defineRecord, defineSchema, defineSchemaUpdate, nextSchema } from "@palantir/pack.schema";
+import * as P from "@palantir/pack.schema";
+import { describe, expect, it } from "vitest";
+import { generateVersionedTypesFromSchema } from "../generateVersionedTypesFromSchema.js";
+
+describe("generateVersionedTypesFromSchema", () => {
+  it("should generate types for a single-version schema (v1 only)", () => {
+    const schemaV1 = defineSchema({
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          top: P.Double,
+          bottom: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    });
+
+    const result = generateVersionedTypesFromSchema(schemaV1);
+
+    // Should generate v1 read types
+    expect(result.readTypes.size).toBe(1);
+    const readV1 = result.readTypes.get(1)!;
+    expect(readV1).toContain("export interface ShapeBox_v1 {");
+    expect(readV1).toContain("readonly left: number;");
+    expect(readV1).toContain("readonly right: number;");
+    expect(readV1).toContain("readonly top: number;");
+    expect(readV1).toContain("readonly bottom: number;");
+    expect(readV1).toContain("readonly color?: string;");
+
+    // Should generate v1 write types
+    expect(result.writeTypes.size).toBe(1);
+    const writeV1 = result.writeTypes.get(1)!;
+    expect(writeV1).toContain("export type ShapeBoxUpdate_v1 = {");
+    expect(writeV1).toContain("readonly left?: number;");
+    expect(writeV1).toContain("readonly color?: string;");
+
+    // Should generate types.ts re-export
+    expect(result.typesReExport).toContain(
+      "export type { ShapeBox_v1 as ShapeBox } from \"./types_v1.js\";",
+    );
+  });
+
+  it("should generate per-version types for multi-version schemas with additive changes", () => {
+    const schemaV1 = defineSchema({
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          top: P.Double,
+          bottom: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    });
+
+    const addFillColor = defineSchemaUpdate(
+      "addFillColor",
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
+        ShapeBox: schema.ShapeBox
+          .addField("fillColor", P.Optional(P.String))
+          .build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addFillColor).build();
+
+    const result = generateVersionedTypesFromSchema(schemaV2, 1);
+
+    // Should generate both v1 and v2 read types
+    expect(result.readTypes.size).toBe(2);
+
+    // v1 read types
+    const readV1 = result.readTypes.get(1)!;
+    expect(readV1).toContain("export interface ShapeBox_v1 {");
+    expect(readV1).toContain("readonly color?: string;");
+    expect(readV1).not.toContain("fillColor");
+
+    // v2 read types
+    const readV2 = result.readTypes.get(2)!;
+    expect(readV2).toContain("export interface ShapeBox_v2 {");
+    expect(readV2).toContain("readonly color?: string;");
+    expect(readV2).toContain("readonly fillColor?: string;");
+
+    // types.ts re-exports latest version
+    expect(result.typesReExport).toContain(
+      "export type { ShapeBox_v2 as ShapeBox } from \"./types_v2.js\";",
+    );
+  });
+
+  it("should handle field removal via manual VersionedSchema construction", () => {
+    // When the schema API gains removeField support, this can use the builder API instead
+    const v1Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v2Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          fillColor: P.Optional(P.String),
+          strokeColor: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const schemaV2: SchemaDefinition = {
+      type: "versioned",
+      models: v2Models,
+      version: 2,
+      previous: { type: "initial", models: v1Models },
+    };
+
+    const result = generateVersionedTypesFromSchema(schemaV2, 1);
+
+    // v1: left, color
+    const readV1 = result.readTypes.get(1)!;
+    expect(readV1).toContain("readonly left: number;");
+    expect(readV1).toContain("readonly color?: string;");
+    expect(readV1).not.toContain("fillColor");
+
+    // v2: left, fillColor, strokeColor (no color)
+    const readV2 = result.readTypes.get(2)!;
+    expect(readV2).toContain("readonly left: number;");
+    expect(readV2).toContain("readonly fillColor?: string;");
+    expect(readV2).toContain("readonly strokeColor?: string;");
+    expect(readV2).not.toContain("readonly color");
+  });
+
+  it("should respect minSupportedVersion and only generate from that version", () => {
+    const schemaV1 = defineSchema({
+      Item: defineRecord("Item", {
+        docs: "An item",
+        fields: {
+          name: P.String,
+        },
+      }),
+    });
+
+    const addDescription = defineSchemaUpdate(
+      "addDescription",
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
+        Item: schema.Item.addField("description", P.Optional(P.String)).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addDescription).build();
+
+    // Only generate from v2 (default: latest only)
+    const result = generateVersionedTypesFromSchema(schemaV2);
+    expect(result.readTypes.size).toBe(1);
+    expect(result.readTypes.has(2)).toBe(true);
+    expect(result.readTypes.has(1)).toBe(false);
+
+    // Generate from v1 onward
+    const resultWithV1 = generateVersionedTypesFromSchema(schemaV2, 1);
+    expect(resultWithV1.readTypes.size).toBe(2);
+    expect(resultWithV1.readTypes.has(1)).toBe(true);
+    expect(resultWithV1.readTypes.has(2)).toBe(true);
+  });
+
+  it("should handle three-version chains", () => {
+    const v1Models = {
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: {
+          name: P.String,
+          color: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v2Models = {
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: {
+          name: P.String,
+          hexColor: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v3Models = {
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: {
+          name: P.String,
+          hexColor: P.Optional(P.String),
+          tags: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const schemaV3: SchemaDefinition = {
+      type: "versioned",
+      models: v3Models,
+      version: 3,
+      previous: {
+        type: "versioned",
+        models: v2Models,
+        version: 2,
+        previous: { type: "initial", models: v1Models },
+      },
+    };
+
+    const result = generateVersionedTypesFromSchema(schemaV3, 1);
+    expect(result.readTypes.size).toBe(3);
+
+    // v1: name, color
+    const readV1 = result.readTypes.get(1)!;
+    expect(readV1).toContain("readonly name: string;");
+    expect(readV1).toContain("readonly color?: string;");
+    expect(readV1).not.toContain("hexColor");
+    expect(readV1).not.toContain("tags");
+
+    // v2: name, hexColor
+    const readV2 = result.readTypes.get(2)!;
+    expect(readV2).toContain("readonly name: string;");
+    expect(readV2).toContain("readonly hexColor?: string;");
+    expect(readV2).not.toContain("readonly color");
+    expect(readV2).not.toContain("tags");
+
+    // v3: name, hexColor, tags
+    const readV3 = result.readTypes.get(3)!;
+    expect(readV3).toContain("readonly name: string;");
+    expect(readV3).toContain("readonly hexColor?: string;");
+    expect(readV3).toContain("readonly tags?: string;");
+
+    // types.ts re-exports v3
+    expect(result.typesReExport).toContain(
+      "export type { Item_v3 as Item } from \"./types_v3.js\";",
+    );
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/generateVersionedZodFromSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/generateVersionedZodFromSchema.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaBuilder, SchemaDefinition } from "@palantir/pack.schema";
+import { defineRecord, defineSchema, defineSchemaUpdate, nextSchema } from "@palantir/pack.schema";
+import * as P from "@palantir/pack.schema";
+import { describe, expect, it } from "vitest";
+import { generateVersionedZodFromSchema } from "../generateVersionedZodFromSchema.js";
+
+describe("generateVersionedZodFromSchema", () => {
+  it("should generate Zod schemas for a single-version schema (v1 only)", () => {
+    const schemaV1 = defineSchema({
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          top: P.Double,
+          bottom: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    });
+
+    const result = generateVersionedZodFromSchema(schemaV1);
+
+    // Should generate v1 Zod schema
+    expect(result.zodSchemas.size).toBe(1);
+    const zodV1 = result.zodSchemas.get(1)!;
+    expect(zodV1).toContain("export const ShapeBoxSchema_v1 = z.object({");
+    expect(zodV1).toContain("left: z.number()");
+    expect(zodV1).toContain("right: z.number()");
+    expect(zodV1).toContain("top: z.number()");
+    expect(zodV1).toContain("bottom: z.number()");
+    expect(zodV1).toContain("color: z.string().optional()");
+    expect(zodV1).not.toContain(".passthrough()");
+    expect(zodV1).toContain("satisfies ZodType<ShapeBox_v1>");
+
+    // Should have imports
+    expect(zodV1).toContain("import type { ZodType } from \"zod\"");
+    expect(zodV1).toContain("import { z } from \"zod\"");
+    expect(zodV1).toContain("import type { ShapeBox_v1 }");
+
+    // Should generate schema re-export
+    expect(result.schemaReExport).toContain(
+      "export { ShapeBoxSchema_v1 as ShapeBoxSchema } from \"./schema_v1.js\";",
+    );
+  });
+
+  it("should generate per-version Zod schemas for multi-version schemas", () => {
+    const schemaV1 = defineSchema({
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    });
+
+    const addFillColor = defineSchemaUpdate(
+      "addFillColor",
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
+        ShapeBox: schema.ShapeBox
+          .addField("fillColor", P.Optional(P.String))
+          .build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addFillColor).build();
+
+    const result = generateVersionedZodFromSchema(schemaV2, 1);
+
+    // Should generate both v1 and v2 Zod schemas
+    expect(result.zodSchemas.size).toBe(2);
+
+    // v1 Zod schema
+    const zodV1 = result.zodSchemas.get(1)!;
+    expect(zodV1).toContain("export const ShapeBoxSchema_v1 = z.object({");
+    expect(zodV1).toContain("color: z.string().optional()");
+    expect(zodV1).not.toContain("fillColor");
+
+    // v2 Zod schema
+    const zodV2 = result.zodSchemas.get(2)!;
+    expect(zodV2).toContain("export const ShapeBoxSchema_v2 = z.object({");
+    expect(zodV2).toContain("color: z.string().optional()");
+    expect(zodV2).toContain("fillColor: z.string().optional()");
+    expect(zodV2).toContain("satisfies ZodType<ShapeBox_v2>");
+  });
+
+  it("should generate internal schema with all fields across all versions", () => {
+    // Use manual VersionedSchema for field removal scenario
+    const v1Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          color: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const v2Models = {
+      ShapeBox: defineRecord("ShapeBox", {
+        docs: "A box shape",
+        fields: {
+          left: P.Double,
+          right: P.Double,
+          fillColor: P.Optional(P.String),
+          strokeColor: P.Optional(P.String),
+        },
+      }),
+    };
+
+    const schemaV2: SchemaDefinition = {
+      type: "versioned",
+      models: v2Models,
+      version: 2,
+      previous: { type: "initial", models: v1Models },
+    };
+
+    const result = generateVersionedZodFromSchema(schemaV2, 1);
+
+    // Internal schema should include ALL fields from ALL versions, all optional
+    const internal = result.internalSchema;
+    expect(internal).toContain("export const ShapeBoxInternalSchema = z.object({");
+    expect(internal).toContain("left: z.number().optional()");
+    expect(internal).toContain("right: z.number().optional()");
+    expect(internal).toContain("color: z.string().optional()");
+    expect(internal).toContain("fillColor: z.string().optional()");
+    expect(internal).toContain("strokeColor: z.string().optional()");
+    expect(internal).toContain(".passthrough()");
+    expect(internal).not.toContain("satisfies");
+  });
+
+  it("should respect minSupportedVersion", () => {
+    const schemaV1 = defineSchema({
+      Item: defineRecord("Item", {
+        docs: "An item",
+        fields: {
+          name: P.String,
+        },
+      }),
+    });
+
+    const addDescription = defineSchemaUpdate(
+      "addDescription",
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
+        Item: schema.Item.addField("description", P.Optional(P.String)).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addDescription).build();
+
+    // Only generate from v2 (default: latest only)
+    const result = generateVersionedZodFromSchema(schemaV2);
+    expect(result.zodSchemas.size).toBe(1);
+    expect(result.zodSchemas.has(2)).toBe(true);
+    expect(result.zodSchemas.has(1)).toBe(false);
+
+    // Generate from v1 onward
+    const resultWithV1 = generateVersionedZodFromSchema(schemaV2, 1);
+    expect(resultWithV1.zodSchemas.size).toBe(2);
+    expect(resultWithV1.zodSchemas.has(1)).toBe(true);
+    expect(resultWithV1.zodSchemas.has(2)).toBe(true);
+  });
+
+  it("should use custom typeImportPathBase", () => {
+    const schemaV1 = defineSchema({
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: {
+          name: P.String,
+        },
+      }),
+    });
+
+    const result = generateVersionedZodFromSchema(schemaV1, undefined, "../types");
+    const zodV1 = result.zodSchemas.get(1)!;
+    expect(zodV1).toContain("from \"../types_v1.js\"");
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/generateVersionsFromSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/generateVersionsFromSchema.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaBuilder } from "@palantir/pack.schema";
+import { defineRecord, defineSchema, defineSchemaUpdate, nextSchema } from "@palantir/pack.schema";
+import * as P from "@palantir/pack.schema";
+import { describe, expect, it } from "vitest";
+import { generateVersionsFromSchema } from "../generateVersionsFromSchema.js";
+
+describe("generateVersionsFromSchema", () => {
+  it("should generate version types for a single-version schema", () => {
+    const schemaV1 = defineSchema({
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: { name: P.String },
+      }),
+    });
+
+    const result = generateVersionsFromSchema(schemaV1);
+
+    expect(result).toContain("export type SupportedVersions = 1;");
+    expect(result).toContain("export type LatestVersion = 1;");
+    expect(result).toContain("export type MinSupportedVersion = 1;");
+  });
+
+  it("should generate version types for a multi-version schema", () => {
+    const schemaV1 = defineSchema({
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: { name: P.String },
+      }),
+    });
+
+    const addDescription = defineSchemaUpdate(
+      "addDescription",
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
+        Item: schema.Item.addField("description", P.Optional(P.String)).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addDescription).build();
+
+    const result = generateVersionsFromSchema(schemaV2, 1);
+
+    expect(result).toContain("export type SupportedVersions = 1 | 2;");
+    expect(result).toContain("export type LatestVersion = 2;");
+    expect(result).toContain("export type MinSupportedVersion = 1;");
+  });
+
+  it("should respect minSupportedVersion", () => {
+    const schemaV1 = defineSchema({
+      Item: defineRecord("Item", {
+        docs: "",
+        fields: { name: P.String },
+      }),
+    });
+
+    const addDescription = defineSchemaUpdate(
+      "addDescription",
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
+        Item: schema.Item.addField("description", P.Optional(P.String)).build(),
+      }),
+    );
+
+    const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addDescription).build();
+
+    // Default (no minVersion): latest only
+    const resultDefault = generateVersionsFromSchema(schemaV2);
+    expect(resultDefault).toContain("export type SupportedVersions = 2;");
+    expect(resultDefault).toContain("export type LatestVersion = 2;");
+    expect(resultDefault).toContain("export type MinSupportedVersion = 2;");
+
+    // Explicit minVersion = 1
+    const resultWithV1 = generateVersionsFromSchema(schemaV2, 1);
+    expect(resultWithV1).toContain("export type SupportedVersions = 1 | 2;");
+    expect(resultWithV1).toContain("export type MinSupportedVersion = 1;");
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/schema/generateIndexFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateIndexFromSchema.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaDefinition } from "@palantir/pack.schema";
+import { GENERATED_FILE_HEADER } from "../generatedFileHeader.js";
+
+const SchemaDefKind = {
+  RECORD: "record",
+  UNION: "union",
+} as const;
+
+interface RuntimeSchemaRecord {
+  readonly type: typeof SchemaDefKind.RECORD;
+  readonly name: string;
+  readonly fields: Readonly<Record<string, unknown>>;
+}
+
+interface RuntimeSchemaUnion {
+  readonly type: typeof SchemaDefKind.UNION;
+  readonly name?: string;
+  readonly variants: Readonly<Record<string, unknown>>;
+  readonly discriminant: string;
+}
+
+type RuntimeSchemaItem = RuntimeSchemaRecord | RuntimeSchemaUnion;
+type RuntimeSchema = Record<string, RuntimeSchemaItem>;
+
+interface VersionedSchemaEntry {
+  version: number;
+  schema: RuntimeSchema;
+}
+
+function isRecordSchema(item: RuntimeSchemaItem): item is RuntimeSchemaRecord {
+  return item.type === SchemaDefKind.RECORD && "fields" in item;
+}
+
+function isUnionSchema(item: RuntimeSchemaItem): item is RuntimeSchemaUnion {
+  return item.type === SchemaDefKind.UNION && "variants" in item;
+}
+
+function collectVersionChain(input: SchemaDefinition): VersionedSchemaEntry[] {
+  const chain: VersionedSchemaEntry[] = [];
+  let current: SchemaDefinition = input;
+
+  while (current.type === "versioned") {
+    chain.unshift({ version: current.version, schema: current.models as RuntimeSchema });
+    current = current.previous;
+  }
+  chain.unshift({ version: 1, schema: current.models as RuntimeSchema });
+
+  return chain;
+}
+
+function formatVariantName(variantName: string): string {
+  return variantName.charAt(0).toUpperCase() + variantName.slice(1);
+}
+
+function versionedTypeName(exportName: string, version: number): string {
+  return `${exportName}_v${version}`;
+}
+
+/**
+ * Generate the index.ts barrel export from a versioned schema.
+ *
+ * Exports:
+ * - `models.js` (star export — model constants and DocumentModel)
+ * - `types.js` (star export — latest-version type aliases)
+ * - `versions.js` (star export — SupportedVersions, LatestVersion, MinSupportedVersion)
+ * - `versionedDocRef.js` (star export — VersionedDocRef types and factory)
+ * - Per supported version: explicit named type exports from `types_vN.js`
+ *   (not star exports, to avoid polluting autocomplete for read-only consumers)
+ */
+export function generateIndexFromSchema(
+  schema: SchemaDefinition,
+  minSupportedVersion?: number,
+): string {
+  const chain = collectVersionChain(schema);
+
+  if (chain.length === 0) {
+    throw new Error("Schema version chain is empty");
+  }
+
+  const latestVersion = chain[chain.length - 1]!.version;
+  const minVersion = minSupportedVersion ?? latestVersion;
+
+  let output = GENERATED_FILE_HEADER;
+
+  // Star exports for core modules
+  output += `export * from "./models.js";\n`;
+  output += `export * from "./types.js";\n`;
+  output += `export * from "./versions.js";\n`;
+  output += `export * from "./versionedDocRef.js";\n`;
+
+  // Per-version explicit named type exports
+  for (const { version, schema: versionSchema } of chain) {
+    if (version < minVersion) continue;
+
+    const typeNames: string[] = [];
+
+    for (const [exportName, item] of Object.entries(versionSchema)) {
+      if (isRecordSchema(item)) {
+        typeNames.push(versionedTypeName(exportName, version));
+      } else if (isUnionSchema(item)) {
+        typeNames.push(versionedTypeName(exportName, version));
+
+        // Union variant types
+        for (const variantName of Object.keys(item.variants)) {
+          const formattedVariant = formatVariantName(variantName);
+          typeNames.push(`${versionedTypeName(exportName, version)}${formattedVariant}`);
+        }
+      }
+    }
+
+    if (typeNames.length > 0) {
+      output += `export type { ${typeNames.sort().join(", ")} } from "./types_v${version}.js";\n`;
+    }
+  }
+
+  return output;
+}

--- a/packages/document-schema/type-gen/src/utils/schema/generateInternalFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateInternalFromSchema.ts
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaDefinition } from "@palantir/pack.schema";
+import { GENERATED_FILE_HEADER } from "../generatedFileHeader.js";
+
+const TypeKind = {
+  ARRAY: "array",
+  BOOLEAN: "boolean",
+  DOC_REF: "docRef",
+  DOUBLE: "double",
+  MEDIA_REF: "mediaRef",
+  OBJECT_REF: "objectRef",
+  OPTIONAL: "optional",
+  REF: "ref",
+  STRING: "string",
+  USER_REF: "userRef",
+} as const;
+
+const SchemaDefKind = {
+  RECORD: "record",
+  UNION: "union",
+} as const;
+
+interface SchemaField {
+  readonly type: string;
+  readonly items?: SchemaField;
+  readonly item?: SchemaField;
+  readonly refType?: "record" | "union";
+  readonly name?: string;
+}
+
+interface RuntimeSchemaRecord {
+  readonly type: typeof SchemaDefKind.RECORD;
+  readonly name: string;
+  readonly fields: Readonly<Record<string, SchemaField>>;
+}
+
+interface RuntimeSchemaUnion {
+  readonly type: typeof SchemaDefKind.UNION;
+  readonly name?: string;
+  readonly variants: Readonly<Record<string, SchemaField>>;
+  readonly discriminant: string;
+}
+
+type RuntimeSchemaItem = RuntimeSchemaRecord | RuntimeSchemaUnion;
+type RuntimeSchema = Record<string, RuntimeSchemaItem>;
+
+function findRecordExportName(recordName: string, schema: RuntimeSchema): string | null {
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (item.type === SchemaDefKind.RECORD && "fields" in item && item.name === recordName) {
+      return exportName;
+    }
+  }
+  return null;
+}
+
+interface VersionedSchemaEntry {
+  version: number;
+  schema: RuntimeSchema;
+}
+
+export interface InternalTypesOutput {
+  /** _internal/types.ts content */
+  internalTypes: string;
+  /** _internal/migrations.ts content */
+  migrations: string;
+  /** _internal/schema.ts content */
+  internalSchema: string;
+}
+
+function isRecordSchema(item: RuntimeSchemaItem): item is RuntimeSchemaRecord {
+  return item.type === SchemaDefKind.RECORD && "fields" in item;
+}
+
+/**
+ * Walk the schema version chain to collect all versions.
+ * Returns versions in ascending order (v1, v2, v3, ...).
+ */
+function collectVersionChain(input: SchemaDefinition): VersionedSchemaEntry[] {
+  const chain: VersionedSchemaEntry[] = [];
+  let current: SchemaDefinition = input;
+
+  while (current.type === "versioned") {
+    chain.unshift({ version: current.version, schema: current.models as RuntimeSchema });
+    current = current.previous;
+  }
+  chain.unshift({ version: 1, schema: current.models as RuntimeSchema });
+
+  return chain;
+}
+
+/**
+ * Convert a schema field type to TypeScript string for internal types.
+ */
+function convertTypeToTypeScript(fieldType: SchemaField): string {
+  switch (fieldType.type) {
+    case TypeKind.ARRAY:
+      if (fieldType.items) {
+        return `readonly ${convertTypeToTypeScript(fieldType.items)}[]`;
+      }
+      return "readonly unknown[]";
+    case TypeKind.BOOLEAN:
+      return "boolean";
+    case TypeKind.DOC_REF:
+      return "string";
+    case TypeKind.DOUBLE:
+      return "number";
+    case TypeKind.MEDIA_REF:
+      return "string";
+    case TypeKind.OBJECT_REF:
+      return "string";
+    case TypeKind.OPTIONAL:
+      if (fieldType.item) {
+        return convertTypeToTypeScript(fieldType.item);
+      }
+      return "unknown";
+    case TypeKind.REF:
+      return "unknown";
+    case TypeKind.STRING:
+      return "string";
+    case TypeKind.USER_REF:
+      return "string";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Convert a schema field type to a FieldTypeDescriptor source string.
+ */
+function convertTypeToFieldTypeDescriptor(fieldType: SchemaField): string {
+  switch (fieldType.type) {
+    case TypeKind.ARRAY:
+      if (fieldType.items) {
+        return `{ kind: "array", element: ${convertTypeToFieldTypeDescriptor(fieldType.items)} }`;
+      }
+      return `{ kind: "array", element: { kind: "primitive" } }`;
+    case TypeKind.OPTIONAL:
+      if (fieldType.item) {
+        return `{ kind: "optional", inner: ${convertTypeToFieldTypeDescriptor(fieldType.item)} }`;
+      }
+      return `{ kind: "optional", inner: { kind: "primitive" } }`;
+    case TypeKind.REF:
+      return `{ kind: "modelRef", model: "${fieldType.name ?? "unknown"}" }`;
+    default:
+      return `{ kind: "primitive" }`;
+  }
+}
+
+/**
+ * Convert a schema field type to a Zod schema string.
+ */
+function convertTypeToZodSchema(fieldType: SchemaField): string {
+  switch (fieldType.type) {
+    case TypeKind.ARRAY:
+      if (fieldType.items) {
+        return `z.array(${convertTypeToZodSchema(fieldType.items)})`;
+      }
+      return "z.array(z.unknown())";
+    case TypeKind.BOOLEAN:
+      return "z.boolean()";
+    case TypeKind.DOC_REF:
+    case TypeKind.MEDIA_REF:
+    case TypeKind.OBJECT_REF:
+    case TypeKind.STRING:
+    case TypeKind.USER_REF:
+      return "z.string()";
+    case TypeKind.DOUBLE:
+      return "z.number()";
+    case TypeKind.OPTIONAL:
+      if (fieldType.item) {
+        return `${convertTypeToZodSchema(fieldType.item)}.optional()`;
+      }
+      return "z.unknown().optional()";
+    case TypeKind.REF:
+      return "z.unknown()";
+    default:
+      return "z.unknown()";
+  }
+}
+
+/** Collected info about all fields for a model across all versions. */
+interface AllFieldInfo {
+  fieldType: SchemaField;
+  /** Versions where this field exists. */
+  presentInVersions: Set<number>;
+  /** Whether field is always optional. */
+  alwaysOptional: boolean;
+}
+
+/**
+ * Represents a migration step for a model between version transitions.
+ */
+interface MigrationStep {
+  name: string;
+  addedInVersion: number;
+  fields: Map<string, { derivedFrom: string[] }>;
+  removedFields: string[];
+}
+
+/**
+ * Generate _internal/types.ts, _internal/migrations.ts, and _internal/schema.ts
+ * from a versioned schema chain.
+ */
+export function generateInternalFromSchema(
+  schema: SchemaDefinition,
+): InternalTypesOutput {
+  const chain = collectVersionChain(schema);
+
+  if (chain.length === 0) {
+    throw new Error("Schema version chain is empty");
+  }
+
+  // Collect all record model names (export names) across all versions
+  const allRecordModels = new Map<string, {
+    allFields: Map<string, AllFieldInfo>;
+    steps: MigrationStep[];
+  }>();
+
+  // Initialize models from all versions
+  for (const { version, schema: versionSchema } of chain) {
+    for (const [exportName, item] of Object.entries(versionSchema)) {
+      if (!isRecordSchema(item)) continue;
+
+      if (!allRecordModels.has(exportName)) {
+        allRecordModels.set(exportName, {
+          allFields: new Map(),
+          steps: [],
+        });
+      }
+
+      const model = allRecordModels.get(exportName)!;
+
+      for (const [fieldName, fieldType] of Object.entries(item.fields)) {
+        const existing = model.allFields.get(fieldName);
+        if (existing == null) {
+          model.allFields.set(fieldName, {
+            fieldType,
+            presentInVersions: new Set([version]),
+            alwaysOptional: fieldType.type === TypeKind.OPTIONAL,
+          });
+        } else {
+          existing.presentInVersions.add(version);
+          if (fieldType.type !== TypeKind.OPTIONAL) {
+            existing.alwaysOptional = false;
+          }
+        }
+      }
+    }
+  }
+
+  // Compute migration steps from version diffs
+  for (let i = 1; i < chain.length; i++) {
+    const prevVersion = chain[i - 1]!;
+    const currVersion = chain[i]!;
+
+    for (const [exportName, currItem] of Object.entries(currVersion.schema)) {
+      if (!isRecordSchema(currItem)) continue;
+
+      const prevItem = prevVersion.schema[exportName];
+      if (prevItem == null || !isRecordSchema(prevItem)) continue;
+
+      const model = allRecordModels.get(exportName);
+      if (model == null) continue;
+
+      const prevFields = new Set(Object.keys(prevItem.fields));
+      const currFields = new Set(Object.keys(currItem.fields));
+
+      // Fields added in this version
+      const addedFields = new Map<string, { derivedFrom: string[] }>();
+      for (const fieldName of currFields) {
+        if (!prevFields.has(fieldName)) {
+          addedFields.set(fieldName, { derivedFrom: [] });
+        }
+      }
+
+      // Fields removed in this version
+      const removedFields: string[] = [];
+      for (const fieldName of prevFields) {
+        if (!currFields.has(fieldName)) {
+          removedFields.push(fieldName);
+        }
+      }
+
+      if (addedFields.size > 0 || removedFields.length > 0) {
+        model.steps.push({
+          name: `v${currVersion.version}`,
+          addedInVersion: currVersion.version,
+          fields: addedFields,
+          removedFields,
+        });
+      }
+    }
+  }
+
+  // Mark fields that are not present in ALL versions as optional in internal type
+  const totalVersions = chain.length;
+  for (const model of allRecordModels.values()) {
+    for (const [, fieldInfo] of model.allFields) {
+      if (fieldInfo.presentInVersions.size < totalVersions) {
+        fieldInfo.alwaysOptional = true;
+      }
+    }
+  }
+
+  // --- Generate _internal/types.ts ---
+  let internalTypes = GENERATED_FILE_HEADER;
+  internalTypes += "\n";
+
+  for (const [exportName, model] of sortedEntries(allRecordModels)) {
+    internalTypes +=
+      `/** Internal representation containing all fields across all schema versions. */\n`;
+    internalTypes += `export interface ${exportName}__Internal {\n`;
+
+    for (const [fieldName, fieldInfo] of sortedEntries(model.allFields)) {
+      const tsType = convertTypeToTypeScript(fieldInfo.fieldType);
+      const optional = fieldInfo.alwaysOptional ? "?" : "";
+      internalTypes += `  readonly ${fieldName}${optional}: ${tsType};\n`;
+    }
+
+    internalTypes += "}\n\n";
+  }
+
+  // --- Generate _internal/migrations.ts ---
+  let migrations = GENERATED_FILE_HEADER;
+  migrations +=
+    `import type { MigrationRegistry, UnionMigrationRegistry } from "@palantir/pack.document-schema.model-types";\n\n`;
+
+  for (const [exportName, model] of sortedEntries(allRecordModels)) {
+    migrations += `export const ${exportName}Migrations: MigrationRegistry<"${exportName}"> = {\n`;
+    migrations += `  modelName: "${exportName}",\n`;
+
+    // allFields
+    migrations += `  allFields: {\n`;
+    for (const [fieldName, fieldInfo] of sortedEntries(model.allFields)) {
+      const typeDescriptor = convertTypeToFieldTypeDescriptor(fieldInfo.fieldType);
+      migrations += `    ${fieldName}: { type: ${typeDescriptor} },\n`;
+    }
+    migrations += `  },\n`;
+
+    // steps
+    migrations += `  steps: [\n`;
+    for (const step of model.steps) {
+      migrations += `    {\n`;
+      migrations += `      name: "${step.name}",\n`;
+      migrations += `      addedInVersion: ${step.addedInVersion},\n`;
+      migrations += `      fields: {\n`;
+      for (const [fieldName, fieldMeta] of step.fields) {
+        migrations += `        ${fieldName}: {\n`;
+        migrations += `          derivedFrom: [${
+          fieldMeta.derivedFrom.map(d => `"${d}"`).join(", ")
+        }],\n`;
+        migrations += `          forward: () => undefined,\n`;
+        migrations += `        },\n`;
+      }
+      migrations += `      },\n`;
+      if (step.removedFields.length > 0) {
+        migrations += `      removedFields: [${
+          step.removedFields.map(f => `"${f}"`).join(", ")
+        }],\n`;
+      }
+      migrations += `    },\n`;
+    }
+    migrations += `  ],\n`;
+
+    migrations += `};\n\n`;
+  }
+
+  // Generate UnionMigrationRegistry entries for union models
+  const latestSchema = chain[chain.length - 1]!.schema;
+  for (const [exportName, item] of Object.entries(latestSchema)) {
+    if (item.type !== SchemaDefKind.UNION || !("variants" in item)) continue;
+    const union = item as RuntimeSchemaUnion;
+
+    migrations +=
+      `export const ${exportName}Migrations: UnionMigrationRegistry<"${exportName}"> = {\n`;
+    migrations += `  modelName: "${exportName}",\n`;
+    migrations += `  discriminant: "${union.discriminant}",\n`;
+    migrations += `  variants: {\n`;
+    for (const [variantKey, variantField] of Object.entries(union.variants)) {
+      if (
+        variantField.type === "ref" && variantField.refType === "record"
+        && variantField.name != null
+      ) {
+        const variantExportName = findRecordExportName(variantField.name, latestSchema);
+        if (variantExportName != null) {
+          migrations += `    "${variantKey}": "${variantExportName}",\n`;
+        }
+      }
+    }
+    migrations += `  },\n`;
+    migrations += `};\n\n`;
+  }
+
+  // --- Generate _internal/schema.ts ---
+  let internalSchema = GENERATED_FILE_HEADER;
+  internalSchema += `import { z } from "zod";\n\n`;
+
+  for (const [exportName, model] of sortedEntries(allRecordModels)) {
+    internalSchema += `export const ${exportName}InternalSchema = z.object({\n`;
+
+    for (const [fieldName, fieldInfo] of sortedEntries(model.allFields)) {
+      const zodType = convertTypeToZodSchema(fieldInfo.fieldType);
+      // In internal schema, all fields that might be absent are optional
+      if (fieldInfo.alwaysOptional) {
+        // If the type already ends with .optional(), don't double-wrap
+        if (zodType.endsWith(".optional()")) {
+          internalSchema += `  ${fieldName}: ${zodType},\n`;
+        } else {
+          internalSchema += `  ${fieldName}: ${zodType}.optional(),\n`;
+        }
+      } else {
+        internalSchema += `  ${fieldName}: ${zodType},\n`;
+      }
+    }
+
+    internalSchema += `}).passthrough();\n\n`;
+  }
+
+  return { internalTypes, migrations, internalSchema };
+}
+
+/**
+ * Helper to iterate sorted entries of a Map.
+ */
+function sortedEntries<V>(map: Map<string, V>): [string, V][] {
+  return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+}

--- a/packages/document-schema/type-gen/src/utils/schema/generateModelMetadataFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateModelMetadataFromSchema.ts
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaDefinition } from "@palantir/pack.schema";
+import { formatVariantName } from "../formatVariantName.js";
+import { GENERATED_FILE_HEADER } from "../generatedFileHeader.js";
+
+const SchemaDefKind = {
+  RECORD: "record",
+  UNION: "union",
+} as const;
+
+interface SchemaField {
+  readonly type: string;
+  readonly items?: SchemaField;
+  readonly item?: SchemaField;
+  readonly refType?: "record" | "union";
+  readonly name?: string;
+}
+
+interface RuntimeSchemaRecord {
+  readonly type: typeof SchemaDefKind.RECORD;
+  readonly name: string;
+  readonly docs?: string;
+  readonly fields: Readonly<Record<string, SchemaField>>;
+}
+
+interface RuntimeSchemaUnion {
+  readonly type: typeof SchemaDefKind.UNION;
+  readonly name?: string;
+  readonly variants: Readonly<Record<string, SchemaField>>;
+  readonly discriminant: string;
+}
+
+type RuntimeSchemaItem = RuntimeSchemaRecord | RuntimeSchemaUnion;
+type RuntimeSchema = Record<string, RuntimeSchemaItem>;
+
+interface VersionedSchemaEntry {
+  version: number;
+  schema: RuntimeSchema;
+}
+
+export interface ModelMetadataOutput {
+  /** models.ts content — DocumentModel with version metadata and migration references */
+  modelsFile: string;
+  /** Schema manifest JSON for backend consumption */
+  schemaManifest: SchemaManifestCompact;
+}
+
+export interface SchemaManifestCompact {
+  latestVersion: number;
+  minSupportedVersion: number;
+  models: Record<string, {
+    versions: Record<string, { fields: string[] }>;
+  }>;
+}
+
+function isRecordSchema(item: RuntimeSchemaItem): item is RuntimeSchemaRecord {
+  return item.type === SchemaDefKind.RECORD && "fields" in item;
+}
+
+function isUnionSchema(item: RuntimeSchemaItem): item is RuntimeSchemaUnion {
+  return item.type === SchemaDefKind.UNION && "variants" in item;
+}
+
+function collectVersionChain(input: SchemaDefinition): VersionedSchemaEntry[] {
+  const chain: VersionedSchemaEntry[] = [];
+  let current: SchemaDefinition = input;
+
+  while (current.type === "versioned") {
+    chain.unshift({ version: current.version, schema: current.models as RuntimeSchema });
+    current = current.previous;
+  }
+  chain.unshift({ version: 1, schema: current.models as RuntimeSchema });
+
+  return chain;
+}
+
+/**
+ * Detect which external ref field types (docRef, mediaRef, objectRef, userRef)
+ * are present on a record for its model metadata.
+ */
+function extractExternalRefFieldTypes(
+  record: RuntimeSchemaRecord,
+): Array<[string, string]> {
+  const refs: Array<[string, string]> = [];
+  for (const [fieldName, fieldType] of Object.entries(record.fields)) {
+    const innerType = fieldType.type === "optional" && fieldType.item ? fieldType.item : fieldType;
+    switch (innerType.type) {
+      case "docRef":
+        refs.push([fieldName, "docRef"]);
+        break;
+      case "mediaRef":
+        refs.push([fieldName, "mediaRef"]);
+        break;
+      case "objectRef":
+        refs.push([fieldName, "objectRef"]);
+        break;
+      case "userRef":
+        refs.push([fieldName, "userRef"]);
+        break;
+    }
+  }
+  return refs;
+}
+
+/**
+ * Generate models.ts and schema manifest from a versioned schema chain.
+ *
+ * @param schema - The schema (ReturnedSchema for v1, or VersionedSchema for multi-version)
+ * @param minSupportedVersion - Minimum version this client supports (defaults to latest)
+ * @param options - Configuration for import paths
+ * @returns Object containing generated models.ts content and schema manifest JSON
+ */
+export function generateModelMetadataFromSchema(
+  schema: SchemaDefinition,
+  minSupportedVersion?: number,
+  options?: {
+    typeImportPath?: string;
+    schemaImportPath?: string;
+    migrationsImportPath?: string;
+  },
+): ModelMetadataOutput {
+  const chain = collectVersionChain(schema);
+
+  if (chain.length === 0) {
+    throw new Error("Schema version chain is empty");
+  }
+
+  const latestVersion = chain[chain.length - 1]!.version;
+  const minVersion = minSupportedVersion ?? latestVersion;
+  const latestSchema = chain[chain.length - 1]!.schema;
+
+  const typeImportPath = options?.typeImportPath ?? "./types.js";
+  const schemaImportPath = options?.schemaImportPath ?? "./schema.js";
+  const migrationsImportPath = options?.migrationsImportPath ?? "./_internal/migrations.js";
+
+  // --- Generate models.ts ---
+  let output = GENERATED_FILE_HEADER;
+
+  // Collect model names for imports
+  const recordNames: string[] = [];
+  const unionNames: string[] = [];
+  const variantNames: string[] = [];
+
+  for (const [exportName, item] of Object.entries(latestSchema)) {
+    if (isRecordSchema(item)) {
+      recordNames.push(exportName);
+    } else if (isUnionSchema(item)) {
+      unionNames.push(exportName);
+      for (const variantName of Object.keys(item.variants)) {
+        variantNames.push(`${exportName}${formatVariantName(variantName)}`);
+      }
+    }
+  }
+
+  const allModelNames = [...recordNames, ...unionNames, ...variantNames].sort();
+
+  // Imports
+  const modelTypesImports: string[] = ["DocumentSchema"];
+  if (recordNames.length > 0) modelTypesImports.push("RecordModel");
+  if (unionNames.length > 0) modelTypesImports.push("UnionModel");
+
+  output += `import type { ${
+    modelTypesImports.sort().join(", ")
+  } } from "@palantir/pack.document-schema.model-types";\n`;
+  output += `import { Metadata } from "@palantir/pack.document-schema.model-types";\n`;
+
+  if (allModelNames.length > 0) {
+    output += `import type { ${allModelNames.join(", ")} } from "${typeImportPath}";\n`;
+  }
+
+  // Schema imports
+  const schemaNames = allModelNames.map(n => `${n}Schema`);
+  if (schemaNames.length > 0) {
+    output += `import { ${schemaNames.join(", ")} } from "${schemaImportPath}";\n`;
+  }
+
+  // Migration imports (only if there are migrations)
+  const migrationNames = [...recordNames, ...unionNames].map(n => `${n}Migrations`);
+  if (chain.length > 1 && migrationNames.length > 0) {
+    output += `import { ${migrationNames.join(", ")} } from "${migrationsImportPath}";\n`;
+  }
+
+  output += "\n";
+
+  // Generate model constants
+  for (const [exportName, item] of Object.entries(latestSchema)) {
+    if (isRecordSchema(item)) {
+      const externalRefs = extractExternalRefFieldTypes(item);
+      const metadataFields: string[] = [];
+
+      if (externalRefs.length > 0) {
+        const entries = externalRefs.map(([field, type]) => `      ${field}: "${type}",`).join(
+          "\n",
+        );
+        metadataFields.push(`    externalRefFieldTypes: {\n${entries}\n    },`);
+      }
+      metadataFields.push(`    name: "${exportName}",`);
+
+      output +=
+        `export interface ${exportName}Model extends RecordModel<${exportName}, typeof ${exportName}Schema> {}\n`;
+      output += `export const ${exportName}Model: ${exportName}Model = {\n`;
+      output += `  __type: {} as ${exportName},\n`;
+      output += `  zodSchema: ${exportName}Schema,\n`;
+      output += `  [Metadata]: {\n${metadataFields.join("\n")}\n  },\n`;
+      output += `};\n\n`;
+    } else if (isUnionSchema(item)) {
+      const metadataFields: string[] = [];
+      metadataFields.push(`    discriminant: "${item.discriminant}",`);
+      metadataFields.push(`    name: "${exportName}",`);
+
+      output +=
+        `export interface ${exportName}Model extends UnionModel<${exportName}, typeof ${exportName}Schema> {}\n`;
+      output += `export const ${exportName}Model: ${exportName}Model = {\n`;
+      output += `  __type: {} as ${exportName},\n`;
+      output += `  zodSchema: ${exportName}Schema,\n`;
+      output += `  [Metadata]: {\n${metadataFields.join("\n")}\n  },\n`;
+      output += `};\n\n`;
+
+      // Generate variant models
+      for (const variantName of Object.keys(item.variants)) {
+        const formattedVariant = formatVariantName(variantName);
+        const variantTypeName = `${exportName}${formattedVariant}`;
+        const variantMetadata: string[] = [];
+        variantMetadata.push(`    discriminant: "${item.discriminant}",`);
+        variantMetadata.push(`    name: "${variantTypeName}",`);
+
+        output +=
+          `export interface ${variantTypeName}Model extends UnionModel<${variantTypeName}, typeof ${variantTypeName}Schema> {}\n`;
+        output += `export const ${variantTypeName}Model: ${variantTypeName}Model = {\n`;
+        output += `  __type: {} as ${variantTypeName},\n`;
+        output += `  zodSchema: ${variantTypeName}Schema,\n`;
+        output += `  [Metadata]: {\n${variantMetadata.join("\n")}\n  },\n`;
+        output += `};\n\n`;
+      }
+    }
+  }
+
+  // Generate DocumentModel
+  const modelEntries: string[] = [];
+  for (const [exportName, item] of Object.entries(latestSchema)) {
+    if (isRecordSchema(item)) {
+      modelEntries.push(`  ${exportName}: ${exportName}Model`);
+    } else if (isUnionSchema(item)) {
+      modelEntries.push(`  ${exportName}: ${exportName}Model`);
+      for (const variantName of Object.keys(item.variants)) {
+        const formattedVariant = formatVariantName(variantName);
+        const variantTypeName = `${exportName}${formattedVariant}`;
+        modelEntries.push(`  ${variantTypeName}: ${variantTypeName}Model`);
+      }
+    }
+  }
+
+  // Build migrations map (includes both record and union entries)
+  let migrationsBlock: string;
+  const allMigrationNames = [...recordNames, ...unionNames];
+  if (chain.length > 1 && allMigrationNames.length > 0) {
+    const migrationEntries = allMigrationNames.map(n => `      ${n}: ${n}Migrations,`).join("\n");
+    migrationsBlock = `    migrations: {\n${migrationEntries}\n    },\n`;
+  } else {
+    migrationsBlock = "";
+  }
+
+  output += `export const DocumentModel = {\n`;
+  output += `${modelEntries.join(",\n")},\n`;
+  output += `  [Metadata]: {\n`;
+  output += `    version: ${latestVersion},\n`;
+  if (minVersion !== latestVersion) {
+    output += `    minSupportedVersion: ${minVersion},\n`;
+  }
+  output += migrationsBlock;
+  output += `  },\n`;
+  output += `} as const satisfies DocumentSchema;\n\n`;
+  output += `export type DocumentModel = typeof DocumentModel;\n`;
+
+  // --- Generate schema manifest ---
+  const models: SchemaManifestCompact["models"] = {};
+
+  for (const [exportName, item] of Object.entries(latestSchema)) {
+    if (!isRecordSchema(item)) continue;
+
+    const versions: Record<string, { fields: string[] }> = {};
+
+    for (const { version, schema: versionSchema } of chain) {
+      const versionItem = versionSchema[exportName];
+      if (versionItem != null && isRecordSchema(versionItem)) {
+        versions[String(version)] = {
+          fields: Object.keys(versionItem.fields).sort(),
+        };
+      }
+    }
+
+    models[exportName] = { versions };
+  }
+
+  const schemaManifest: SchemaManifestCompact = {
+    latestVersion,
+    minSupportedVersion: minVersion,
+    models,
+  };
+
+  return { modelsFile: output, schemaManifest };
+}

--- a/packages/document-schema/type-gen/src/utils/schema/generateSchemaManifest.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateSchemaManifest.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaDefinition } from "@palantir/pack.schema";
+
+const SchemaDefKind = { RECORD: "record", UNION: "union" } as const;
+
+interface RuntimeSchemaRecord {
+  readonly type: typeof SchemaDefKind.RECORD;
+  readonly name: string;
+  readonly fields: Readonly<Record<string, unknown>>;
+}
+
+type RuntimeSchemaItem = RuntimeSchemaRecord | { readonly type: string };
+type RuntimeSchema = Record<string, RuntimeSchemaItem>;
+
+interface VersionedSchemaEntry {
+  version: number;
+  schema: RuntimeSchema;
+}
+
+function collectVersionChain(input: SchemaDefinition): VersionedSchemaEntry[] {
+  const chain: VersionedSchemaEntry[] = [];
+  let current: SchemaDefinition = input;
+
+  while (current.type === "versioned") {
+    chain.unshift({ version: current.version, schema: current.models as RuntimeSchema });
+    current = current.previous;
+  }
+  chain.unshift({ version: 1, schema: current.models as RuntimeSchema });
+
+  return chain;
+}
+
+export interface SchemaManifest {
+  latestVersion: number;
+  versions: Record<number, VersionManifest>;
+}
+
+export interface VersionManifest {
+  version: number;
+  models: Record<string, ModelManifest>;
+}
+
+export interface ModelManifest {
+  fields: string[];
+}
+
+/**
+ * Generate a schema manifest for the backend. Contains per-version field lists
+ * for each model, enabling the backend to validate writes and compute compatibility.
+ */
+export function generateSchemaManifest(
+  schema: SchemaDefinition,
+): SchemaManifest {
+  const chain = collectVersionChain(schema);
+
+  if (chain.length === 0) {
+    throw new Error("Schema version chain is empty");
+  }
+
+  const versions: Record<number, VersionManifest> = {};
+
+  for (const { version, schema: versionSchema } of chain) {
+    const models: Record<string, ModelManifest> = {};
+
+    for (const [exportName, item] of Object.entries(versionSchema)) {
+      if (item.type === SchemaDefKind.RECORD && "fields" in item) {
+        const record = item as RuntimeSchemaRecord;
+        models[exportName] = {
+          fields: Object.keys(record.fields).sort(),
+        };
+      }
+    }
+
+    versions[version] = { version, models };
+  }
+
+  return {
+    latestVersion: chain[chain.length - 1]!.version,
+    versions,
+  };
+}

--- a/packages/document-schema/type-gen/src/utils/schema/generateScopeFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateScopeFromSchema.ts
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaDefinition } from "@palantir/pack.schema";
+import { GENERATED_FILE_HEADER } from "../generatedFileHeader.js";
+
+const SchemaDefKind = {
+  RECORD: "record",
+  UNION: "union",
+} as const;
+
+interface SchemaField {
+  readonly type: string;
+  readonly items?: SchemaField;
+  readonly item?: SchemaField;
+  readonly refType?: "record" | "union";
+  readonly name?: string;
+}
+
+interface RuntimeSchemaRecord {
+  readonly type: typeof SchemaDefKind.RECORD;
+  readonly name: string;
+  readonly fields: Readonly<Record<string, SchemaField>>;
+}
+
+interface RuntimeSchemaUnion {
+  readonly type: typeof SchemaDefKind.UNION;
+  readonly name?: string;
+  readonly variants: Readonly<Record<string, SchemaField>>;
+  readonly discriminant: string;
+}
+
+type RuntimeSchemaItem = RuntimeSchemaRecord | RuntimeSchemaUnion;
+type RuntimeSchema = Record<string, RuntimeSchemaItem>;
+
+interface VersionedSchemaEntry {
+  version: number;
+  schema: RuntimeSchema;
+}
+
+function isRecordSchema(item: RuntimeSchemaItem): item is RuntimeSchemaRecord {
+  return item.type === SchemaDefKind.RECORD && "fields" in item;
+}
+
+function isUnionSchema(item: RuntimeSchemaItem): item is RuntimeSchemaUnion {
+  return item.type === SchemaDefKind.UNION && "variants" in item;
+}
+
+function collectVersionChain(input: SchemaDefinition): VersionedSchemaEntry[] {
+  const chain: VersionedSchemaEntry[] = [];
+  let current: SchemaDefinition = input;
+
+  while (current.type === "versioned") {
+    chain.unshift({ version: current.version, schema: current.models as RuntimeSchema });
+    current = current.previous;
+  }
+  chain.unshift({ version: 1, schema: current.models as RuntimeSchema });
+
+  return chain;
+}
+
+/**
+ * Compare field sets between two record definitions.
+ * Returns true if any field was added, removed, or the set differs.
+ */
+function recordFieldsChanged(
+  prev: RuntimeSchemaRecord | undefined,
+  curr: RuntimeSchemaRecord,
+): boolean {
+  if (prev == null) return true; // new model — treat as changed
+  const prevFields = Object.keys(prev.fields).sort().join(",");
+  const currFields = Object.keys(curr.fields).sort().join(",");
+  return prevFields !== currFields;
+}
+
+/**
+ * For a union, check if any of its record variants reference changed models.
+ */
+function unionReferencesChangedModel(
+  union: RuntimeSchemaUnion,
+  changedRecordNames: Set<string>,
+  schema: RuntimeSchema,
+): boolean {
+  for (const variantField of Object.values(union.variants)) {
+    if (variantField.type === "ref" && variantField.refType === "record") {
+      const exportName = findRecordExportName(variantField.name!, schema);
+      if (exportName != null && changedRecordNames.has(exportName)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function findRecordExportName(recordName: string, schema: RuntimeSchema): string | null {
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (isRecordSchema(item) && item.name === recordName) {
+      return exportName;
+    }
+  }
+  return null;
+}
+
+/**
+ * Determine which record models changed between two adjacent schema versions.
+ * Returns the set of export names (e.g. "ShapeBox") that changed.
+ */
+function getChangedRecordModels(
+  prev: RuntimeSchema | undefined,
+  curr: RuntimeSchema,
+): Set<string> {
+  const changed = new Set<string>();
+
+  for (const [exportName, item] of Object.entries(curr)) {
+    if (!isRecordSchema(item)) continue;
+    const prevItem = prev?.[exportName];
+    const prevRecord = prevItem != null && isRecordSchema(prevItem) ? prevItem : undefined;
+    if (recordFieldsChanged(prevRecord, item)) {
+      changed.add(exportName);
+    }
+  }
+
+  return changed;
+}
+
+function versionedTypeName(exportName: string, version: number): string {
+  return `${exportName}_v${version}`;
+}
+
+function versionedWriteTypeName(exportName: string, version: number): string {
+  return `${exportName}Update_v${version}`;
+}
+
+/**
+ * Generate versionedDocRef.ts from a versioned schema chain.
+ *
+ * Produces:
+ * - Per-version VersionedDocRef_vN interfaces extending DocumentRef<DocumentModel>
+ * - Union type VersionedDocRef = VersionedDocRef_v1 | VersionedDocRef_v2
+ * - asVersioned identity function
+ * - matchVersion exhaustive version handler
+ */
+export function generateScopeFromSchema(
+  schema: SchemaDefinition,
+  minSupportedVersion?: number,
+): string {
+  const chain = collectVersionChain(schema);
+
+  if (chain.length === 0) {
+    throw new Error("Schema version chain is empty");
+  }
+
+  const latestVersion = chain[chain.length - 1]!.version;
+  const minVersion = minSupportedVersion ?? latestVersion;
+
+  // Filter to supported versions
+  const supportedVersions = chain.filter(v => v.version >= minVersion);
+
+  // Collect all model names from the latest schema
+  const latestSchema = chain[chain.length - 1]!.schema;
+  const allRecordNames: string[] = [];
+  const allUnionNames: string[] = [];
+  const allModelNames: string[] = [];
+  for (const [exportName, item] of Object.entries(latestSchema)) {
+    if (isRecordSchema(item)) {
+      allRecordNames.push(exportName);
+      allModelNames.push(exportName);
+    } else if (isUnionSchema(item)) {
+      allUnionNames.push(exportName);
+      allModelNames.push(exportName);
+    }
+  }
+
+  // For each supported version, determine which models changed relative to previous
+  const changedModelsPerVersion = new Map<number, Set<string>>();
+  for (let i = 0; i < supportedVersions.length; i++) {
+    const curr = supportedVersions[i]!;
+    const chainIdx = chain.findIndex(v => v.version === curr.version);
+    const prev = chainIdx > 0 ? chain[chainIdx - 1] : undefined;
+    const changedRecords = getChangedRecordModels(prev?.schema, curr.schema);
+
+    // Also include unions that reference changed records
+    const changedModels = new Set(changedRecords);
+    for (const [exportName, item] of Object.entries(curr.schema)) {
+      if (isUnionSchema(item) && unionReferencesChangedModel(item, changedRecords, curr.schema)) {
+        changedModels.add(exportName);
+      }
+    }
+
+    changedModelsPerVersion.set(curr.version, changedModels);
+  }
+
+  // Build output
+  let output = GENERATED_FILE_HEADER;
+
+  // Import model-types
+  output +=
+    `import type { DocumentRef, Model, ModelData, RecordId, RecordRef } from "@palantir/pack.document-schema.model-types";\n`;
+
+  // Import model types from models.ts
+  const modelImports = allModelNames.map(n => `${n}Model`);
+  const typeImportsFromModels = ["DocumentModel", ...modelImports];
+  output += `import type { ${typeImportsFromModels.join(", ")} } from "./models.js";\n`;
+
+  // Import per-version types
+  for (const { version } of supportedVersions) {
+    const versionSchema = chain.find(v => v.version === version)!.schema;
+    const readTypeImports: string[] = [];
+    const writeTypeImports: string[] = [];
+
+    for (const [exportName, item] of Object.entries(versionSchema)) {
+      if (isRecordSchema(item)) {
+        readTypeImports.push(versionedTypeName(exportName, version));
+        writeTypeImports.push(versionedWriteTypeName(exportName, version));
+      } else if (isUnionSchema(item)) {
+        readTypeImports.push(versionedTypeName(exportName, version));
+      }
+    }
+
+    if (readTypeImports.length > 0) {
+      output += `import type { ${
+        readTypeImports.sort().join(", ")
+      } } from "./types_v${version}.js";\n`;
+    }
+    if (writeTypeImports.length > 0) {
+      output += `import type { ${
+        writeTypeImports.sort().join(", ")
+      } } from "./writeTypes_v${version}.js";\n`;
+    }
+  }
+
+  output += "\n";
+
+  // Generate per-version VersionedDocRef interfaces extending DocumentRef
+  for (const { version, schema: versionSchema } of supportedVersions) {
+    const changed = changedModelsPerVersion.get(version) ?? new Set<string>();
+
+    output += `export interface VersionedDocRef_v${version} extends DocumentRef<DocumentModel> {\n`;
+    output += `  readonly version: ${version};\n`;
+
+    // updateRecord overloads
+    for (const [exportName, item] of Object.entries(versionSchema)) {
+      if (!changed.has(exportName)) continue;
+
+      if (isRecordSchema(item)) {
+        const writeType = versionedWriteTypeName(exportName, version);
+        output +=
+          `  updateRecord(ref: RecordRef<typeof ${exportName}Model>, data: ${writeType}): Promise<void>;\n`;
+      } else if (isUnionSchema(item)) {
+        const readType = versionedTypeName(exportName, version);
+        output +=
+          `  updateRecord(ref: RecordRef<typeof ${exportName}Model>, data: Partial<${readType}>): Promise<void>;\n`;
+      }
+    }
+    output +=
+      `  updateRecord<M extends Model>(ref: RecordRef<M>, data: Partial<ModelData<M>>): Promise<void>;\n`;
+
+    // setCollectionRecord overloads
+    for (const [exportName, item] of Object.entries(versionSchema)) {
+      if (!changed.has(exportName)) continue;
+
+      const readType = versionedTypeName(exportName, version);
+      output +=
+        `  setCollectionRecord(model: typeof ${exportName}Model, id: RecordId, data: ${readType}): Promise<void>;\n`;
+    }
+    output +=
+      `  setCollectionRecord<M extends Model>(model: M, id: RecordId, data: ModelData<M>): Promise<void>;\n`;
+
+    output += `}\n\n`;
+  }
+
+  // Union type
+  if (supportedVersions.length === 1) {
+    output += `export type VersionedDocRef = VersionedDocRef_v${supportedVersions[0]!.version};\n`;
+  } else {
+    const unionMembers = supportedVersions.map(v => `VersionedDocRef_v${v.version}`).join(" | ");
+    output += `export type VersionedDocRef = ${unionMembers};\n`;
+  }
+
+  // asVersioned — identity cast to unlock version-specific write overloads
+  output += `\n/** Narrow a DocumentRef to a version-discriminated type for type-safe writes. */\n`;
+  output += `export function asVersioned(docRef: DocumentRef<DocumentModel>): VersionedDocRef {\n`;
+  output += `  return docRef as VersionedDocRef;\n`;
+  output += `}\n`;
+
+  // matchVersion — exhaustive version handler
+  const handlerProps = supportedVersions.map(
+    v => `  readonly ${v.version}: (doc: VersionedDocRef_v${v.version}) => R;`,
+  ).join("\n");
+
+  output += `\n/**\n`;
+  output += ` * Exhaustive version handler. TypeScript enforces that every supported\n`;
+  output += ` * version has a corresponding handler — adding a new schema version\n`;
+  output += ` * produces a compile error at every call site until handled.\n`;
+  output += ` */\n`;
+  output += `export function matchVersion<R>(\n`;
+  output += `  doc: VersionedDocRef,\n`;
+  output += `  handlers: {\n`;
+  output += handlerProps + "\n";
+  output += `  },\n`;
+  output += `): R {\n`;
+  output +=
+    `  return (handlers as Record<number, (doc: VersionedDocRef) => R>)[doc.version]!(doc);\n`;
+  output += `}\n`;
+
+  return output;
+}

--- a/packages/document-schema/type-gen/src/utils/schema/generateVersionedTypesFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateVersionedTypesFromSchema.ts
@@ -1,0 +1,456 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaDefinition } from "@palantir/pack.schema";
+import { formatVariantName } from "../formatVariantName.js";
+import { GENERATED_FILE_HEADER } from "../generatedFileHeader.js";
+
+const TypeKind = {
+  ANY: "any",
+  ARRAY: "array",
+  BOOLEAN: "boolean",
+  DOC_REF: "docRef",
+  DOUBLE: "double",
+  MEDIA_REF: "mediaRef",
+  OBJECT_REF: "objectRef",
+  OPTIONAL: "optional",
+  REF: "ref",
+  STRING: "string",
+  USER_REF: "userRef",
+} as const;
+
+const SchemaDefKind = {
+  RECORD: "record",
+  UNION: "union",
+} as const;
+
+// Runtime types mirroring the schema structure
+interface SchemaField {
+  readonly type: string;
+  readonly items?: SchemaField;
+  readonly item?: SchemaField;
+  readonly refType?: "record" | "union";
+  readonly name?: string;
+}
+
+interface RuntimeSchemaRecord {
+  readonly type: typeof SchemaDefKind.RECORD;
+  readonly name: string;
+  readonly docs?: string;
+  readonly fields: Readonly<Record<string, SchemaField>>;
+}
+
+interface RuntimeSchemaUnion {
+  readonly type: typeof SchemaDefKind.UNION;
+  readonly name?: string;
+  readonly variants: Readonly<Record<string, SchemaField>>;
+  readonly discriminant: string;
+}
+
+type RuntimeSchemaItem = RuntimeSchemaRecord | RuntimeSchemaUnion;
+type RuntimeSchema = Record<string, RuntimeSchemaItem>;
+
+interface VersionedSchemaEntry {
+  version: number;
+  schema: RuntimeSchema;
+}
+
+export interface VersionedTypesOutput {
+  /** types_vN.ts files keyed by version number */
+  readTypes: Map<number, string>;
+  /** writeTypes_vN.ts files keyed by version number */
+  writeTypes: Map<number, string>;
+  /** types.ts re-export of latest version types under unversioned names */
+  typesReExport: string;
+}
+
+function isRecordSchema(item: RuntimeSchemaItem): item is RuntimeSchemaRecord {
+  return item.type === SchemaDefKind.RECORD && "fields" in item;
+}
+
+function isUnionSchema(item: RuntimeSchemaItem): item is RuntimeSchemaUnion {
+  return item.type === SchemaDefKind.UNION && "variants" in item;
+}
+
+/**
+ * Walk the schema version chain to collect all versions.
+ * Returns versions in ascending order (v1, v2, v3, ...).
+ */
+function collectVersionChain(input: SchemaDefinition): VersionedSchemaEntry[] {
+  const chain: VersionedSchemaEntry[] = [];
+  let current: SchemaDefinition = input;
+
+  while (current.type === "versioned") {
+    chain.unshift({ version: current.version, schema: current.models as RuntimeSchema });
+    current = current.previous;
+  }
+  chain.unshift({ version: 1, schema: current.models as RuntimeSchema });
+
+  return chain;
+}
+
+function detectUsedRefTypes(schema: RuntimeSchema): Set<string> {
+  const refTypes = new Set<string>();
+
+  function scanField(field: SchemaField): void {
+    switch (field.type) {
+      case TypeKind.ARRAY:
+        if (field.items) scanField(field.items);
+        break;
+      case TypeKind.DOC_REF:
+        refTypes.add("DocumentRef");
+        break;
+      case TypeKind.MEDIA_REF:
+        refTypes.add("MediaRef");
+        break;
+      case TypeKind.OBJECT_REF:
+        refTypes.add("ObjectRef");
+        break;
+      case TypeKind.OPTIONAL:
+        if (field.item) scanField(field.item);
+        break;
+      case TypeKind.USER_REF:
+        refTypes.add("UserRef");
+        break;
+    }
+  }
+
+  for (const item of Object.values(schema)) {
+    if (isRecordSchema(item)) {
+      for (const f of Object.values(item.fields)) {
+        scanField(f);
+      }
+    } else if (isUnionSchema(item)) {
+      for (const v of Object.values(item.variants)) {
+        scanField(v);
+      }
+    }
+  }
+
+  return refTypes;
+}
+
+function findRecordExportName(recordName: string, schema: RuntimeSchema): string | null {
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (isRecordSchema(item) && item.name === recordName) {
+      return exportName;
+    }
+  }
+  return null;
+}
+
+function collectReferencedTypes(
+  fieldType: SchemaField,
+  schema: RuntimeSchema,
+  version: number,
+  out: Set<string>,
+): void {
+  switch (fieldType.type) {
+    case TypeKind.ARRAY:
+      if (fieldType.items) collectReferencedTypes(fieldType.items, schema, version, out);
+      break;
+    case TypeKind.OPTIONAL:
+      if (fieldType.item) collectReferencedTypes(fieldType.item, schema, version, out);
+      break;
+    case TypeKind.REF: {
+      let name: string;
+      if (fieldType.refType === "record") {
+        name = findRecordExportName(fieldType.name!, schema) || fieldType.name || "unknown";
+      } else {
+        name = fieldType.name || "unknown";
+      }
+      out.add(versionedTypeName(name, version));
+      break;
+    }
+  }
+}
+
+function convertTypeToTypeScript(
+  fieldType: SchemaField,
+  schema?: RuntimeSchema,
+  version?: number,
+): string {
+  switch (fieldType.type) {
+    case TypeKind.ANY:
+      return "any";
+    case TypeKind.ARRAY:
+      if (fieldType.items) {
+        return `readonly ${convertTypeToTypeScript(fieldType.items, schema, version)}[]`;
+      }
+      return "readonly unknown[]";
+    case TypeKind.BOOLEAN:
+      return "boolean";
+    case TypeKind.DOC_REF:
+      return "DocumentRef";
+    case TypeKind.DOUBLE:
+      return "number";
+    case TypeKind.MEDIA_REF:
+      return "MediaRef";
+    case TypeKind.OBJECT_REF:
+      return "ObjectRef";
+    case TypeKind.OPTIONAL:
+      if (fieldType.item) {
+        return convertTypeToTypeScript(fieldType.item, schema, version);
+      }
+      return "unknown";
+    case TypeKind.REF: {
+      let name: string;
+      if (fieldType.refType === "record" && schema) {
+        name = findRecordExportName(fieldType.name!, schema) || fieldType.name || "unknown";
+      } else {
+        name = fieldType.name || "unknown";
+      }
+      return version != null ? versionedTypeName(name, version) : name;
+    }
+    case TypeKind.STRING:
+      return "string";
+    case TypeKind.USER_REF:
+      return "UserRef";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Generate versioned read type name: RecordName_vN
+ */
+function versionedTypeName(exportName: string, version: number): string {
+  return `${exportName}_v${version}`;
+}
+
+/**
+ * Generate versioned write type name: RecordNameUpdate_vN
+ */
+function versionedWriteTypeName(exportName: string, version: number): string {
+  return `${exportName}Update_v${version}`;
+}
+
+/**
+ * Generate read types for a specific schema version.
+ */
+function generateReadTypesForVersion(
+  version: number,
+  schema: RuntimeSchema,
+): string {
+  const usedRefTypes = detectUsedRefTypes(schema);
+
+  let output = GENERATED_FILE_HEADER;
+
+  if (usedRefTypes.size > 0) {
+    const refTypesList = Array.from(usedRefTypes).sort().join(", ");
+    output +=
+      `import type { ${refTypesList} } from "@palantir/pack.document-schema.model-types";\n`;
+  }
+
+  output += "\n";
+
+  // Generate record interfaces
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (!isRecordSchema(item)) continue;
+
+    const typeName = versionedTypeName(exportName, version);
+
+    if (item.docs) {
+      output += `/**\n * ${item.docs}\n */\n`;
+    }
+
+    output += `export interface ${typeName} {\n`;
+
+    for (const [fieldName, fieldType] of Object.entries(item.fields)) {
+      const tsType = convertTypeToTypeScript(fieldType, schema, version);
+      const optional = fieldType.type === TypeKind.OPTIONAL ? "?" : "";
+      output += `  readonly ${fieldName}${optional}: ${tsType};\n`;
+    }
+
+    output += "}\n\n";
+  }
+
+  // Generate union types
+  const unionEntries = Object.entries(schema).filter(
+    ([_, item]) => isUnionSchema(item),
+  );
+
+  for (const [exportName, item] of unionEntries) {
+    if (!isUnionSchema(item)) continue;
+
+    const typeName = versionedTypeName(exportName, version);
+    const discriminantField = item.discriminant;
+    const variantInterfaces: Array<{ name: string; discriminatorValue: string }> = [];
+
+    for (const [variantName, variantType] of Object.entries(item.variants)) {
+      const interfaceName = `${typeName}${formatVariantName(variantName)}`;
+      variantInterfaces.push({ name: interfaceName, discriminatorValue: variantName });
+
+      if (variantType.type === TypeKind.REF && variantType.refType === "record") {
+        const recordExport = findRecordExportName(variantType.name!, schema);
+        const recordTypeName = recordExport
+          ? versionedTypeName(recordExport, version)
+          : variantType.name!;
+        output += `export interface ${interfaceName} extends ${recordTypeName} {\n`;
+        output += `  readonly ${discriminantField}: "${variantName}";\n`;
+        output += "}\n\n";
+      } else {
+        const tsType = convertTypeToTypeScript(variantType, schema, version);
+        output += `export interface ${interfaceName} {\n`;
+        output += `  readonly ${discriminantField}: "${variantName}";\n`;
+        output += `  readonly value: ${tsType};\n`;
+        output += "}\n\n";
+      }
+    }
+
+    output += `export type ${typeName} = ${variantInterfaces.map(v => v.name).join(" | ")};\n\n`;
+
+    for (const variant of variantInterfaces) {
+      output +=
+        `export function is${variant.name}(value: ${typeName}): value is ${variant.name} {\n`;
+      output += `  return value.${discriminantField} === "${variant.discriminatorValue}";\n`;
+      output += "}\n\n";
+    }
+  }
+
+  return output;
+}
+
+/**
+ * Generate write types for a specific schema version.
+ * All fields are optional in write types.
+ */
+function generateWriteTypesForVersion(
+  version: number,
+  schema: RuntimeSchema,
+): string {
+  const usedRefTypes = detectUsedRefTypes(schema);
+
+  // Collect referenced schema-local types (refs to other records/unions)
+  const referencedLocalTypes = new Set<string>();
+  for (const item of Object.values(schema)) {
+    if (!isRecordSchema(item)) continue;
+    for (const fieldType of Object.values(item.fields)) {
+      collectReferencedTypes(fieldType, schema, version, referencedLocalTypes);
+    }
+  }
+
+  let output = GENERATED_FILE_HEADER;
+
+  if (usedRefTypes.size > 0) {
+    const refTypesList = Array.from(usedRefTypes).sort().join(", ");
+    output +=
+      `import type { ${refTypesList} } from "@palantir/pack.document-schema.model-types";\n`;
+  }
+
+  if (referencedLocalTypes.size > 0) {
+    const localTypesList = Array.from(referencedLocalTypes).sort().join(", ");
+    output += `import type { ${localTypesList} } from "./types_v${version}.js";\n`;
+  }
+
+  output += "\n";
+
+  // Generate record write types
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (!isRecordSchema(item)) continue;
+
+    const typeName = versionedWriteTypeName(exportName, version);
+
+    output += `export type ${typeName} = {\n`;
+
+    for (const [fieldName, fieldType] of Object.entries(item.fields)) {
+      // All fields are optional in write types
+      const tsType = convertTypeToTypeScript(fieldType, schema, version);
+      output += `  readonly ${fieldName}?: ${tsType};\n`;
+    }
+
+    output += "};\n\n";
+  }
+
+  return output;
+}
+
+/**
+ * Generate the types.ts re-export file that maps unversioned names to the latest version.
+ */
+function generateTypesReExport(
+  latestVersion: number,
+  schema: RuntimeSchema,
+): string {
+  let output = GENERATED_FILE_HEADER;
+
+  const reExports: string[] = [];
+
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (isRecordSchema(item)) {
+      const versioned = versionedTypeName(exportName, latestVersion);
+      reExports.push(
+        `export type { ${versioned} as ${exportName} } from "./types_v${latestVersion}.js";`,
+      );
+    } else if (isUnionSchema(item)) {
+      const versioned = versionedTypeName(exportName, latestVersion);
+      reExports.push(
+        `export type { ${versioned} as ${exportName} } from "./types_v${latestVersion}.js";`,
+      );
+
+      // Also re-export union variant types
+      for (const variantName of Object.keys(item.variants)) {
+        const formattedVariant = formatVariantName(variantName);
+        const versionedVariant = `${
+          versionedTypeName(exportName, latestVersion)
+        }${formattedVariant}`;
+        const unversionedVariant = `${exportName}${formattedVariant}`;
+        reExports.push(
+          `export type { ${versionedVariant} as ${unversionedVariant} } from "./types_v${latestVersion}.js";`,
+        );
+      }
+    }
+  }
+
+  output += reExports.join("\n") + "\n";
+
+  return output;
+}
+
+/**
+ * Generate per-version public types and write types from a schema with version chain.
+ *
+ * @param schema - The schema (ReturnedSchema for v1, or VersionedSchema for multi-version)
+ * @param minSupportedVersion - Minimum version to generate types for (defaults to latest)
+ * @returns Object containing generated code for each output file
+ */
+export function generateVersionedTypesFromSchema(
+  schema: SchemaDefinition,
+  minSupportedVersion?: number,
+): VersionedTypesOutput {
+  const chain = collectVersionChain(schema);
+
+  if (chain.length === 0) {
+    throw new Error("Schema version chain is empty");
+  }
+
+  const latestVersion = chain[chain.length - 1]!.version;
+  const minVersion = minSupportedVersion ?? latestVersion;
+
+  const readTypes = new Map<number, string>();
+  const writeTypes = new Map<number, string>();
+
+  for (const { version, schema: versionSchema } of chain) {
+    if (version < minVersion) continue;
+
+    readTypes.set(version, generateReadTypesForVersion(version, versionSchema));
+    writeTypes.set(version, generateWriteTypesForVersion(version, versionSchema));
+  }
+
+  const typesReExport = generateTypesReExport(latestVersion, chain[chain.length - 1]!.schema);
+
+  return { readTypes, writeTypes, typesReExport };
+}

--- a/packages/document-schema/type-gen/src/utils/schema/generateVersionedZodFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateVersionedZodFromSchema.ts
@@ -1,0 +1,391 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaDefinition } from "@palantir/pack.schema";
+import { formatVariantName } from "../formatVariantName.js";
+import { GENERATED_FILE_HEADER } from "../generatedFileHeader.js";
+
+const TypeKind = {
+  ANY: "any",
+  ARRAY: "array",
+  BOOLEAN: "boolean",
+  DOC_REF: "docRef",
+  DOUBLE: "double",
+  MEDIA_REF: "mediaRef",
+  OBJECT_REF: "objectRef",
+  OPTIONAL: "optional",
+  REF: "ref",
+  STRING: "string",
+  USER_REF: "userRef",
+} as const;
+
+const SchemaDefKind = {
+  RECORD: "record",
+  UNION: "union",
+} as const;
+
+interface SchemaField {
+  readonly type: string;
+  readonly items?: SchemaField;
+  readonly item?: SchemaField;
+  readonly refType?: "record" | "union";
+  readonly name?: string;
+}
+
+interface RuntimeSchemaRecord {
+  readonly type: typeof SchemaDefKind.RECORD;
+  readonly name: string;
+  readonly docs?: string;
+  readonly fields: Readonly<Record<string, SchemaField>>;
+}
+
+interface RuntimeSchemaUnion {
+  readonly type: typeof SchemaDefKind.UNION;
+  readonly name?: string;
+  readonly variants: Readonly<Record<string, SchemaField>>;
+  readonly discriminant: string;
+}
+
+type RuntimeSchemaItem = RuntimeSchemaRecord | RuntimeSchemaUnion;
+type RuntimeSchema = Record<string, RuntimeSchemaItem>;
+
+interface VersionedSchemaEntry {
+  version: number;
+  schema: RuntimeSchema;
+}
+
+export interface VersionedZodOutput {
+  /** schema_vN.ts files keyed by version number */
+  zodSchemas: Map<number, string>;
+  /** _internal/schema.ts — internal schema with all fields across all versions */
+  internalSchema: string;
+  /** schema.ts re-export of latest version schemas under unversioned names */
+  schemaReExport: string;
+}
+
+function isRecordSchema(item: RuntimeSchemaItem): item is RuntimeSchemaRecord {
+  return item.type === SchemaDefKind.RECORD && "fields" in item;
+}
+
+function isUnionSchema(item: RuntimeSchemaItem): item is RuntimeSchemaUnion {
+  return item.type === SchemaDefKind.UNION && "variants" in item;
+}
+
+function collectVersionChain(input: SchemaDefinition): VersionedSchemaEntry[] {
+  const chain: VersionedSchemaEntry[] = [];
+  let current: SchemaDefinition = input;
+
+  while (current.type === "versioned") {
+    chain.unshift({ version: current.version, schema: current.models as RuntimeSchema });
+    current = current.previous;
+  }
+  chain.unshift({ version: 1, schema: current.models as RuntimeSchema });
+
+  return chain;
+}
+
+function findRecordExportName(recordName: string, schema: RuntimeSchema): string | null {
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (isRecordSchema(item) && item.name === recordName) {
+      return exportName;
+    }
+  }
+  return null;
+}
+
+function convertFieldTypeToZodSchema(
+  fieldType: SchemaField,
+  schema?: RuntimeSchema,
+  version?: number,
+): string {
+  switch (fieldType.type) {
+    case TypeKind.ANY:
+      return "z.unknown()";
+    case TypeKind.ARRAY:
+      if (fieldType.items) {
+        return `z.array(${convertFieldTypeToZodSchema(fieldType.items, schema, version)})`;
+      }
+      return "z.array(z.unknown())";
+    case TypeKind.BOOLEAN:
+      return "z.boolean()";
+    case TypeKind.DOC_REF:
+      return "z.string()";
+    case TypeKind.DOUBLE:
+      return "z.number()";
+    case TypeKind.MEDIA_REF:
+      return "z.string()";
+    case TypeKind.OBJECT_REF:
+      return "z.string()";
+    case TypeKind.OPTIONAL:
+      if (fieldType.item) {
+        return convertFieldTypeToZodSchema(fieldType.item, schema, version);
+      }
+      return "z.unknown()";
+    case TypeKind.REF: {
+      let refSchemaName: string;
+      if (fieldType.refType === "record" && schema) {
+        const exportName = findRecordExportName(fieldType.name!, schema);
+        const name = exportName || fieldType.name || "unknown";
+        refSchemaName = version != null ? versionedSchemaName(name, version) : `${name}Schema`;
+      } else {
+        const name = fieldType.name || "unknown";
+        refSchemaName = version != null ? versionedSchemaName(name, version) : `${name}Schema`;
+      }
+      return `z.lazy(() => ${refSchemaName}) as any`;
+    }
+    case TypeKind.STRING:
+      return "z.string()";
+    case TypeKind.USER_REF:
+      return "z.string()";
+    default:
+      return "z.unknown()";
+  }
+}
+
+function versionedSchemaName(exportName: string, version: number): string {
+  return `${exportName}Schema_v${version}`;
+}
+
+/**
+ * Generate Zod schemas for a specific schema version.
+ */
+function generateZodSchemasForVersion(
+  version: number,
+  schema: RuntimeSchema,
+  typeImportPath: string,
+): string {
+  let output = GENERATED_FILE_HEADER;
+
+  // Collect type names for import
+  const typeNames: string[] = [];
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (isRecordSchema(item)) {
+      typeNames.push(`${exportName}_v${version}`);
+    } else if (isUnionSchema(item)) {
+      typeNames.push(`${exportName}_v${version}`);
+      for (const variantName of Object.keys(item.variants)) {
+        typeNames.push(`${exportName}_v${version}${formatVariantName(variantName)}`);
+      }
+    }
+  }
+
+  output += "import type { ZodType } from \"zod\";\n";
+  output += "import { z } from \"zod\";\n";
+
+  if (typeNames.length > 0) {
+    output += `import type { ${typeNames.sort().join(", ")} } from "${typeImportPath}";\n`;
+  }
+
+  output += "\n";
+
+  // Generate record schemas first (unions may depend on them)
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (!isRecordSchema(item)) continue;
+
+    const schemaName = versionedSchemaName(exportName, version);
+    const typeName = `${exportName}_v${version}`;
+    const fieldLines: string[] = [];
+
+    for (const [fieldName, fieldType] of Object.entries(item.fields)) {
+      if (fieldType.type === TypeKind.OPTIONAL) {
+        const innerZod = fieldType.item
+          ? convertFieldTypeToZodSchema(fieldType.item, schema, version)
+          : "z.unknown()";
+        fieldLines.push(`  ${fieldName}: ${innerZod}.optional()`);
+      } else {
+        const zodType = convertFieldTypeToZodSchema(fieldType, schema, version);
+        fieldLines.push(`  ${fieldName}: ${zodType}`);
+      }
+    }
+
+    output += `export const ${schemaName} = z.object({\n${
+      fieldLines.join(",\n")
+    }\n}) satisfies ZodType<${typeName}>;\n\n`;
+  }
+
+  // Generate union schemas
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (!isUnionSchema(item)) continue;
+
+    const discriminantField = item.discriminant;
+    const variantSchemaNames: string[] = [];
+
+    for (const [variantName, variantType] of Object.entries(item.variants)) {
+      const formattedVariant = formatVariantName(variantName);
+      const variantSchemaName = `${versionedSchemaName(exportName, version)}${formattedVariant}`;
+      const variantTypeName = `${exportName}_v${version}${formattedVariant}`;
+      variantSchemaNames.push(variantSchemaName);
+
+      if (variantType.type === TypeKind.REF && variantType.refType === "record") {
+        const recordExport = findRecordExportName(variantType.name!, schema);
+        const recordSchemaName = recordExport
+          ? versionedSchemaName(recordExport, version)
+          : `${variantType.name!}Schema`;
+        output += `export const ${variantSchemaName} = ${recordSchemaName}.extend({\n`;
+        output += `  ${discriminantField}: z.literal("${variantName}")\n`;
+        output += `}) satisfies ZodType<${variantTypeName}>;\n\n`;
+      } else {
+        const zodType = convertFieldTypeToZodSchema(variantType, schema, version);
+        output += `export const ${variantSchemaName} = z.object({\n`;
+        output += `  ${discriminantField}: z.literal("${variantName}"),\n`;
+        output += `  value: ${zodType}\n`;
+        output += `}) satisfies ZodType<${variantTypeName}>;\n\n`;
+      }
+    }
+
+    const schemaName = versionedSchemaName(exportName, version);
+    const typeName = `${exportName}_v${version}`;
+    output += `export const ${schemaName} = z.discriminatedUnion("${discriminantField}", [\n  ${
+      variantSchemaNames.join(",\n  ")
+    }\n]) satisfies ZodType<${typeName}>;\n\n`;
+  }
+
+  return output;
+}
+
+/**
+ * Generate the internal Zod schema with all fields across all versions, all optional, with `.passthrough()`.
+ */
+function generateInternalZodSchema(
+  chain: VersionedSchemaEntry[],
+): string {
+  let output = GENERATED_FILE_HEADER;
+  output += "import { z } from \"zod\";\n\n";
+
+  // Collect all fields across all versions for each record
+  const allRecordFields = new Map<string, Map<string, { zodType: string; isOptional: boolean }>>();
+
+  for (const { schema } of chain) {
+    for (const [exportName, item] of Object.entries(schema)) {
+      if (!isRecordSchema(item)) continue;
+
+      if (!allRecordFields.has(exportName)) {
+        allRecordFields.set(exportName, new Map());
+      }
+
+      const fieldMap = allRecordFields.get(exportName)!;
+
+      for (const [fieldName, fieldType] of Object.entries(item.fields)) {
+        if (fieldMap.has(fieldName)) continue;
+
+        if (fieldType.type === TypeKind.OPTIONAL) {
+          const innerZod = fieldType.item
+            ? convertFieldTypeToZodSchema(fieldType.item, schema)
+            : "z.unknown()";
+          fieldMap.set(fieldName, { zodType: innerZod, isOptional: true });
+        } else {
+          const zodType = convertFieldTypeToZodSchema(fieldType, schema);
+          fieldMap.set(fieldName, { zodType, isOptional: false });
+        }
+      }
+    }
+  }
+
+  // Emit internal schemas — all fields optional
+  for (const [exportName, fieldMap] of allRecordFields) {
+    const fieldLines: string[] = [];
+
+    for (const [fieldName, { zodType }] of fieldMap) {
+      fieldLines.push(`  ${fieldName}: ${zodType}.optional()`);
+    }
+
+    output += `export const ${exportName}InternalSchema = z.object({\n${
+      fieldLines.join(",\n")
+    }\n}).passthrough();\n\n`;
+  }
+
+  return output;
+}
+
+/**
+ * Generate the schema.ts re-export file mapping unversioned names to latest version.
+ */
+function generateSchemaReExport(
+  latestVersion: number,
+  schema: RuntimeSchema,
+): string {
+  let output = GENERATED_FILE_HEADER;
+
+  const reExports: string[] = [];
+
+  for (const [exportName, item] of Object.entries(schema)) {
+    if (isRecordSchema(item)) {
+      const versioned = versionedSchemaName(exportName, latestVersion);
+      reExports.push(
+        `export { ${versioned} as ${exportName}Schema } from "./schema_v${latestVersion}.js";`,
+      );
+    } else if (isUnionSchema(item)) {
+      const versioned = versionedSchemaName(exportName, latestVersion);
+      reExports.push(
+        `export { ${versioned} as ${exportName}Schema } from "./schema_v${latestVersion}.js";`,
+      );
+
+      // Also re-export union variant schemas
+      for (const variantName of Object.keys(item.variants)) {
+        const formattedVariant = formatVariantName(variantName);
+        const versionedVariant = `${
+          versionedSchemaName(exportName, latestVersion)
+        }${formattedVariant}`;
+        const unversionedVariant = `${exportName}${formattedVariant}Schema`;
+        reExports.push(
+          `export { ${versionedVariant} as ${unversionedVariant} } from "./schema_v${latestVersion}.js";`,
+        );
+      }
+    }
+  }
+
+  output += reExports.join("\n") + "\n";
+
+  return output;
+}
+
+/**
+ * Generate per-version Zod schemas from a schema with version chain.
+ *
+ * @param schema - The schema (ReturnedSchema for v1, or VersionedSchema for multi-version)
+ * @param minSupportedVersion - Minimum version to generate schemas for (defaults to latest)
+ * @param typeImportPathBase - Import path base for per-version type definitions
+ * @returns Object containing generated Zod schema code for each output file
+ */
+export function generateVersionedZodFromSchema(
+  schema: SchemaDefinition,
+  minSupportedVersion?: number,
+  typeImportPathBase?: string,
+): VersionedZodOutput {
+  const chain = collectVersionChain(schema);
+
+  if (chain.length === 0) {
+    throw new Error("Schema version chain is empty");
+  }
+
+  const latestVersion = chain[chain.length - 1]!.version;
+  const minVersion = minSupportedVersion ?? latestVersion;
+  const importBase = typeImportPathBase ?? "./types";
+
+  const zodSchemas = new Map<number, string>();
+
+  for (const { version, schema: versionSchema } of chain) {
+    if (version < minVersion) continue;
+
+    const typeImportPath = `${importBase}_v${version}.js`;
+    zodSchemas.set(version, generateZodSchemasForVersion(version, versionSchema, typeImportPath));
+  }
+
+  const internalSchema = generateInternalZodSchema(chain);
+  const schemaReExport = generateSchemaReExport(latestVersion, chain[chain.length - 1]!.schema);
+
+  return { zodSchemas, internalSchema, schemaReExport };
+}

--- a/packages/document-schema/type-gen/src/utils/schema/generateVersionsFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateVersionsFromSchema.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SchemaDefinition } from "@palantir/pack.schema";
+import { GENERATED_FILE_HEADER } from "../generatedFileHeader.js";
+
+interface VersionInfo {
+  version: number;
+}
+
+function collectVersionChain(input: SchemaDefinition): VersionInfo[] {
+  const chain: VersionInfo[] = [];
+  let current: SchemaDefinition = input;
+
+  while (current.type === "versioned") {
+    chain.unshift({ version: current.version });
+    current = current.previous;
+  }
+  // current is now InitialSchema (version 1)
+  chain.unshift({ version: 1 });
+
+  return chain;
+}
+
+/**
+ * Generate versions.ts from a versioned schema chain.
+ *
+ * Output:
+ * ```
+ * export type SupportedVersions = 1 | 2;
+ * export type LatestVersion = 2;
+ * export type MinSupportedVersion = 1;
+ * ```
+ */
+export function generateVersionsFromSchema(
+  schema: SchemaDefinition,
+  minSupportedVersion?: number,
+): string {
+  const chain = collectVersionChain(schema);
+
+  if (chain.length === 0) {
+    throw new Error("Schema version chain is empty");
+  }
+
+  const latestVersion = chain[chain.length - 1]!.version;
+  const minVersion = minSupportedVersion ?? latestVersion;
+
+  const supportedVersions: number[] = [];
+  for (const { version } of chain) {
+    if (version >= minVersion) {
+      supportedVersions.push(version);
+    }
+  }
+
+  let output = GENERATED_FILE_HEADER;
+  output += `export type SupportedVersions = ${supportedVersions.join(" | ")};\n`;
+  output += `export type LatestVersion = ${latestVersion};\n`;
+  output += `export type MinSupportedVersion = ${minVersion};\n`;
+
+  return output;
+}

--- a/packages/document-schema/type-gen/src/utils/schema/validateSchemaModule.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/validateSchemaModule.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/document-schema/type-gen/src/utils/schema/validateSchemaModule.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/validateSchemaModule.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/schema/src/__tests__/defineSchemaUpdate.test.ts
+++ b/packages/schema/src/__tests__/defineSchemaUpdate.test.ts
@@ -17,29 +17,32 @@
 import { describe, expect, it } from "vitest";
 import type { SchemaBuilder } from "../defineMigration.js";
 import { defineRecord } from "../defineRecord.js";
-import { defineSchemaUpdate, isVersionedSchema, nextSchema } from "../defineSchemaUpdate.js";
+import { defineSchema, defineSchemaUpdate, nextSchema } from "../defineSchemaUpdate.js";
 import { defineUnion } from "../defineUnion.js";
 import * as P from "../primitives.js";
 import { assertExactKeys, assertHasKeys, assertTypeEquals } from "./testTypeUtils.js";
 
 describe("defineSchemaUpdate", () => {
   it("should create a schema update and apply it via nextSchema", () => {
-    const schemaV1 = {
+    const schemaV1 = defineSchema({
       Person: defineRecord("Person", {
         docs: "A person",
         fields: {
           name: P.String,
         },
       }),
-    };
+    });
 
-    const addAge = defineSchemaUpdate("addAge", (schema: SchemaBuilder<typeof schemaV1>) => ({
-      PersonV2: schema.Person.addField("age", P.Double).build(),
-    }));
+    const addAge = defineSchemaUpdate(
+      "addAge",
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
+        PersonV2: schema.Person.addField("age", P.Double).build(),
+      }),
+    );
 
     const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addAge).build();
 
-    expect(schemaV2.models.Person).toBe(schemaV1.Person);
+    expect(schemaV2.models.Person).toBe(schemaV1.models.Person);
     expect(schemaV2.models.PersonV2.fields.name).toEqual({ type: "string" });
     expect(schemaV2.models.PersonV2.fields.age).toEqual({ type: "double" });
     expect(schemaV2.version).toBe(2);
@@ -51,7 +54,7 @@ describe("defineSchemaUpdate", () => {
   });
 
   it("should compose multiple schema updates in one version", () => {
-    const schemaV1 = {
+    const schemaV1 = defineSchema({
       ShapeBox: defineRecord("ShapeBox", {
         docs: "A box shape",
         fields: {
@@ -68,11 +71,11 @@ describe("defineSchemaUpdate", () => {
           color: P.Optional(P.String),
         },
       }),
-    };
+    });
 
     const addFillColor = defineSchemaUpdate(
       "addFillColor",
-      (schema: SchemaBuilder<typeof schemaV1>) => ({
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
         ShapeBox: schema.ShapeBox
           .addField("fillColor", P.Optional(P.String))
           .build(),
@@ -84,7 +87,7 @@ describe("defineSchemaUpdate", () => {
 
     const addOpacity = defineSchemaUpdate(
       "addOpacity",
-      (schema: SchemaBuilder<typeof schemaV1>) => ({
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
         ShapeBox: schema.ShapeBox
           .addField("opacity", P.Optional(P.Double))
           .build(),
@@ -120,18 +123,18 @@ describe("defineSchemaUpdate", () => {
   });
 
   it("should track version advancement across multiple nextSchema calls", () => {
-    const schemaV1 = {
+    const schemaV1 = defineSchema({
       Item: defineRecord("Item", {
         docs: "An item",
         fields: {
           name: P.String,
         },
       }),
-    };
+    });
 
     const addDescription = defineSchemaUpdate(
       "addDescription",
-      (schema: SchemaBuilder<typeof schemaV1>) => ({
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
         Item: schema.Item.addField("description", P.Optional(P.String)).build(),
       }),
     );
@@ -162,38 +165,37 @@ describe("defineSchemaUpdate", () => {
   });
 
   it("should build a walkable version chain via .previous", () => {
-    const schemaV1 = {
+    const schemaV1 = defineSchema({
       Node: defineRecord("Node", {
         docs: "A node",
         fields: {
           label: P.String,
         },
       }),
-    };
+    });
 
     const addWeight = defineSchemaUpdate(
       "addWeight",
-      (schema: SchemaBuilder<typeof schemaV1>) => ({
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
         Node: schema.Node.addField("weight", P.Double).build(),
       }),
     );
 
     const schemaV2 = nextSchema(schemaV1).addSchemaUpdate(addWeight).build();
 
-    // v2 points back to a synthetic v1 wrapper
-    expect(schemaV2.previous?.models).toBe(schemaV1);
-    expect(schemaV2.previous?.version).toBe(1);
-    expect(schemaV2.previous?.previous).toBeUndefined();
+    // v2 points back to the v1 InitialSchema
+    expect(schemaV2.previous).toBe(schemaV1);
+    expect(schemaV2.previous.type).toBe("initial");
     expect(schemaV2.version).toBe(2);
   });
 
   it("should build a multi-step version chain", () => {
-    const schemaV1 = {
+    const schemaV1 = defineSchema({
       Item: defineRecord("Item", {
         docs: "An item",
         fields: { name: P.String },
       }),
-    };
+    });
 
     const schemaV2 = nextSchema(schemaV1)
       .addSchemaUpdate(
@@ -217,20 +219,23 @@ describe("defineSchemaUpdate", () => {
       )
       .build();
 
-    // Walk the chain: v3 -> v2 -> v1 -> undefined
+    // Walk the chain: v3 (versioned) -> v2 (versioned) -> v1 (initial)
     expect(schemaV3.version).toBe(3);
     expect(schemaV3.previous).toBe(schemaV2);
-    expect(schemaV3.previous?.previous?.models).toBe(schemaV1);
-    expect(schemaV3.previous?.previous?.previous).toBeUndefined();
+    expect(schemaV3.previous.type).toBe("versioned");
+    if (schemaV3.previous.type === "versioned") {
+      expect(schemaV3.previous.previous).toBe(schemaV1);
+      expect(schemaV3.previous.previous.type).toBe("initial");
+    }
   });
 
-  it("should correctly identify versioned schemas with isVersionedSchema", () => {
-    const schemaV1 = {
+  it("should discriminate via type field on built schemas", () => {
+    const schemaV1 = defineSchema({
       Item: defineRecord("Item", {
         docs: "An item",
         fields: { name: P.String },
       }),
-    };
+    });
 
     const schemaV2 = nextSchema(schemaV1)
       .addSchemaUpdate(
@@ -243,10 +248,8 @@ describe("defineSchemaUpdate", () => {
       )
       .build();
 
-    expect(isVersionedSchema(schemaV2)).toBe(true);
-    expect(isVersionedSchema(schemaV1)).toBe(false);
-    expect(isVersionedSchema(null)).toBe(false);
-    expect(isVersionedSchema(undefined)).toBe(false);
+    expect(schemaV2.type).toBe("versioned");
+    expect(schemaV2.previous.type).toBe("initial");
   });
 
   it("should work with union schema updates", () => {
@@ -265,7 +268,7 @@ describe("defineSchemaUpdate", () => {
       fields: { base: P.Double, height: P.Double },
     });
 
-    const schemaV1 = {
+    const schemaV1 = defineSchema({
       Shape: defineUnion("Shape", {
         docs: "A shape",
         variants: {
@@ -273,11 +276,11 @@ describe("defineSchemaUpdate", () => {
           rectangle: RectangleRecord,
         },
       }),
-    };
+    });
 
     const addTriangle = defineSchemaUpdate(
       "addTriangle",
-      (schema: SchemaBuilder<typeof schemaV1>) => ({
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
         Shape: schema.Shape.addVariant("triangle", TriangleRecord).build(),
       }),
     );
@@ -313,7 +316,7 @@ describe("defineSchemaUpdate", () => {
       fields: { orgName: P.String },
     });
 
-    const schemaV1 = {
+    const schemaV1 = defineSchema({
       Person: PersonRecord,
       Entity: defineUnion("Entity", {
         docs: "An entity",
@@ -321,18 +324,18 @@ describe("defineSchemaUpdate", () => {
           person: PersonRecord,
         },
       }),
-    };
+    });
 
     const addAge = defineSchemaUpdate(
       "addAge",
-      (schema: SchemaBuilder<typeof schemaV1>) => ({
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
         PersonV2: schema.Person.addField("age", P.Double).build(),
       }),
     );
 
     const addOrgVariant = defineSchemaUpdate(
       "addOrgVariant",
-      (schema: SchemaBuilder<typeof schemaV1>) => ({
+      (schema: SchemaBuilder<typeof schemaV1.models>) => ({
         Entity: schema.Entity.addVariant("organization", OrganizationRecord).build(),
       }),
     );

--- a/packages/schema/src/defineMigration.ts
+++ b/packages/schema/src/defineMigration.ts
@@ -16,16 +16,18 @@
 
 import type { UnionVariantArg } from "./defineUnion.js";
 import { resolveUnionVariantArg } from "./defineUnion.js";
-import type { RecordDef, RecordFields, UnionDef, UnionVariants } from "./defs.js";
+import type { ModelDefs, RecordDef, RecordFields, UnionDef, UnionVariants } from "./defs.js";
 import { ModelDefType } from "./defs.js";
 import type { Ref, Type } from "./primitives.js";
 import { isRecordDef, isUnionDef } from "./utils.js";
 
-export type ReturnedSchema = Record<string, RecordDef | UnionDef>;
+/** Soon to be deprecated - Use `ModelDefs` instead. */
+export type ReturnedSchema = ModelDefs;
 
-export type Schema<T extends ReturnedSchema> = T;
+/** Soon to be deprecated - Use `ModelDefs` instead. */
+export type Schema<T extends ModelDefs> = T;
 
-export type SchemaBuilder<T extends ReturnedSchema> = {
+export type SchemaBuilder<T extends ModelDefs> = {
   [k in keyof T]: T[k] extends UnionDef<infer R> ? UnionBuilder<R>
     : T[k] extends RecordDef<infer R> ? RecordBuilder<R>
     : never;
@@ -114,30 +116,16 @@ class RecordBuilderImpl<T extends RecordFields> implements RecordBuilder<T> {
 }
 
 export function defineMigration<
-  const T extends ReturnedSchema,
-  const S extends ReturnedSchema,
+  const T extends ModelDefs,
+  const S extends ModelDefs,
 >(
-  previous: Schema<T>,
+  models: T,
   migration: (schema: SchemaBuilder<T>) => S,
-): Schema<T & S> {
-  /**
-   * Create a map of builders for the schema.
-   *
-   * Note about type assertions:
-   * We use a type assertion here (SchemaBuilder<T>) because TypeScript cannot
-   * track the relationship between the keys in the original schema and the
-   * corresponding builder types. This is a fundamental limitation of TypeScript's
-   * type system when dealing with dynamically constructed objects.
-   *
-   * The assertion is safe because:
-   * 1. We're only adding keys that exist in the original schema
-   * 2. For each key, we're creating a builder of the correct type
-   * 3. The resulting object exactly matches the SchemaBuilder<T> type
-   */
+): T & S {
   const builders = {} as SchemaBuilder<T>;
 
-  for (const key in previous) {
-    const v = previous[key];
+  for (const key in models) {
+    const v = models[key];
 
     // Use our type guards for safer type narrowing
     if (isRecordDef(v)) {
@@ -153,7 +141,7 @@ export function defineMigration<
   }
 
   return {
-    ...previous,
+    ...models,
     ...migration(builders),
   };
 }

--- a/packages/schema/src/defineSchemaUpdate.ts
+++ b/packages/schema/src/defineSchemaUpdate.ts
@@ -14,82 +14,80 @@
  * limitations under the License.
  */
 
-import type { ReturnedSchema, Schema, SchemaBuilder } from "./defineMigration.js";
+import type { SchemaBuilder } from "./defineMigration.js";
 import { defineMigration } from "./defineMigration.js";
+import type { ModelDefs } from "./defs.js";
 
-export interface VersionedSchema<T extends ReturnedSchema = ReturnedSchema> {
+export interface InitialSchema<T extends ModelDefs = ModelDefs> {
+  readonly type: "initial";
+  readonly models: T;
+}
+
+export interface VersionedSchema<T extends ModelDefs = ModelDefs> {
+  readonly type: "versioned";
   readonly models: T;
   readonly version: number;
-  readonly previous?: VersionedSchema;
+  readonly previous: SchemaDefinition;
 }
 
-export function isVersionedSchema(value: unknown): value is VersionedSchema {
-  return (
-    typeof value === "object"
-    && value != null
-    && "models" in value
-    && "version" in value
-    && typeof (value as VersionedSchema).version === "number"
-  );
+export type SchemaDefinition<T extends ModelDefs = ModelDefs> =
+  | InitialSchema<T>
+  | VersionedSchema<T>;
+
+export function defineSchema<T extends ModelDefs>(models: T): InitialSchema<T> {
+  return { type: "initial", models };
 }
 
-export interface SchemaUpdate<T extends ReturnedSchema, S extends ReturnedSchema> {
+export interface SchemaUpdate<T extends ModelDefs, S extends ModelDefs> {
   readonly name: string;
   readonly migration: (schema: SchemaBuilder<T>) => S;
 }
 
-export function defineSchemaUpdate<T extends ReturnedSchema, S extends ReturnedSchema>(
+export function defineSchemaUpdate<T extends ModelDefs, S extends ModelDefs>(
   name: string,
   migration: (schema: SchemaBuilder<T>) => S,
 ): SchemaUpdate<T, S> {
   return { name, migration };
 }
 
-export interface SchemaVersionBuilder<T extends ReturnedSchema> {
-  addSchemaUpdate<S extends ReturnedSchema>(
+export interface SchemaVersionBuilder<T extends ModelDefs> {
+  addSchemaUpdate<S extends ModelDefs>(
     update: SchemaUpdate<T, S>,
   ): SchemaVersionBuilder<T & S>;
   build(): VersionedSchema<T>;
 }
 
-class SchemaVersionBuilderImpl<T extends ReturnedSchema> implements SchemaVersionBuilder<T> {
-  private readonly schema: Schema<T>;
+class SchemaVersionBuilderImpl<T extends ModelDefs> implements SchemaVersionBuilder<T> {
+  private readonly models: T;
   private readonly version: number;
-  private readonly previous: VersionedSchema;
+  private readonly previous: SchemaDefinition;
 
-  constructor(schema: Schema<T>, version: number, previous: VersionedSchema) {
-    this.schema = schema;
+  constructor(models: T, version: number, previous: SchemaDefinition) {
+    this.models = models;
     this.version = version;
     this.previous = previous;
   }
 
-  addSchemaUpdate<S extends ReturnedSchema>(
+  addSchemaUpdate<S extends ModelDefs>(
     update: SchemaUpdate<T, S>,
   ): SchemaVersionBuilder<T & S> {
-    const merged = defineMigration(this.schema, update.migration);
+    const merged = defineMigration(this.models, update.migration);
     return new SchemaVersionBuilderImpl(merged, this.version, this.previous);
   }
 
   build(): VersionedSchema<T> {
     return {
-      models: { ...this.schema },
+      type: "versioned",
+      models: { ...this.models },
       version: this.version,
       previous: this.previous,
     };
   }
 }
 
-export function nextSchema<T extends ReturnedSchema>(
-  previous: VersionedSchema<T>,
-): SchemaVersionBuilder<T>;
-export function nextSchema<T extends ReturnedSchema>(
-  previous: Schema<T>,
-): SchemaVersionBuilder<T>;
-export function nextSchema(
-  previous: ReturnedSchema | VersionedSchema,
-): SchemaVersionBuilder<ReturnedSchema> {
-  if (isVersionedSchema(previous)) {
-    return new SchemaVersionBuilderImpl(previous.models, previous.version + 1, previous);
-  }
-  return new SchemaVersionBuilderImpl(previous, 2, { models: previous, version: 1 });
+export function nextSchema<T extends ModelDefs>(
+  previous: SchemaDefinition<T>,
+): SchemaVersionBuilder<T> {
+  const prevVersion = previous.type === "versioned" ? previous.version : 1;
+  return new SchemaVersionBuilderImpl(previous.models, prevVersion + 1, previous);
 }

--- a/packages/schema/src/defs.ts
+++ b/packages/schema/src/defs.ts
@@ -44,3 +44,4 @@ export interface RecordDef<TFields extends RecordFields = RecordFields> extends 
 }
 
 export type ModelDef = RecordDef | UnionDef;
+export type ModelDefs = Record<string, ModelDef>;


### PR DESCRIPTION
There's quite a lot of tests here, making this a very large change. I could split this up further, e.g. not generating the Zod in this PR. Let me know if that'd be easier. 

Also, follows through on some renames - I'd recommend reading bottom to top :)