### PR TITLE
Rewrite context path prefix for asset deploy handler

### DIFF
--- a/.changeset/gold-aliens-leave.md
+++ b/.changeset/gold-aliens-leave.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.document-schema.type-gen": patch
+---
+
+create flag for asset deploy to override api context path

--- a/packages/document-schema/type-gen/src/commands/asset/__tests__/buildPrefixRewriteFetch.test.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/__tests__/buildPrefixRewriteFetch.test.ts
@@ -22,7 +22,7 @@ describe("buildPrefixRewriteFetch", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    fetchSpy = vi.fn(async () => new Response(null, { status: 204 }));
+    fetchSpy = vi.fn(() => Promise.resolve(new Response(null, { status: 204 })));
     globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
   });
 

--- a/packages/document-schema/type-gen/src/commands/asset/__tests__/buildPrefixRewriteFetch.test.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/__tests__/buildPrefixRewriteFetch.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildPrefixRewriteFetch } from "../assetDeployHandler.js";
+
+describe("buildPrefixRewriteFetch", () => {
+  const originalFetch = globalThis.fetch;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(async () => new Response(null, { status: 204 }));
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function calledUrl(): string {
+    const arg = fetchSpy.mock.calls[0]![0] as Request;
+    return arg.url;
+  }
+
+  it("rewrites /api/foo to /api/gotham/foo", async () => {
+    const wrapped = buildPrefixRewriteFetch("/api/gotham");
+    await wrapped("https://stack.example.com/api/foo");
+    expect(calledUrl()).toBe("https://stack.example.com/api/gotham/foo");
+  });
+
+  it("rewrites bare /api to /api/gotham", async () => {
+    const wrapped = buildPrefixRewriteFetch("/api/gotham");
+    await wrapped("https://stack.example.com/api");
+    expect(calledUrl()).toBe("https://stack.example.com/api/gotham");
+  });
+
+  it("preserves query strings on rewritten requests", async () => {
+    const wrapped = buildPrefixRewriteFetch("/api/gotham");
+    await wrapped("https://stack.example.com/api/foo?x=1&y=2");
+    expect(calledUrl()).toBe("https://stack.example.com/api/gotham/foo?x=1&y=2");
+  });
+
+  it("does not rewrite paths that only share the /api prefix string", async () => {
+    const wrapped = buildPrefixRewriteFetch("/api/gotham");
+    await wrapped("https://stack.example.com/apiother/foo");
+    expect(calledUrl()).toBe("https://stack.example.com/apiother/foo");
+  });
+
+  it("does not rewrite non-/api paths", async () => {
+    const wrapped = buildPrefixRewriteFetch("/api/gotham");
+    await wrapped("https://stack.example.com/healthz");
+    expect(calledUrl()).toBe("https://stack.example.com/healthz");
+  });
+
+  it("forwards method and headers from the original request", async () => {
+    const wrapped = buildPrefixRewriteFetch("/api/gotham");
+    await wrapped("https://stack.example.com/api/foo", {
+      method: "POST",
+      headers: { "x-custom": "value" },
+      body: JSON.stringify({ hello: "world" }),
+    });
+    const req = fetchSpy.mock.calls[0]![0] as Request;
+    expect(req.method).toBe("POST");
+    expect(req.headers.get("x-custom")).toBe("value");
+    await expect(req.text()).resolves.toBe(JSON.stringify({ hello: "world" }));
+  });
+
+  it("throws on an unsupported prefix", () => {
+    expect(() => buildPrefixRewriteFetch("/api/other")).toThrow(
+      /Unsupported first-party prefix/,
+    );
+  });
+
+  it("throws on a prefix missing the leading slash", () => {
+    expect(() => buildPrefixRewriteFetch("api/gotham")).toThrow(
+      /Unsupported first-party prefix/,
+    );
+  });
+});

