### PR TITLE
Remove record metadata field

### DIFF
--- a/.changeset/witty-berries-tease.md
+++ b/.changeset/witty-berries-tease.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.document-schema.type-gen": patch
+---
+
+rm metadata field from record to match api shape

--- a/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/recordDef.ts
+++ b/packages/document-schema/type-gen/src/lib/pack-docschema-api/pack-docschema-ir/recordDef.ts
@@ -16,11 +16,9 @@
 
 import type { IModelTypeKey } from "../pack-docschema-api/modelTypeKey.js";
 import type { IFieldDef } from "./fieldDef.js";
-import type { ISchemaMeta } from "./schemaMeta.js";
 export interface IRecordDef {
   readonly "key": IModelTypeKey;
   readonly "name": string;
   readonly "description"?: string | null;
   readonly "fields": ReadonlyArray<IFieldDef>;
-  readonly "metadata": ISchemaMeta;
 }

--- a/packages/document-schema/type-gen/src/utils/ir/__tests__/convertIrToWireSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/__tests__/convertIrToWireSchema.test.ts
@@ -42,7 +42,6 @@ describe("convertIrToWireSchema", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     const ir: IRealTimeDocumentSchema = {
@@ -123,7 +122,6 @@ describe("convertIrToWireSchema", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     const ir: IRealTimeDocumentSchema = {
@@ -168,7 +166,6 @@ describe("convertIrToWireSchema", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     const ir: IRealTimeDocumentSchema = {
@@ -235,7 +232,6 @@ describe("convertIrToWireSchema", () => {
             metadata: { addedInVersion: 1 },
           },
         ],
-        metadata: { addedInVersion: 1 },
       };
 
       const ir: IRealTimeDocumentSchema = {

--- a/packages/document-schema/type-gen/src/utils/ir/__tests__/generateModelsFromIr.test.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/__tests__/generateModelsFromIr.test.ts
@@ -63,7 +63,6 @@ describe("generateModelsFromIr", () => {
       name: "Person",
       description: "A person record",
       fields: [personField1, personField2],
-      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -144,7 +143,6 @@ describe("generateModelsFromIr", () => {
       name: "Event",
       description: "An event record with external refs",
       fields: [eventField1, eventField2, eventField3],
-      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -205,7 +203,6 @@ describe("generateModelsFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     // Define the TextBox record
@@ -241,7 +238,6 @@ describe("generateModelsFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     // Define the Node union
@@ -319,7 +315,6 @@ describe("generateModelsFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     const dogRecord: IRecordDef = {
@@ -341,7 +336,6 @@ describe("generateModelsFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     const animalUnion: IUnionDef = {

--- a/packages/document-schema/type-gen/src/utils/ir/__tests__/generateZodSchemasFromIr.test.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/__tests__/generateZodSchemasFromIr.test.ts
@@ -77,7 +77,6 @@ describe("generateZodSchemasFromIr", () => {
       name: "Person",
       description: "A person record",
       fields: [personField1, personField2, personField3],
-      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -143,7 +142,6 @@ describe("generateZodSchemasFromIr", () => {
       name: "Container",
       description: "A container record",
       fields: [arrayField, mapField],
-      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -185,7 +183,6 @@ describe("generateZodSchemasFromIr", () => {
       name: "Event",
       description: "An event record",
       fields: [datetimeField],
-      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -259,7 +256,6 @@ describe("generateZodSchemasFromIr", () => {
       name: "Feature",
       description: "A feature toggle record",
       fields: [booleanField, optionalBooleanField, booleanArrayField],
-      metadata: { addedInVersion: 1 },
     };
 
     const schema: IRealTimeDocumentSchema = {
@@ -329,7 +325,6 @@ describe("generateZodSchemasFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     // Define the TextBox record
@@ -378,7 +373,6 @@ describe("generateZodSchemasFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     // Define the Node union
@@ -442,7 +436,6 @@ describe("generateZodSchemasFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     const barRecord: IRecordDef = {
@@ -464,7 +457,6 @@ describe("generateZodSchemasFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     // Define union that references the records
@@ -542,7 +534,6 @@ describe("generateZodSchemasFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     const dogRecord: IRecordDef = {
@@ -564,7 +555,6 @@ describe("generateZodSchemasFromIr", () => {
           metadata: { addedInVersion: 1 },
         },
       ],
-      metadata: { addedInVersion: 1 },
     };
 
     const animalUnion: IUnionDef = {

--- a/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/ir/convertIrToWireSchema.ts
@@ -61,14 +61,16 @@ export function convertIrToWireSchema(ir: IRealTimeDocumentSchema): DocumentType
 function convertModelDef(model: IModelDef): ModelDef {
   switch (model.type) {
     case "record":
+      // TODO: The @osdk/foundry.pack wire types still declare `metadata` as required on
+      // RecordDef, but the Pack API schema (api-gateway / backpack) has removed it.
+      // Cast through unknown until the published types catch up.
       return {
         type: "record",
         key: model.record.key,
         name: model.record.name,
         description: orUndefined(model.record.description),
         fields: [...model.record.fields.map(convertFieldDef)],
-        metadata: convertSchemaMeta(model.record.metadata),
-      };
+      } as unknown as ModelDef;
     case "union":
       return {
         type: "union",

--- a/packages/document-schema/type-gen/src/utils/steps/convertStepsToIr.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/convertStepsToIr.ts
@@ -122,7 +122,6 @@ export function convertRecordDefToIr(recordDef: P.RecordDef): IRecordDef {
     name: recordDef.name,
     description: recordDef.docs || undefined,
     fields,
-    metadata: { addedInVersion: 1 },
   };
 }
 


### PR DESCRIPTION
The public api shape for the document schema has been updated to not included the metadata field on a given Record. This PR will remove the metadata field to match the schema shape.

Testing:
Deploy generated asset file is successful, passing backend validation.