### PR TITLE
generate ir and asset min version and compability ranges asset file

### DIFF
--- a/.changeset/bright-seals-say.md
+++ b/.changeset/bright-seals-say.md
@@ -1,0 +1,6 @@
+---
+"@palantir/pack.sdkgen.pack-versioned-template": minor
+"@palantir/pack.document-schema.type-gen": minor
+---
+
+refactor minimum supported version to be piped from configuration file so IR contains minimum supported version. This will enable downstream consumers to read the same supported version. Asset file with version compatibility range also generated for first party apps.

--- a/.changeset/bright-seals-say.md
+++ b/.changeset/bright-seals-say.md
@@ -3,4 +3,8 @@
 "@palantir/pack.document-schema.type-gen": minor
 ---
 
-refactor minimum supported version to be piped from configuration file so IR contains minimum supported version. This will enable downstream consumers to read the same supported version. Asset file with version compatibility range also generated for first party apps.
+Pipe minimum supported schema version from the SDK's pack-config so the IR is the single source of truth. `ir asset` now also emits a sibling `*-schema-compatibility-range.json` file required by the backend to compute operational versions for first-party apps.
+
+- `schema ir` now requires `--config <pack-config.json>`. Its optional `minSupportedVersion` field declares the oldest schema version this SDK supports; omit the field to track latest only.
+- `ir gen-types` no longer accepts `--min-version`; the value is read from the IR payload.
+- `pack-versioned-template` no longer prompts for `minVersion`; declare `minSupportedVersion` in your pack-config instead.