--- a/packages/document-schema/type-gen/src/commands/asset/assetDeployHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/assetDeployHandler.ts
@@ -34,13 +34,27 @@ interface AssetDeployOptions {
 const DEFAULT_API_PREFIX = "/api";
 
 /**
+ * The set of API prefixes that `--first-party-prefix` is allowed to rewrite to.
+ * Only `/api/gotham` is supported today; expand this list as new gateways are added.
+ */
+export const ALLOWED_FIRST_PARTY_PREFIXES = ["/api/gotham"] as const;
+
+/**
  * Builds a fetch wrapper that rewrites the OSDK client's `/api/...` requests
  * to a different prefix (e.g. `/api/gotham`). Used for stacks where the
  * endpoint is served behind a different gateway path instead
  * of the default `/api` route.
+ *
+ * Throws if `prefix` is not one of {@link ALLOWED_FIRST_PARTY_PREFIXES}.
  */
-function buildPrefixRewriteFetch(prefix: string): typeof globalThis.fetch {
-  const normalized = prefix.replace(/\/+$/, "");
+export function buildPrefixRewriteFetch(prefix: string): typeof globalThis.fetch {
+  if (!(ALLOWED_FIRST_PARTY_PREFIXES as readonly string[]).includes(prefix)) {
+    throw new Error(
+      `Unsupported first-party prefix '${prefix}'. Allowed values: ${
+        ALLOWED_FIRST_PARTY_PREFIXES.join(", ")
+      }`,
+    );
+  }
   return (input, init) => {
     const req = new Request(input, init);
     const url = new URL(req.url);
@@ -50,7 +64,7 @@ function buildPrefixRewriteFetch(prefix: string): typeof globalThis.fetch {
     ) {
       return globalThis.fetch(req);
     }
-    url.pathname = normalized + url.pathname.slice(DEFAULT_API_PREFIX.length);
+    url.pathname = prefix + url.pathname.slice(DEFAULT_API_PREFIX.length);
     return globalThis.fetch(new Request(url, req));
   };
 }

--- a/packages/document-schema/type-gen/src/commands/asset/assetDeployHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/assetDeployHandler.ts
@@ -28,6 +28,31 @@ interface AssetDeployOptions {
   readonly baseUrl: string;
   readonly auth: string;
   readonly ontologyRid: string;
+  readonly firstPartyPrefix?: string;
+}
+
+const DEFAULT_API_PREFIX = "/api";
+
+/**
+ * Builds a fetch wrapper that rewrites the OSDK client's `/api/...` requests
+ * to a different prefix (e.g. `/api/gotham`). Used for stacks where the
+ * endpoint is served behind a different gateway path instead
+ * of the default `/api` route.
+ */
+function buildPrefixRewriteFetch(prefix: string): typeof globalThis.fetch {
+  const normalized = prefix.replace(/\/+$/, "");
+  return (input, init) => {
+    const req = new Request(input, init);
+    const url = new URL(req.url);
+    if (
+      url.pathname !== DEFAULT_API_PREFIX
+      && !url.pathname.startsWith(`${DEFAULT_API_PREFIX}/`)
+    ) {
+      return globalThis.fetch(req);
+    }
+    url.pathname = normalized + url.pathname.slice(DEFAULT_API_PREFIX.length);
+    return globalThis.fetch(new Request(url, req));
+  };
 }
 
 /** Useful for manually deploying a document type during development to test schema changes. */
@@ -40,9 +65,18 @@ export async function assetDeployHandler(options: AssetDeployOptions): Promise<v
     const assetContent = readFileSync(assetPath, "utf8");
     const asset = JSON.parse(assetContent) as DocumentTypeAsset;
 
+    const fetchFn = options.firstPartyPrefix != null
+      ? buildPrefixRewriteFetch(options.firstPartyPrefix)
+      : undefined;
+    if (fetchFn != null) {
+      consola.info(`Rewriting OSDK '${DEFAULT_API_PREFIX}' -> '${options.firstPartyPrefix}'`);
+    }
+
     const osdkClient = createPlatformClient(
       options.baseUrl,
       () => Promise.resolve(options.auth),
+      undefined,
+      fetchFn,
     );
 
     const request: CreateFirstPartyDocumentTypeRequest = {

--- a/packages/document-schema/type-gen/src/commands/asset/registerAssetCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/registerAssetCommands.ts
@@ -29,5 +29,9 @@ export function registerAssetCommands(program: Command): void {
     .requiredOption("-b, --base-url <url>", "Base URL for Foundry API")
     .requiredOption("-a, --auth <token>", "Authentication token for Foundry API")
     .requiredOption("-o, --ontology-rid <rid>", "Target ontology RID")
+    .option(
+      "--first-party-prefix <path>",
+      "Override the API prefix used for first-party deploy (e.g. /api/gotham). Defaults to /api.",
+    )
     .action(assetDeployHandler);
 }


### PR DESCRIPTION
For first party document type deployment, devs may require deploying document type via a different api context path, i.e. /api/gotham for environments using gotham-api-gateway. An extra flag will be added to provide this path to override the default /api path.

Test:

```
pnpm exec type-gen asset deploy -i build/asset11test.json -o ri.ontology.main.ontology.6ae2b235-997d-4b5e-9611-85fa88742697 -a $FOUNDRY_TOKEN -b https://danube-staging.palantircloud.com --first-party-prefix /api/gotham
ℹ Reading asset file from: /Volumes/git/pack/demos/canvas/schema/build/asset11test.json                                                                                                   2:30:37 PM
ℹ Rewriting OSDK '/api' -> '/api/gotham'                                                                                                                                                  2:30:37 PM
ℹ Creating first-party document type { requestBody:                                                                                                                                       2:30:37 PM
   { name: 'com.palantir.pack.demo.document-type-13',
     ontologyRid: 'ri.ontology.main.ontology.6ae2b235-997d-4b5e-9611-85fa88742697',
     schema: { primaryModelKeys: [Array], models: [Object] },
     fileSystemType: 'ARTIFACTS',
     version: 1 } }
✔ Successfully created first-party document type { rid: 'ri.backpack..document-type.9757319e-433c-47b2-90bc-64dcefba2be1',                                                                2:30:39 PM
  name: 'com.palantir.pack.demo.document-type-13',
  fileSystemType: 'ARTIFACTS',
  version: 1 }
```