### PR TITLE
Update release workflow to Node 24 for NPM Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 


### PR DESCRIPTION
Node 22 does not, by default, install a new enough npm version for NPM Trusted Publishing