--- a/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
@@ -81,9 +81,8 @@ function resolveFromSingleIr(ir: IRealTimeDocumentSchema): ResolvedIrInput {
 }
 
 function deriveCompatibilityRangePath(assetOutputPath: string): string {
-  const ext = extname(assetOutputPath);
-  const stem = basename(assetOutputPath, ext);
-  return join(dirname(assetOutputPath), `${stem}-schema-compatibility-range${ext || ".json"}`);
+  const stem = basename(assetOutputPath, extname(assetOutputPath));
+  return join(dirname(assetOutputPath), `${stem}-schema-compatibility-range.json`);
 }
 
 /**

--- a/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
@@ -21,7 +21,7 @@ import { basename, dirname, extname, join, resolve } from "path";
 import type { IRealTimeDocumentSchema } from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
 import { GENERATED_JSON_COMMENT } from "../../utils/generatedFileHeader.js";
 import { convertIrToWireSchema } from "../../utils/ir/convertIrToWireSchema.js";
-import { resolveMinVersion, type VersionedIrEntry } from "../../utils/schema/resolveSchemaChain.js";
+import { type IrChainPayload, resolveMinVersion } from "../../utils/schema/resolveSchemaChain.js";
 import type { DocumentTypeAsset, FileSystemType } from "../types.js";
 
 interface IrGenAssetOptions {
@@ -34,13 +34,6 @@ interface IrGenAssetOptions {
 interface SchemaCompatibilityRangeFile {
   readonly min: number;
   readonly max: number;
-}
-
-interface IrChainPayload {
-  __comment?: string;
-  latestVersion: number;
-  minSupportedVersion?: number;
-  chain: VersionedIrEntry[];
 }
 
 interface ResolvedIrInput {

--- a/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
@@ -17,25 +17,99 @@
 import { CommanderError } from "commander";
 import { consola } from "consola";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { dirname, resolve } from "path";
+import { basename, dirname, extname, join, resolve } from "path";
 import type { IRealTimeDocumentSchema } from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
 import { GENERATED_JSON_COMMENT } from "../../utils/generatedFileHeader.js";
 import { convertIrToWireSchema } from "../../utils/ir/convertIrToWireSchema.js";
+import { resolveMinVersion, type VersionedIrEntry } from "../../utils/schema/resolveSchemaChain.js";
 import type { DocumentTypeAsset, FileSystemType } from "../types.js";
 
 interface IrGenAssetOptions {
   readonly ir: string;
   readonly output: string;
   readonly fileSystemType?: FileSystemType;
+  readonly compatibilityRangeOutput?: string;
+}
+
+interface SchemaCompatibilityRangeFile {
+  readonly min: number;
+  readonly max: number;
+}
+
+interface IrChainPayload {
+  __comment?: string;
+  latestVersion: number;
+  minSupportedVersion?: number;
+  chain: VersionedIrEntry[];
+}
+
+interface ResolvedIrInput {
+  readonly ir: IRealTimeDocumentSchema;
+  readonly latestVersion: number;
+  readonly minSupportedVersion: number;
+}
+
+function isChainPayload(parsed: unknown): parsed is IrChainPayload {
+  return (
+    typeof parsed === "object"
+    && parsed != null
+    && "chain" in parsed
+    && Array.isArray((parsed as IrChainPayload).chain)
+    && typeof (parsed as IrChainPayload).latestVersion === "number"
+  );
+}
+
+function resolveFromChain(payload: IrChainPayload, irPath: string): ResolvedIrInput {
+  if (payload.chain.length === 0) {
+    throw new CommanderError(
+      1,
+      "EINVAL",
+      `Invalid IR chain payload at ${irPath}: 'chain' is empty`,
+    );
+  }
+  const { latestVersion, minVersion } = resolveMinVersion(
+    payload.chain,
+    payload.minSupportedVersion,
+  );
+  const latestEntry = payload.chain.find(c => c.version === latestVersion);
+  if (latestEntry == null) {
+    throw new CommanderError(
+      1,
+      "EINVAL",
+      `IR chain payload at ${irPath} has no entry matching latestVersion ${latestVersion}`,
+    );
+  }
+  return { ir: latestEntry.ir, latestVersion, minSupportedVersion: minVersion };
+}
+
+function resolveFromSingleIr(ir: IRealTimeDocumentSchema): ResolvedIrInput {
+  // Legacy single-IR input has no chain, so min defaults to max (no back-compat claim).
+  return { ir, latestVersion: ir.version, minSupportedVersion: ir.version };
+}
+
+function deriveCompatibilityRangePath(assetOutputPath: string): string {
+  const ext = extname(assetOutputPath);
+  const stem = basename(assetOutputPath, ext);
+  return join(dirname(assetOutputPath), `${stem}-schema-compatibility-range${ext || ".json"}`);
 }
 
 /**
- * Generates a document type asset JSON file from an IR schema.
+ * Generates a document type asset JSON file (and a sibling schema
+ * compatibility range JSON file) from an IR schema.
  *
- * This command is intended for internal platform applications where the document
- * type asset must exist on disk so the platform can discover it and register the
- * document type automatically at deploy time. Most users should use `ir deploy`
- * to register document types via the Foundry API instead.
+ * The input IR may be either:
+ *  - a chain payload `{ latestVersion, minSupportedVersion?, chain }` produced
+ *    by `schema ir`. The latest entry's `ir` is used as the wire schema; the
+ *    asset's `schemaVersion` is `latestVersion`; the compatibility range is
+ *    `{ min: minSupportedVersion ?? latestVersion, max: latestVersion }`.
+ *  - a bare single-version `IRealTimeDocumentSchema` (legacy). The compat
+ *    range defaults to `{ min: version, max: version }` since no chain
+ *    information is available.
+ *
+ * This command is intended for internal platform applications where the
+ * document type asset must exist on disk so the platform can discover it and
+ * register the document type automatically at deploy time. Most users should
+ * use `ir deploy` to register document types via the Foundry API instead.
  *
  * If you are unsure whether you need this command, you almost certainly do not.
  */
@@ -49,11 +123,14 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
     }
 
     consola.info(`Reading IR schema from: ${irPath}`);
-    const irSchema = JSON.parse(
-      readFileSync(irPath, "utf8"),
-    ) as IRealTimeDocumentSchema;
+    const parsed = JSON.parse(readFileSync(irPath, "utf8")) as unknown;
 
-    const { name: documentTypeName, version: schemaVersion } = irSchema;
+    const resolved = isChainPayload(parsed)
+      ? resolveFromChain(parsed, irPath)
+      : resolveFromSingleIr(parsed as IRealTimeDocumentSchema);
+
+    const { ir: irSchema, latestVersion, minSupportedVersion } = resolved;
+    const { name: documentTypeName } = irSchema;
     const wireSchema = convertIrToWireSchema(irSchema);
 
     const fileSystemType = options.fileSystemType ?? "ARTIFACTS";
