### PR TITLE
Fix asset schema shape

### DIFF
--- a/.changeset/bold-frogs-live.md
+++ b/.changeset/bold-frogs-live.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.document-schema.type-gen": patch
+---
+
+fix schema shape for asset file

--- a/packages/document-schema/type-gen/src/commands/asset/assetDeployHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/assetDeployHandler.ts
@@ -97,7 +97,7 @@ export async function assetDeployHandler(options: AssetDeployOptions): Promise<v
       requestBody: {
         name: asset.documentTypeName,
         ontologyRid: options.ontologyRid,
-        schema: asset.documentStorageType.yjs,
+        schema: asset.documentStorageType.yjs.schema,
         fileSystemType: asset.fileSystemType,
         version: asset.schemaVersion,
       },

--- a/packages/document-schema/type-gen/src/commands/asset/assetUpdateSchemaHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/assetUpdateSchemaHandler.ts
@@ -65,7 +65,7 @@ export async function assetUpdateSchemaHandler(
       documentTypeName: asset.documentTypeName,
       requestBody: {
         ontologyRid: options.ontologyRid,
-        schema: asset.documentStorageType.yjs,
+        schema: asset.documentStorageType.yjs.schema,
         version: asset.schemaVersion,
         ...(options.forceOverwrite ? { forceOverwrite: true } : {}),
       },

--- a/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
@@ -69,7 +69,9 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
       documentTypeName,
       documentStorageType: {
         type: "yjs",
-        yjs: wireSchema,
+        yjs: {
+          schema: wireSchema,
+        },
       },
       fileSystemType,
       schemaVersion,

--- a/packages/document-schema/type-gen/src/commands/types.ts
+++ b/packages/document-schema/type-gen/src/commands/types.ts
@@ -22,7 +22,9 @@ export interface DocumentTypeAsset {
   readonly documentTypeName: string;
   readonly documentStorageType: {
     readonly type: "yjs";
-    readonly yjs: DocumentTypeSchema;
+    readonly yjs: {
+      readonly schema: DocumentTypeSchema;
+    };
   };
   readonly fileSystemType: FileSystemType;
   readonly schemaVersion: number;


### PR DESCRIPTION
For first-party document type registration, the asset file requires nested schema field in yjs field for proper deserialization by the backend. However, the manual doctype registration api sends just the schema field, which gets translated to the proper nested field in api-gateway translator.

This fixes the discrepancy by generating the asset file with the appropriate schema shape for the BE, and the deploy handler just extracts the nested schema field.

A discrepancy remains where the generated IR and asset file uses `fieldType` and `addedInVersion` for proper parsing by api-gateway, but for first-party asset file discovery by the backend, `value` and `addedIn` are required in place of fieldType/addedInVersion (these get mapped in api-gateway). Will follow-up on whether it's possible to just rename these properly in the backend to avoid the mismatch.

Before:
```
"documentStorageType": {
    "type": "yjs",
    "yjs": {
      "primaryModelKeys": ...
```

After:
```
documentStorageType": {
    "type": "yjs",
    "yjs": {
      "schema": {
        "primaryModelKeys": ...
```