### PR TITLE
rewrite websocket url

### DIFF
--- a/.changeset/small-cases-chew.md
+++ b/.changeset/small-cases-chew.md
@@ -1,0 +1,7 @@
+---
+"@palantir/pack.state.foundry-event": minor
+"@palantir/pack.core": minor
+"@palantir/pack.app": minor
+---
+
+rewrite websocket url

--- a/packages/app/src/utils/initPackApp.ts
+++ b/packages/app/src/utils/initPackApp.ts
@@ -344,9 +344,20 @@ function getAppConfig(
     remote: {
       baseUrl,
       fetchFn,
-      packWsPath: options.remote?.packWsPath ?? "/api/v2/packSubscriptions",
+      packWebsocketUrl: resolvePackWebsocketUrl(options, baseUrl),
     },
   };
+}
+
+function resolvePackWebsocketUrl(options: AppOptions, baseUrl: string | undefined): string {
+  if (options.remote?.packWebsocketUrl != null) {
+    return options.remote.packWebsocketUrl;
+  }
+  const path = "/api/v2/packSubscriptions";
+  if (baseUrl == null || baseUrl === "") {
+    return `${path}/cometd`;
+  }
+  return new URL(`${path}/cometd`, baseUrl).toString();
 }
 
 function isPublicOauthClient(auth: AppOptions["auth"]): auth is PublicOauthClient {

--- a/packages/app/src/utils/initPackApp.ts
+++ b/packages/app/src/utils/initPackApp.ts
@@ -344,14 +344,14 @@ function getAppConfig(
     remote: {
       baseUrl,
       fetchFn,
-      packWebsocketUrl: resolvePackWebsocketUrl(options, baseUrl),
+      packEventsUrl: resolvePackEventsUrl(options, baseUrl),
     },
   };
 }
 