@@ -74,7 +151,7 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
         },
       },
       fileSystemType,
-      schemaVersion,
+      schemaVersion: latestVersion,
     };
 
     const outputDir = dirname(outputPath);
@@ -84,10 +161,33 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
     const output = { __comment: GENERATED_JSON_COMMENT, ...asset };
     writeFileSync(outputPath, JSON.stringify(output, null, 2), "utf8");
 
+    const compatibilityRange: SchemaCompatibilityRangeFile = {
+      min: minSupportedVersion,
+      max: latestVersion,
+    };
+    const compatibilityRangePath = resolve(
+      options.compatibilityRangeOutput ?? deriveCompatibilityRangePath(outputPath),
+    );
+    const compatibilityRangeDir = dirname(compatibilityRangePath);
+    if (!existsSync(compatibilityRangeDir)) {
+      mkdirSync(compatibilityRangeDir, { recursive: true });
+    }
+    const compatibilityRangeOutput = {
+      __comment: GENERATED_JSON_COMMENT,
+      ...compatibilityRange,
+    };
+    writeFileSync(
+      compatibilityRangePath,
+      JSON.stringify(compatibilityRangeOutput, null, 2),
+      "utf8",
+    );
+
     consola.success("Successfully generated document type asset");
     consola.info(`   Output: ${outputPath}`);
+    consola.info(`   Compatibility range output: ${compatibilityRangePath}`);
     consola.info(`   Document type: ${documentTypeName}`);
