### PR TITLE
provide optional ontologyRid param in create doc metadata

### DIFF
--- a/.changeset/ontology-rid-per-create.md
+++ b/.changeset/ontology-rid-per-create.md
@@ -1,0 +1,11 @@
+---
+"@palantir/pack.state.foundry": minor
+"@palantir/pack.state.core": minor
+---
+
+Allow `createDocument` to target a specific ontology via `CreateDocumentMetadata.ontologyRid`.
+
+When provided, the document is created in that ontology (the target ontology travels in the create
+request body); when omitted, the app's default ontology is used. This lets multi-tenant hosts create
+documents in different ontologies without a separate OSDK client per ontology — the app's single
+client is used regardless, since its bound ontology does not affect document creation.

--- a/packages/state/core/src/types/CreateDocumentMetadata.ts
+++ b/packages/state/core/src/types/CreateDocumentMetadata.ts
@@ -21,6 +21,13 @@ export interface CreateDocumentMetadata {
   readonly documentTypeName: string;
   readonly security?: DocumentSecurity;
   readonly parentFolderRid?: string;
+  /**
+   * Ontology to create the document in. When omitted, the app's default ontology is used. Provide
+   * this to create in a different ontology (e.g. multi-tenant hosts that pick an ontology per
+   * document); the document's target ontology travels in the create request, so the app's OSDK
+   * client does not need to be bound to it.
+   */
+  readonly ontologyRid?: string;
 }
 
 export const FileSystemType = {

--- a/packages/state/demo/src/DemoDocumentService.ts
+++ b/packages/state/demo/src/DemoDocumentService.ts
@@ -182,11 +182,16 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
   }
 
   readonly createDocument = async <T extends DocumentSchema>(
-    { documentTypeName, name, security = EMPTY_DOCUMENT_SECURITY }: CreateDocumentMetadata,
+    {
+      documentTypeName,
+      name,
+      security = EMPTY_DOCUMENT_SECURITY,
+      ontologyRid: metadataOntologyRid,
+    }: CreateDocumentMetadata,
     schema: T,
   ): Promise<DocumentRef<T>> => {
     await this.metadataStore.whenReady();
-    const ontologyRid = await getOntologyRid(this.app);
+    const ontologyRid = metadataOntologyRid ?? await getOntologyRid(this.app);
 
     const id = generateDocumentId();
     const docRef = createDocRef(this.app, id, schema);

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -139,7 +139,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     schema: T,
   ): Promise<DocumentRef<T>> => {
     const { documentTypeName, name, parentFolderRid, security } = metadata;
-    const ontologyRid = await getOntologyRid(this.app);
+    const ontologyRid = metadata.ontologyRid ?? await getOntologyRid(this.app);
 
     const request: CreateDocumentRequest = {
       documentTypeName: documentTypeName,


### PR DESCRIPTION
Create Document requires ontologyRid, which for certain first-party apps, may change depending on the chosen ontologyRid (multi-ontology hosts). To keep the api simple to accommodate such environments, callers of createDocument can pass in the specified ontologyRid to use for creating the Document, instead of the one bound to the app/osdk client create api doesn't use the ontologyRid bound to osdkclient).