-function resolvePackWebsocketUrl(options: AppOptions, baseUrl: string | undefined): string {
-  if (options.remote?.packWebsocketUrl != null) {
-    return options.remote.packWebsocketUrl;
+function resolvePackEventsUrl(options: AppOptions, baseUrl: string | undefined): string {
+  if (options.remote?.packEventsUrl != null) {
+    return options.remote.packEventsUrl;
   }
   const path = "/api/v2/packSubscriptions";
   if (baseUrl == null || baseUrl === "") {

--- a/packages/app/src/utils/initPackApp.ts
+++ b/packages/app/src/utils/initPackApp.ts
@@ -357,7 +357,7 @@ function resolvePackWebsocketUrl(options: AppOptions, baseUrl: string | undefine
   if (baseUrl == null || baseUrl === "") {
     return `${path}/cometd`;
   }
-  return new URL(`${path}/cometd`, baseUrl).toString();
+  return new URL(`${path}/cometd`, baseUrl).href;
 }
 
 function isPublicOauthClient(auth: AppOptions["auth"]): auth is PublicOauthClient {

--- a/packages/auth/foundry/src/__tests__/AuthServiceConfidential.test.ts
+++ b/packages/auth/foundry/src/__tests__/AuthServiceConfidential.test.ts
@@ -55,7 +55,7 @@ describe("ConfidentialOauthService", () => {
         ontologyRid: Promise.resolve("ri.ontology...test"),
         osdkClient: mockOsdkClient,
         remote: {
-          packWsPath: "/api/v2/packSubscriptions",
+          packWebsocketUrl: "https://test.example.com/api/v2/packSubscriptions/cometd",
           baseUrl: "https://test.example.com",
           fetchFn: globalThis.fetch,
         },

--- a/packages/auth/foundry/src/__tests__/AuthServiceConfidential.test.ts
+++ b/packages/auth/foundry/src/__tests__/AuthServiceConfidential.test.ts
@@ -55,7 +55,7 @@ describe("ConfidentialOauthService", () => {
         ontologyRid: Promise.resolve("ri.ontology...test"),
         osdkClient: mockOsdkClient,
         remote: {
-          packWebsocketUrl: "https://test.example.com/api/v2/packSubscriptions/cometd",
+          packEventsUrl: "https://test.example.com/api/v2/packSubscriptions/cometd",
           baseUrl: "https://test.example.com",
           fetchFn: globalThis.fetch,
         },

--- a/packages/auth/foundry/src/__tests__/AuthServicePublic.test.ts
+++ b/packages/auth/foundry/src/__tests__/AuthServicePublic.test.ts
@@ -54,7 +54,7 @@ describe("PublicOauthService", () => {
         ontologyRid: Promise.resolve("ri.ontology...test"),
         osdkClient: mockOsdkClient,
         remote: {
-          packWebsocketUrl: "https://test.example.com/api/v2/packSubscriptions/cometd",
+          packEventsUrl: "https://test.example.com/api/v2/packSubscriptions/cometd",
           baseUrl: "https://test.example.com",
           fetchFn: globalThis.fetch,
         },

--- a/packages/auth/foundry/src/__tests__/AuthServicePublic.test.ts
+++ b/packages/auth/foundry/src/__tests__/AuthServicePublic.test.ts
@@ -54,7 +54,7 @@ describe("PublicOauthService", () => {
         ontologyRid: Promise.resolve("ri.ontology...test"),
         osdkClient: mockOsdkClient,
         remote: {
-          packWsPath: "/api/v2/packSubscriptions",
+          packWebsocketUrl: "https://test.example.com/api/v2/packSubscriptions/cometd",
           baseUrl: "https://test.example.com",
           fetchFn: globalThis.fetch,
         },

--- a/packages/auth/foundry/src/__tests__/AuthServiceStatic.test.ts
+++ b/packages/auth/foundry/src/__tests__/AuthServiceStatic.test.ts
@@ -51,7 +51,7 @@ describe("StaticTokenService", () => {
         ontologyRid: Promise.resolve("ri.ontology...test"),
         osdkClient: mockOsdkClient,
         remote: {
-          packWsPath: "/api/v2/packSubscriptions",
+          packWebsocketUrl: "https://test.example.com/api/v2/packSubscriptions/cometd",
           baseUrl: "https://test.example.com",
           fetchFn: globalThis.fetch,
         },

--- a/packages/auth/foundry/src/__tests__/AuthServiceStatic.test.ts
+++ b/packages/auth/foundry/src/__tests__/AuthServiceStatic.test.ts
@@ -51,7 +51,7 @@ describe("StaticTokenService", () => {
         ontologyRid: Promise.resolve("ri.ontology...test"),
         osdkClient: mockOsdkClient,
         remote: {
-          packWebsocketUrl: "https://test.example.com/api/v2/packSubscriptions/cometd",
+          packEventsUrl: "https://test.example.com/api/v2/packSubscriptions/cometd",
           baseUrl: "https://test.example.com",
           fetchFn: globalThis.fetch,
         },

--- a/packages/core/src/types/AppConfig.ts
+++ b/packages/core/src/types/AppConfig.ts
@@ -40,7 +40,7 @@ export interface AppConfig {
   readonly osdkClient: Client;
 
   readonly remote: {
-    readonly packWsPath: string;
+    readonly packWebsocketUrl: string;
     readonly baseUrl: string;
     readonly fetchFn: typeof globalThis.fetch;
   };
@@ -93,9 +93,10 @@ export interface AppOptions {
 
   readonly remote?: {
     /**
-     * @default "/api/v2/packSubscriptions"
+     * Absolute URL of the backpack cometD endpoint. Typically supplied by host
+     * environments.
      */
-    readonly packWsPath?: string;
+    readonly packWebsocketUrl?: string;
 
     /**
      * Override the base URL from the OSDK client.

--- a/packages/core/src/types/AppConfig.ts
+++ b/packages/core/src/types/AppConfig.ts
@@ -40,7 +40,7 @@ export interface AppConfig {
   readonly osdkClient: Client;
 
   readonly remote: {
-    readonly packWebsocketUrl: string;
+    readonly packEventsUrl: string;
     readonly baseUrl: string;
     readonly fetchFn: typeof globalThis.fetch;
   };
@@ -96,7 +96,7 @@ export interface AppOptions {
      * Absolute URL of the backpack cometD endpoint. Typically supplied by host
      * environments.
      */
-    readonly packWebsocketUrl?: string;
+    readonly packEventsUrl?: string;
 
     /**
      * Override the base URL from the OSDK client.

--- a/packages/state/core/src/__tests__/testUtils.ts
+++ b/packages/state/core/src/__tests__/testUtils.ts
@@ -47,7 +47,7 @@ export function createTestApp(
       ontologyRid: config.ontologyRid ?? Promise.resolve("ri.ontology...test"),
       osdkClient: mockClient,
       remote: {
-        packWebsocketUrl: "http://localhost/api/v2/packSubscriptions/cometd",
+        packEventsUrl: "http://localhost/api/v2/packSubscriptions/cometd",
         baseUrl: "http://localhost",
         fetchFn: fetch,
         ...config.remote,

--- a/packages/state/core/src/__tests__/testUtils.ts
+++ b/packages/state/core/src/__tests__/testUtils.ts
@@ -47,7 +47,7 @@ export function createTestApp(
       ontologyRid: config.ontologyRid ?? Promise.resolve("ri.ontology...test"),
       osdkClient: mockClient,
       remote: {
-        packWsPath: "/api/v2/packSubscriptions",
+        packWebsocketUrl: "http://localhost/api/v2/packSubscriptions/cometd",
         baseUrl: "http://localhost",
         fetchFn: fetch,
         ...config.remote,

--- a/packages/state/demo/src/__tests__/DemoDocumentService.test.ts
+++ b/packages/state/demo/src/__tests__/DemoDocumentService.test.ts
@@ -72,7 +72,7 @@ function createTestApp(
       remote: {
         baseUrl: "http://localhost",
         fetchFn: fetch,
-        packWsPath: "/api/v2/packSubscriptions",
+        packWebsocketUrl: "http://localhost/api/v2/packSubscriptions/cometd",
         ...config.remote,
       },
     } satisfies AppConfig,

--- a/packages/state/demo/src/__tests__/DemoDocumentService.test.ts
+++ b/packages/state/demo/src/__tests__/DemoDocumentService.test.ts
@@ -72,7 +72,7 @@ function createTestApp(
       remote: {
         baseUrl: "http://localhost",
         fetchFn: fetch,
-        packWebsocketUrl: "http://localhost/api/v2/packSubscriptions/cometd",
+        packEventsUrl: "http://localhost/api/v2/packSubscriptions/cometd",
         ...config.remote,
       },
     } satisfies AppConfig,

--- a/packages/state/foundry-event/src/__tests__/EventServiceCometD.reconnection.test.ts
+++ b/packages/state/foundry-event/src/__tests__/EventServiceCometD.reconnection.test.ts
@@ -50,7 +50,7 @@ const mockApp = {
   config: {
     logger: mockLogger,
     remote: {
-      packWsPath: "/ws",
+      packWebsocketUrl: "https://test.example.com/ws/cometd",
       baseUrl: "https://test.example.com",
     },
   },

--- a/packages/state/foundry-event/src/__tests__/EventServiceCometD.reconnection.test.ts
+++ b/packages/state/foundry-event/src/__tests__/EventServiceCometD.reconnection.test.ts
@@ -50,7 +50,7 @@ const mockApp = {
   config: {
     logger: mockLogger,
     remote: {
-      packWebsocketUrl: "https://test.example.com/ws/cometd",
+      packEventsUrl: "https://test.example.com/ws/cometd",
       baseUrl: "https://test.example.com",
     },
   },

--- a/packages/state/foundry-event/src/cometd/EventServiceCometD.ts
+++ b/packages/state/foundry-event/src/cometd/EventServiceCometD.ts
@@ -294,13 +294,13 @@ export class EventServiceCometD implements EventService {
 }
 
 function getCometDWebsocketUrl(appConfig: AppConfig) {
-  const httpUrl = new URL(
-    `${appConfig.remote.packWsPath}/cometd`,
-    appConfig.remote.baseUrl,
-  );
-  httpUrl.protocol.replace(/https?/, "ws");
-  // TODO: likely need a specific port for ingest - all of this should be in in appConfig
-  return httpUrl.href;
+  const url = new URL(appConfig.remote.packWebsocketUrl, appConfig.remote.baseUrl);
+  if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  } else if (url.protocol === "http:") {
+    url.protocol = "ws:";
+  }
+  return url.href;
 }
 
 class TokenExtension {

--- a/packages/state/foundry-event/src/cometd/EventServiceCometD.ts
+++ b/packages/state/foundry-event/src/cometd/EventServiceCometD.ts
@@ -294,7 +294,7 @@ export class EventServiceCometD implements EventService {
 }
 
 function getCometDWebsocketUrl(appConfig: AppConfig) {
-  const url = new URL(appConfig.remote.packWebsocketUrl, appConfig.remote.baseUrl);
+  const url = new URL(appConfig.remote.packEventsUrl, appConfig.remote.baseUrl);
   if (url.protocol === "https:") {
     url.protocol = "wss:";
   } else if (url.protocol === "http:") {

--- a/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
@@ -61,7 +61,7 @@ const mockApp = {
     logger: mockLogger,
     osdkClient: mockOsdkClient,
     remote: {
-      packWsPath: "/ws",
+      packWebsocketUrl: "https://test.example.com/ws/cometd",
       baseUrl: "https://test.example.com",
     },
   },

--- a/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
@@ -61,7 +61,7 @@ const mockApp = {
     logger: mockLogger,
     osdkClient: mockOsdkClient,
     remote: {
-      packWebsocketUrl: "https://test.example.com/ws/cometd",
+      packEventsUrl: "https://test.example.com/ws/cometd",
       baseUrl: "https://test.example.com",
     },
   },

--- a/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
@@ -70,7 +70,7 @@ const mockApp = {
     logger: mockLogger,
     osdkClient: mockOsdkClient,
     remote: {
-      packWebsocketUrl: "https://test.example.com/ws/cometd",
+      packEventsUrl: "https://test.example.com/ws/cometd",
       baseUrl: "https://test.example.com",
     },
   },

--- a/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
@@ -70,7 +70,7 @@ const mockApp = {
     logger: mockLogger,
     osdkClient: mockOsdkClient,
     remote: {
-      packWsPath: "/ws",
+      packWebsocketUrl: "https://test.example.com/ws/cometd",
       baseUrl: "https://test.example.com",
     },
   },


### PR DESCRIPTION
Small refactor of websocket url option to enable passing full url from internal applications requiring url's with different context paths (depending on the environment they are running in). Third party apps will continue to be able to default to the hardcoded context path which will get rewritten appropriately on the backend.

Checked for first party apps routing to proper websocket path.