-    consola.info(`   Schema version: ${schemaVersion}`);
+    consola.info(`   Schema version: ${latestVersion}`);
+    consola.info(`   Compatibility range: [${minSupportedVersion}, ${latestVersion}]`);
     consola.info(`   File system type: ${fileSystemType}`);
   } catch (error) {
     if (error instanceof CommanderError) {

--- a/packages/document-schema/type-gen/src/commands/ir/irGenTypesHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenTypesHandler.ts
@@ -17,19 +17,12 @@
 import { consola } from "consola";
 import fs from "fs-extra";
 import path from "path";
-import { resolveMinVersion, type VersionedIrEntry } from "../../utils/schema/resolveSchemaChain.js";
+import { type IrChainPayload, resolveMinVersion } from "../../utils/schema/resolveSchemaChain.js";
 import { writeAllSdkFiles } from "../../utils/schema/writeAllSdkFiles.js";
 
 interface IrGenTypesOptions {
   schema: string;
   output: string;
-}
-
-interface IrChainPayload {
-  __comment?: string;
-  latestVersion: number;
-  minSupportedVersion?: number;
-  chain: VersionedIrEntry[];
 }
 
 export async function irGenTypesHandler(options: IrGenTypesOptions): Promise<void> {

--- a/packages/document-schema/type-gen/src/commands/ir/irGenTypesHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenTypesHandler.ts
@@ -18,17 +18,17 @@ import { consola } from "consola";
 import fs from "fs-extra";
 import path from "path";
 import { resolveMinVersion, type VersionedIrEntry } from "../../utils/schema/resolveSchemaChain.js";
-import { parseMinVersion, writeAllSdkFiles } from "../../utils/schema/writeAllSdkFiles.js";
+import { writeAllSdkFiles } from "../../utils/schema/writeAllSdkFiles.js";
 
 interface IrGenTypesOptions {
   schema: string;
   output: string;
-  minVersion?: string;
 }
 
 interface IrChainPayload {
   __comment?: string;
   latestVersion: number;
+  minSupportedVersion?: number;
   chain: VersionedIrEntry[];
 }
 
@@ -47,7 +47,7 @@ export async function irGenTypesHandler(options: IrGenTypesOptions): Promise<voi
     throw new Error(`Invalid IR chain payload at ${inputPath}: missing non-empty 'chain' array`);
   }
 
-  const minSupportedVersion = parseMinVersion(options.minVersion);
+  const { minSupportedVersion } = payload;
   const { latestVersion, minVersion } = resolveMinVersion(payload.chain, minSupportedVersion);
   const resolved = { chain: payload.chain, latestVersion, minVersion };
 

--- a/packages/document-schema/type-gen/src/commands/ir/registerIrCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/registerIrCommands.ts
@@ -29,11 +29,10 @@ export function registerIrCommands(program: Command): void {
   irCmd
     .command("gen-types")
     .description(
-      "Generate versioned SDK files (types, schemas, internal/, models.ts, versions.ts, versionedDocRef.ts, index.ts) from a versioned IR chain JSON",
+      "Generate versioned SDK files (types, schemas, internal/, models.ts, versions.ts, versionedDocRef.ts, index.ts) from a versioned IR chain JSON. The minimum supported schema version is sourced from the IR payload's 'minSupportedVersion' field (set by 'schema ir --min-version').",
     )
     .requiredOption("-s, --schema <file>", "Path to versioned IR chain JSON file")
     .requiredOption("-o, --output <dir>", "Output directory for generated SDK files")
-    .option("--min-version <version>", "Minimum supported version")
     .action(irGenTypesHandler);
 
   irCmd
@@ -80,14 +79,21 @@ export function registerIrCommands(program: Command): void {
   irCmd
     .command("asset")
     .description(
-      "Generate document type asset JSON from IR schema (advanced — most users should use 'ir deploy' instead)",
+      "Generate document type asset JSON and a sibling schema compatibility range JSON from an IR file (advanced — most users should use 'ir deploy' instead). The minimum supported schema version is sourced from the IR payload's 'minSupportedVersion' field (set by 'schema ir --min-version'); legacy single-IR inputs default to min == max.",
     )
-    .requiredOption("-i, --ir <file>", "Path to IR JSON file")
+    .requiredOption(
+      "-i, --ir <file>",
+      "Path to IR JSON file (chain payload from 'schema ir', or legacy single-version IR)",
+    )
     .requiredOption("-o, --output <file>", "Output file path for asset JSON")
     .option(
       "-f, --file-system-type <type>",
       "File system type (ARTIFACTS or COMPASS)",
       "ARTIFACTS",
+    )
+    .option(
+      "--compatibility-range-output <file>",
+      "Output path for the schema compatibility range JSON (defaults to a sibling of --output with '-schema-compatibility-range' suffix)",
     )
     .action(irGenAssetHandler);
 }

--- a/packages/document-schema/type-gen/src/commands/ir/registerIrCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/registerIrCommands.ts
@@ -29,7 +29,7 @@ export function registerIrCommands(program: Command): void {
   irCmd
     .command("gen-types")
     .description(
-      "Generate versioned SDK files (types, schemas, internal/, models.ts, versions.ts, versionedDocRef.ts, index.ts) from a versioned IR chain JSON. The minimum supported schema version is sourced from the IR payload's 'minSupportedVersion' field (set by 'schema ir --min-version').",
+      "Generate versioned SDK files (types, schemas, internal/, models.ts, versions.ts, versionedDocRef.ts, index.ts) from a versioned IR chain JSON. The minimum supported schema version is sourced from the IR payload's 'minSupportedVersion' field (set by 'schema ir --config <pack-config.json>').",
     )
     .requiredOption("-s, --schema <file>", "Path to versioned IR chain JSON file")
     .requiredOption("-o, --output <dir>", "Output directory for generated SDK files")
@@ -79,7 +79,7 @@ export function registerIrCommands(program: Command): void {
   irCmd
     .command("asset")
     .description(
-      "Generate document type asset JSON and a sibling schema compatibility range JSON from an IR file (advanced — most users should use 'ir deploy' instead). The minimum supported schema version is sourced from the IR payload's 'minSupportedVersion' field (set by 'schema ir --min-version'); legacy single-IR inputs default to min == max.",
+      "Generate document type asset JSON and a sibling schema compatibility range JSON from an IR file (advanced — most users should use 'ir deploy' instead). The minimum supported schema version is sourced from the IR payload's 'minSupportedVersion' field (set by 'schema ir --config <pack-config.json>'); legacy single-IR inputs default to min == max.",
     )
     .requiredOption(
       "-i, --ir <file>",

--- a/packages/document-schema/type-gen/src/commands/ir/registerIrCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/registerIrCommands.ts
@@ -29,7 +29,7 @@ export function registerIrCommands(program: Command): void {
   irCmd
     .command("gen-types")
     .description(
-      "Generate versioned SDK files (types, schemas, internal/, models.ts, versions.ts, versionedDocRef.ts, index.ts) from a versioned IR chain JSON. The minimum supported schema version is sourced from the IR payload's 'minSupportedVersion' field (set by 'schema ir --config <pack-config.json>').",
+      "Generate versioned SDK files (types, schemas, internal/, models.ts, versions.ts, versionedDocRef.ts, index.ts) from a versioned IR chain JSON.",
     )
     .requiredOption("-s, --schema <file>", "Path to versioned IR chain JSON file")
     .requiredOption("-o, --output <dir>", "Output directory for generated SDK files")

--- a/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
@@ -35,5 +35,9 @@ export function registerSchemaCommands(program: Command): void {
     .description("Resolve a TypeScript schema module to a versioned IR chain JSON file")
     .requiredOption("-i, --input <file>", "Input TypeScript/JavaScript schema module")
     .requiredOption("-o, --output <file>", "Output IR chain JSON file")
+    .option(
+      "--config <file>",
+      "Path to the SDK's pack-config JSON file. Its 'minSupportedVersion' field is the single source of truth for the minimum supported schema version; the resolved value must match one of the chain's versions and is embedded in the output IR payload so downstream consumers ('ir gen-types', 'ir asset') read the same value.",
+    )
     .action(schemaIrHandler);
 }

--- a/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
@@ -35,9 +35,9 @@ export function registerSchemaCommands(program: Command): void {
     .description("Resolve a TypeScript schema module to a versioned IR chain JSON file")
     .requiredOption("-i, --input <file>", "Input TypeScript/JavaScript schema module")
     .requiredOption("-o, --output <file>", "Output IR chain JSON file")
-    .option(
+    .requiredOption(
       "--config <file>",
-      "Path to the SDK's pack-config JSON file containing the minSupportedVersion.",
+      "Path to the SDK's pack-config JSON file. Its optional 'minSupportedVersion' field declares the oldest schema version this SDK supports; omit the field to track latest only.",
     )
     .action(schemaIrHandler);
 }

--- a/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
@@ -37,7 +37,7 @@ export function registerSchemaCommands(program: Command): void {
     .requiredOption("-o, --output <file>", "Output IR chain JSON file")
     .option(
       "--config <file>",
-      "Path to the SDK's pack-config JSON file. Its 'minSupportedVersion' field is the single source of truth for the minimum supported schema version; the resolved value must match one of the chain's versions and is embedded in the output IR payload so downstream consumers ('ir gen-types', 'ir asset') read the same value.",
+      "Path to the SDK's pack-config JSON file containing the minSupportedVersion.",
     )
     .action(schemaIrHandler);
 }

--- a/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
@@ -19,27 +19,74 @@ import fs from "fs-extra";
 import path from "path";
 import { GENERATED_JSON_COMMENT } from "../../utils/generatedFileHeader.js";
 import { loadSchemaModule } from "../../utils/schema/loadSchemaModule.js";
-import { resolveSchemaChain } from "../../utils/schema/resolveSchemaChain.js";
+import { resolveMinVersion, resolveSchemaChain } from "../../utils/schema/resolveSchemaChain.js";
 
 interface SchemaIrOptions {
   input: string;
   output: string;
+  config?: string;
+}
+
+interface PackConfigLike {
+  minSupportedVersion?: unknown;
+}
+
+async function readMinVersionFromConfig(configPath: string): Promise<number | undefined> {
+  const resolvedConfigPath = path.resolve(configPath);
+  if (!(await fs.pathExists(resolvedConfigPath))) {
+    throw new Error(`--config file not found: ${resolvedConfigPath}`);
+  }
+  const config = (await fs.readJson(resolvedConfigPath)) as PackConfigLike;
+  const raw = config.minSupportedVersion;
+  if (raw == null) return undefined;
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw <= 0) {
+    throw new Error(
+      `'minSupportedVersion' in ${resolvedConfigPath} must be a positive integer, got: ${
+        JSON.stringify(raw)
+      }`,
+    );
+  }
+  return raw;
 }
 
 /**
  * Resolve a TypeScript schema module to a versioned IR chain JSON file.
  *
- * The output is a `{ latestVersion, chain }` payload where each entry is
- * `{ version, ir, migrations? }` and `ir` is a single-version
- * `IRealTimeDocumentSchema`. This is the input format for `ir gen-types`.
+ * The output is a `{ latestVersion, minSupportedVersion?, chain }` payload
+ * where each entry is `{ version, ir, migrations? }` and `ir` is a
+ * single-version `IRealTimeDocumentSchema`. This is the input format for
+ * `ir gen-types` and `ir asset`.
+ *
+ * The minimum supported schema version is sourced exclusively from the SDK's
+ * pack-config file via `--config <pack-config.json>` (reading its `minSupportedVersion`
+ * field). When provided, the value must match one of the chain entries'
+ * `version` values; it is then embedded as `minSupportedVersion` in the
+ * payload so downstream consumers (`ir gen-types`, `ir asset`) read the same
+ * value without needing it forwarded to them. The pack-config is the single
+ * source of truth for the minimum supported version.
  *
  * Note: this is distinct from the legacy single-version IR JSON consumed by
- * `ir deploy` / `ir asset` / `ir zod`, which is a bare `IRealTimeDocumentSchema`
- * (no chain, no migrations). Tools that previously read that format should
- * pick the entry matching `latestVersion` from `chain` and use its `ir` field.
+ * `ir deploy` / `ir zod`, which is a bare `IRealTimeDocumentSchema` (no chain,
+ * no migrations). Tools that previously read that format should pick the
+ * entry matching `latestVersion` from `chain` and use its `ir` field.
  */
 export async function schemaIrHandler(options: SchemaIrOptions): Promise<void> {
   const { input, output } = options;
+  const minSupportedVersion = options.config != null
+    ? await readMinVersionFromConfig(options.config)
+    : undefined;
+
+  if (options.config == null) {
+    consola.warn(
+      "No --config provided. The generated IR will not include 'minSupportedVersion', so downstream tools (ir gen-types, ir asset) will default to supporting only the latest schema version. Pass --config <pack-config.json> with a 'minSupportedVersion' field to enable back-compat.",
+    );
+  } else if (minSupportedVersion == null) {
+    consola.warn(
+      `--config was provided but no 'minSupportedVersion' field is set in ${
+        path.resolve(options.config)
+      }. The generated IR will not include 'minSupportedVersion', so downstream tools (ir gen-types, ir asset) will default to supporting only the latest schema version. Add 'minSupportedVersion' to your pack-config to enable back-compat.`,
+    );
+  }
 
   consola.info(`Loading schema from: ${input}`);
   const schema = await loadSchemaModule(input);
@@ -47,15 +94,22 @@ export async function schemaIrHandler(options: SchemaIrOptions): Promise<void> {
   consola.info("Resolving versioned IR chain...");
   const { chain, latestVersion } = resolveSchemaChain(schema);
 
+  resolveMinVersion(chain, minSupportedVersion);
+
   const outputPath = path.resolve(output);
   await fs.ensureDir(path.dirname(outputPath));
 
   const payload = {
     __comment: GENERATED_JSON_COMMENT,
     latestVersion,
+    ...(minSupportedVersion != null ? { minSupportedVersion } : {}),
     chain,
   };
   await fs.writeFile(outputPath, JSON.stringify(payload, null, 2) + "\n", "utf8");
 
-  consola.success(`Wrote IR chain (${chain.length} version(s)) to: ${outputPath}`);
+  consola.success(
+    `Wrote IR chain (${chain.length} version(s), min=${
+      minSupportedVersion ?? latestVersion
+    }, max=${latestVersion}) to: ${outputPath}`,
+  );
 }

--- a/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
@@ -19,7 +19,7 @@ import fs from "fs-extra";
 import path from "path";
 import { GENERATED_JSON_COMMENT } from "../../utils/generatedFileHeader.js";
 import { loadSchemaModule } from "../../utils/schema/loadSchemaModule.js";
-import { resolveMinVersion, resolveSchemaChain } from "../../utils/schema/resolveSchemaChain.js";
+import { resolveSchemaChain } from "../../utils/schema/resolveSchemaChain.js";
 
 interface SchemaIrOptions {
   input: string;
@@ -92,9 +92,7 @@ export async function schemaIrHandler(options: SchemaIrOptions): Promise<void> {
   const schema = await loadSchemaModule(input);
 
   consola.info("Resolving versioned IR chain...");
-  const { chain, latestVersion } = resolveSchemaChain(schema);
-
-  resolveMinVersion(chain, minSupportedVersion);
+  const { chain, latestVersion } = resolveSchemaChain(schema, minSupportedVersion);
 
   const outputPath = path.resolve(output);
   await fs.ensureDir(path.dirname(outputPath));

--- a/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
@@ -24,7 +24,7 @@ import { resolveSchemaChain } from "../../utils/schema/resolveSchemaChain.js";
 interface SchemaIrOptions {
   input: string;
   output: string;
-  config?: string;
+  config: string;
 }
 
 interface PackConfigLike {
@@ -57,13 +57,14 @@ async function readMinVersionFromConfig(configPath: string): Promise<number | un
  * single-version `IRealTimeDocumentSchema`. This is the input format for
  * `ir gen-types` and `ir asset`.
  *
- * The minimum supported schema version is sourced exclusively from the SDK's
- * pack-config file via `--config <pack-config.json>` (reading its `minSupportedVersion`
- * field). When provided, the value must match one of the chain entries'
- * `version` values; it is then embedded as `minSupportedVersion` in the
- * payload so downstream consumers (`ir gen-types`, `ir asset`) read the same
- * value without needing it forwarded to them. The pack-config is the single
- * source of truth for the minimum supported version.
+ * `--config <pack-config.json>` is required: the pack-config is the single
+ * source of truth for the minimum supported schema version. Its optional
+ * `minSupportedVersion` field declares the oldest version this SDK supports;
+ * when set, it must match one of the chain entries' `version` values and is
+ * embedded as `minSupportedVersion` in the payload so downstream consumers
+ * (`ir gen-types`, `ir asset`) read the same value. Omitting the field is
+ * an explicit opt-out: the IR will not include `minSupportedVersion` and
+ * downstream tools default to supporting only the latest schema version.
  *
  * Note: this is distinct from the legacy single-version IR JSON consumed by
  * `ir deploy` / `ir zod`, which is a bare `IRealTimeDocumentSchema` (no chain,
@@ -71,20 +72,14 @@ async function readMinVersionFromConfig(configPath: string): Promise<number | un
  * entry matching `latestVersion` from `chain` and use its `ir` field.
  */
 export async function schemaIrHandler(options: SchemaIrOptions): Promise<void> {
-  const { input, output } = options;
-  const minSupportedVersion = options.config != null
-    ? await readMinVersionFromConfig(options.config)
-    : undefined;
+  const { input, output, config } = options;
+  const minSupportedVersion = await readMinVersionFromConfig(config);
 
-  if (options.config == null) {
+  if (minSupportedVersion == null) {
     consola.warn(
-      "No --config provided. The generated IR will not include 'minSupportedVersion', so downstream tools (ir gen-types, ir asset) will default to supporting only the latest schema version. Pass --config <pack-config.json> with a 'minSupportedVersion' field to enable back-compat.",
-    );
-  } else if (minSupportedVersion == null) {
-    consola.warn(
-      `--config was provided but no 'minSupportedVersion' field is set in ${
-        path.resolve(options.config)
-      }. The generated IR will not include 'minSupportedVersion', so downstream tools (ir gen-types, ir asset) will default to supporting only the latest schema version. Add 'minSupportedVersion' to your pack-config to enable back-compat.`,
+      `--config ${
+        path.resolve(config)
+      } does not set 'minSupportedVersion'. The generated IR will not include it, so downstream tools (ir gen-types, ir asset) will default to supporting only the latest schema version. Add 'minSupportedVersion' to your pack-config to enable back-compat.`,
     );
   }
 

--- a/packages/document-schema/type-gen/src/utils/schema/resolveSchemaChain.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/resolveSchemaChain.ts
@@ -41,6 +41,13 @@ export interface ResolvedIrChain {
   minVersion: number;
 }
 
+export interface IrChainPayload {
+  __comment?: string;
+  latestVersion: number;
+  minSupportedVersion?: number;
+  chain: VersionedIrEntry[];
+}
+
 function collectVersionedIrChain(input: SchemaDefinition): VersionedIrEntry[] {
   const chain: VersionedIrEntry[] = [];
   let current: SchemaDefinition = input;

--- a/packages/document-schema/type-gen/src/utils/schema/writeAllSdkFiles.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/writeAllSdkFiles.ts
@@ -108,12 +108,3 @@ export async function writeAllSdkFiles(
   await fs.writeFile(versionedDocRefPath, versionedDocRefContent, "utf8");
   consola.success(`Generated versioned doc ref: ${versionedDocRefPath}`);
 }
-
-export function parseMinVersion(minVersion: string | undefined): number | undefined {
-  if (minVersion == null) return undefined;
-  const parsed = parseInt(minVersion, 10);
-  if (isNaN(parsed)) {
-    throw new Error(`--min-version must be a valid integer, got: "${minVersion}"`);
-  }
-  return parsed;
-}

--- a/packages/sdkgen/sdkgen-pack-versioned-template/src/config.ts
+++ b/packages/sdkgen/sdkgen-pack-versioned-template/src/config.ts
@@ -37,11 +37,6 @@ export const config = {
       message: "Author:",
       default: "",
     },
-    {
-      type: "number",
-      name: "minVersion",
-      message: "Minimum supported schema version (leave blank to track latest):",
-    },
   ] as const,
   hooks: {
     afterGenerate: "./build/esm/hooks/afterGenerate.js",

--- a/packages/sdkgen/sdkgen-pack-versioned-template/src/hooks/afterGenerate.ts
+++ b/packages/sdkgen/sdkgen-pack-versioned-template/src/hooks/afterGenerate.ts
@@ -24,7 +24,6 @@ interface HookContext {
   outputPath: string;
   schema: unknown;
   schemaPath?: string;
-  answers?: Readonly<Record<string, unknown>>;
   options: { dryRun?: boolean; skipInstall?: boolean };
 }
 
@@ -70,23 +69,8 @@ async function syncModelTypesVersion(
   }
 }
 
-function readMinVersion(
-  answers: Readonly<Record<string, unknown>> | undefined,
-): number | undefined {
-  const raw = answers?.minVersion;
-  if (raw == null || raw === "") return undefined;
-  if (typeof raw !== "number" && typeof raw !== "string") {
-    throw new Error(`minVersion answer must be a number or numeric string`);
-  }
-  const value = typeof raw === "number" ? raw : Number(raw);
-  if (!Number.isInteger(value)) {
-    throw new Error(`minVersion answer must be an integer, got: ${raw}`);
-  }
-  return value;
-}
-
 export default async function afterGenerate(context: HookContext): Promise<void> {
-  const { outputPath, schemaPath, answers, options } = context;
+  const { outputPath, schemaPath, options } = context;
 
   if (options.dryRun) return;
   if (schemaPath == null) {
@@ -103,8 +87,6 @@ export default async function afterGenerate(context: HookContext): Promise<void>
   const resolvedIr = path.resolve(schemaPath);
   const { cli: typeGenCli, packageJsonPath: typeGenPackageJsonPath } = resolveTypeGenCli();
 
-  const minVersion = readMinVersion(answers);
-
   consola.log("Generating versioned SDK files from IR...");
   const genArgs = [
     "ir",
@@ -114,9 +96,6 @@ export default async function afterGenerate(context: HookContext): Promise<void>
     "-o",
     path.join(outputPath, "src"),
   ];
-  if (minVersion != null) {
-    genArgs.push("--min-version", String(minVersion));
-  }
   const genResult = spawnSync(typeGenCli, genArgs, { stdio: "inherit", cwd: outputPath });
   if (genResult.status !== 0) {
     throw new Error(


### PR DESCRIPTION
Plumb `minSupportedVersion` through the schema → IR → SDK / asset pipeline as a single source of truth, and emit a schema-compatibility-range file alongside the asset JSON.

Before this change, the min version was forwarded via the sdkgen template's afterGenerate hook, and no compatibility-range file was generated. The generated file is required for first party apps and will be discovered by the backend to compute the operational versions.
