### PR TITLE
include addedInVersion for each updated field and deprecatedFromVersion in schema

### DIFF
--- a/.changeset/itchy-snakes-walk.md
+++ b/.changeset/itchy-snakes-walk.md
@@ -1,0 +1,6 @@
+---
+"@palantir/pack.document-schema.type-gen": minor
+"@palantir/pack.schema": minor
+---
+
+included versions for added fields and models and deprecations

--- a/demos/canvas/schema/src/schema.mjs
+++ b/demos/canvas/schema/src/schema.mjs
@@ -135,13 +135,13 @@ const splitShapeColorIntoFillAndStroke = S.defineSchemaUpdate(
     const ShapeBox = schema.ShapeBox
       .addField("fillColor", S.Optional(S.String), { derivedFrom: ["color"] })
       .addField("strokeColor", S.Optional(S.String), { derivedFrom: ["color"] })
-      .deprecateField("color")
+      .deprecateField("color", "Use fillColor and strokeColor instead.")
       .build();
 
     const ShapeCircle = schema.ShapeCircle
       .addField("fillColor", S.Optional(S.String), { derivedFrom: ["color"] })
       .addField("strokeColor", S.Optional(S.String), { derivedFrom: ["color"] })
-      .deprecateField("color")
+      .deprecateField("color", "Use fillColor and strokeColor instead.")
       .build();
 
     return { ShapeBox, ShapeCircle };

--- a/demos/canvas/schema/src/schema.mjs
+++ b/demos/canvas/schema/src/schema.mjs
@@ -135,13 +135,13 @@ const splitShapeColorIntoFillAndStroke = S.defineSchemaUpdate(
     const ShapeBox = schema.ShapeBox
       .addField("fillColor", S.Optional(S.String), { derivedFrom: ["color"] })
       .addField("strokeColor", S.Optional(S.String), { derivedFrom: ["color"] })
-      .removeField("color")
+      .deprecateField("color")
       .build();
 
     const ShapeCircle = schema.ShapeCircle
       .addField("fillColor", S.Optional(S.String), { derivedFrom: ["color"] })
       .addField("strokeColor", S.Optional(S.String), { derivedFrom: ["color"] })
-      .removeField("color")
+      .deprecateField("color")
       .build();
 
     return { ShapeBox, ShapeCircle };

--- a/demos/canvas/sdk/schema/ir.json
+++ b/demos/canvas/sdk/schema/ir.json
@@ -6,7 +6,7 @@
     {
       "version": 1,
       "ir": {
-        "name": "Canvas Document Type",
+        "name": "com.palantir.pack.demo.migration-doctype5",
         "description": "Document type description for demo canvas",
         "version": 1,
         "primaryModelKeys": [
@@ -395,7 +395,7 @@
     {
       "version": 2,
       "ir": {
-        "name": "Canvas Document Type",
+        "name": "com.palantir.pack.demo.migration-doctype5",
         "description": "Document type description for demo canvas",
         "version": 2,
         "primaryModelKeys": [
@@ -500,7 +500,8 @@
                   },
                   "metadata": {
                     "addedInVersion": 1,
-                    "deprecatedFromVersion": 2
+                    "deprecatedFromVersion": 2,
+                    "deprecatedMessage": "Use fillColor and strokeColor instead."
                   },
                   "isOptional": true
                 },
@@ -627,7 +628,8 @@
                   },
                   "metadata": {
                     "addedInVersion": 1,
-                    "deprecatedFromVersion": 2
+                    "deprecatedFromVersion": 2,
+                    "deprecatedMessage": "Use fillColor and strokeColor instead."
                   },
                   "isOptional": true
                 },
@@ -902,7 +904,7 @@
     {
       "version": 3,
       "ir": {
-        "name": "Canvas Document Type",
+        "name": "com.palantir.pack.demo.migration-doctype5",
         "description": "Document type description for demo canvas",
         "version": 3,
         "primaryModelKeys": [
@@ -1008,7 +1010,8 @@
                   },
                   "metadata": {
                     "addedInVersion": 1,
-                    "deprecatedFromVersion": 2
+                    "deprecatedFromVersion": 2,
+                    "deprecatedMessage": "Use fillColor and strokeColor instead."
                   },
                   "isOptional": true
                 },
@@ -1135,7 +1138,8 @@
                   },
                   "metadata": {
                     "addedInVersion": 1,
-                    "deprecatedFromVersion": 2
+                    "deprecatedFromVersion": 2,
+                    "deprecatedMessage": "Use fillColor and strokeColor instead."
                   },
                   "isOptional": true
                 },

--- a/demos/canvas/sdk/schema/ir.json
+++ b/demos/canvas/sdk/schema/ir.json
@@ -6,7 +6,7 @@
     {
       "version": 1,
       "ir": {
-        "name": "com.palantir.pack.demo.migration-doctype5",
+        "name": "Canvas Document Type",
         "description": "Document type description for demo canvas",
         "version": 1,
         "primaryModelKeys": [
@@ -395,7 +395,7 @@
     {
       "version": 2,
       "ir": {
-        "name": "com.palantir.pack.demo.migration-doctype5",
+        "name": "Canvas Document Type",
         "description": "Document type description for demo canvas",
         "version": 2,
         "primaryModelKeys": [
@@ -904,7 +904,7 @@
     {
       "version": 3,
       "ir": {
-        "name": "com.palantir.pack.demo.migration-doctype5",
+        "name": "Canvas Document Type",
         "description": "Document type description for demo canvas",
         "version": 3,
         "primaryModelKeys": [

--- a/demos/canvas/sdk/schema/ir.json
+++ b/demos/canvas/sdk/schema/ir.json
@@ -6,7 +6,7 @@
     {
       "version": 1,
       "ir": {
-        "name": "com.palantir.pack.demo.migration-doctype3",
+        "name": "Canvas Document Type",
         "description": "Document type description for demo canvas",
         "version": 1,
         "primaryModelKeys": [
@@ -395,7 +395,7 @@
     {
       "version": 2,
       "ir": {
-        "name": "com.palantir.pack.demo.migration-doctype3",
+        "name": "Canvas Document Type",
         "description": "Document type description for demo canvas",
         "version": 2,
         "primaryModelKeys": [
@@ -902,7 +902,7 @@
     {
       "version": 3,
       "ir": {
-        "name": "com.palantir.pack.demo.migration-doctype3",
+        "name": "Canvas Document Type",
         "description": "Document type description for demo canvas",
         "version": 3,
         "primaryModelKeys": [

--- a/demos/canvas/sdk/schema/ir.json
+++ b/demos/canvas/sdk/schema/ir.json
@@ -6,7 +6,7 @@
     {
       "version": 1,
       "ir": {
-        "name": "Canvas Document Type",
+        "name": "com.palantir.pack.demo.migration-doctype3",
         "description": "Document type description for demo canvas",
         "version": 1,
         "primaryModelKeys": [
@@ -395,7 +395,7 @@
     {
       "version": 2,
       "ir": {
-        "name": "Canvas Document Type",
+        "name": "com.palantir.pack.demo.migration-doctype3",
         "description": "Document type description for demo canvas",
         "version": 2,
         "primaryModelKeys": [
@@ -489,6 +489,22 @@
                   }
                 },
                 {
+                  "key": "color",
+                  "name": "color",
+                  "fieldType": {
+                    "value": {
+                      "string": {},
+                      "type": "string"
+                    },
+                    "type": "value"
+                  },
+                  "metadata": {
+                    "addedInVersion": 1,
+                    "deprecatedFromVersion": 2
+                  },
+                  "isOptional": true
+                },
+                {
                   "key": "fillColor",
                   "name": "fillColor",
                   "fieldType": {
@@ -499,7 +515,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 },
@@ -514,7 +530,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 },
@@ -529,7 +545,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 }
@@ -600,6 +616,22 @@
                   }
                 },
                 {
+                  "key": "color",
+                  "name": "color",
+                  "fieldType": {
+                    "value": {
+                      "string": {},
+                      "type": "string"
+                    },
+                    "type": "value"
+                  },
+                  "metadata": {
+                    "addedInVersion": 1,
+                    "deprecatedFromVersion": 2
+                  },
+                  "isOptional": true
+                },
+                {
                   "key": "fillColor",
                   "name": "fillColor",
                   "fieldType": {
@@ -610,7 +642,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 },
@@ -625,7 +657,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 },
@@ -640,7 +672,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 }
@@ -870,7 +902,7 @@
     {
       "version": 3,
       "ir": {
-        "name": "Canvas Document Type",
+        "name": "com.palantir.pack.demo.migration-doctype3",
         "description": "Document type description for demo canvas",
         "version": 3,
         "primaryModelKeys": [
@@ -965,6 +997,22 @@
                   }
                 },
                 {
+                  "key": "color",
+                  "name": "color",
+                  "fieldType": {
+                    "value": {
+                      "string": {},
+                      "type": "string"
+                    },
+                    "type": "value"
+                  },
+                  "metadata": {
+                    "addedInVersion": 1,
+                    "deprecatedFromVersion": 2
+                  },
+                  "isOptional": true
+                },
+                {
                   "key": "fillColor",
                   "name": "fillColor",
                   "fieldType": {
@@ -975,7 +1023,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 },
@@ -990,7 +1038,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 },
@@ -1005,7 +1053,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 }
@@ -1076,6 +1124,22 @@
                   }
                 },
                 {
+                  "key": "color",
+                  "name": "color",
+                  "fieldType": {
+                    "value": {
+                      "string": {},
+                      "type": "string"
+                    },
+                    "type": "value"
+                  },
+                  "metadata": {
+                    "addedInVersion": 1,
+                    "deprecatedFromVersion": 2
+                  },
+                  "isOptional": true
+                },
+                {
                   "key": "fillColor",
                   "name": "fillColor",
                   "fieldType": {
@@ -1086,7 +1150,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 },
@@ -1101,7 +1165,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 },
@@ -1116,7 +1180,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 2
                   },
                   "isOptional": true
                 }
@@ -1331,7 +1395,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 3
                   }
                 },
                 {
@@ -1345,7 +1409,7 @@
                     "type": "value"
                   },
                   "metadata": {
-                    "addedInVersion": 1
+                    "addedInVersion": 3
                   },
                   "isOptional": true
                 }

--- a/packages/document-schema/type-gen/src/commands/ir/irGenTypesHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenTypesHandler.ts
@@ -17,7 +17,11 @@
 import { consola } from "consola";
 import fs from "fs-extra";
 import path from "path";
-import { type IrChainPayload, resolveMinVersion } from "../../utils/schema/resolveSchemaChain.js";
+import {
+  type IrChainPayload,
+  resolveMinVersion,
+  stripDeprecatedFieldsForSdk,
+} from "../../utils/schema/resolveSchemaChain.js";
 import { writeAllSdkFiles } from "../../utils/schema/writeAllSdkFiles.js";
 
 interface IrGenTypesOptions {
@@ -42,7 +46,8 @@ export async function irGenTypesHandler(options: IrGenTypesOptions): Promise<voi
 
   const { minSupportedVersion } = payload;
   const { latestVersion, minVersion } = resolveMinVersion(payload.chain, minSupportedVersion);
-  const resolved = { chain: payload.chain, latestVersion, minVersion };
+  const chain = stripDeprecatedFieldsForSdk(payload.chain);
+  const resolved = { chain, latestVersion, minVersion };
 
   const resolvedOutputDir = path.resolve(outputDir);
   await writeAllSdkFiles(resolved, resolvedOutputDir, minSupportedVersion);

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/provenanceScenarios.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/provenanceScenarios.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { defineRecord, defineSchema, defineSchemaUpdate, nextSchema } from "@palantir/pack.schema";
 import * as P from "@palantir/pack.schema";
+import { defineRecord, defineSchema, defineSchemaUpdate, nextSchema } from "@palantir/pack.schema";
 import { describe, expect, it } from "vitest";
 import type {
   IFieldDef,
@@ -43,7 +43,6 @@ function unionMeta(e: VersionedIrEntry, key: string) {
 }
 
 describe("provenance — scenarios beyond the demo", () => {
-  // v1: Box(a) + one v1 union.
   const v1 = defineSchema({
     Box: defineRecord("Box", { docs: "", fields: { a: P.Double } }),
     OldUnion: P.defineUnion("OldUnion", {
@@ -52,7 +51,6 @@ describe("provenance — scenarios beyond the demo", () => {
     }),
   });
 
-  // v2: add a NEW record (Circle) AND a NEW union (NewUnion); add field b to Box.
   const v2update = defineSchemaUpdate("v2", (s: P.SchemaBuilder<typeof v1.models>) => {
     const Box = s.Box.addField("b", P.Optional(P.String)).build();
     const Circle = defineRecord("Circle", { docs: "", fields: { r: P.Double } });
@@ -64,7 +62,6 @@ describe("provenance — scenarios beyond the demo", () => {
   });
   const v2 = nextSchema(v1).addSchemaUpdate(v2update).build();
 
-  // v3: add field c to Box (3 hops from v1).
   const v3update = defineSchemaUpdate("v3", (s: P.SchemaBuilder<typeof v2.models>) => ({
     Box: s.Box.addField("c", P.Optional(P.Double)).build(),
   }));
@@ -79,9 +76,7 @@ describe("provenance — scenarios beyond the demo", () => {
 
   it("union added in v2 gets addedInVersion 2", () => {
     const { chain } = resolveSchemaChain(v3);
-    // not present in v1
     expect(entry(chain, 1).ir.models.NewUnion).toBeUndefined();
-    // present in v2 and v3, stamped 2 in both
     expect(unionMeta(entry(chain, 2), "NewUnion").addedInVersion).toBe(2);
     expect(unionMeta(entry(chain, 3), "NewUnion").addedInVersion).toBe(2);
   });
@@ -96,13 +91,11 @@ describe("provenance — scenarios beyond the demo", () => {
   it("field added in v3 to a v1 record gets addedInVersion 3; older fields keep theirs", () => {
     const { chain } = resolveSchemaChain(v3);
     const f = recordFields(entry(chain, 3), "Box");
-    expect(f.a!.metadata.addedInVersion).toBe(1); // since v1
-    expect(f.b!.metadata.addedInVersion).toBe(2); // added v2
-    expect(f.c!.metadata.addedInVersion).toBe(3); // added v3
+    expect(f.b!.metadata.addedInVersion).toBe(2);
+    expect(f.c!.metadata.addedInVersion).toBe(3);
   });
 
   it("hand-built schema provenance is derived from first appearance in the chain", () => {
-    // Simulate a SchemaDefinition produced without the DSL builder.
     const hand: P.SchemaDefinition = {
       type: "versioned",
       version: 2,
@@ -116,7 +109,6 @@ describe("provenance — scenarios beyond the demo", () => {
   });
 
   it("upgrade lens still records removedFields + derivedFrom for a deprecated field", () => {
-    // Box: color in v1, split to fillColor/strokeColor + deprecate in v2.
     const b1 = defineSchema({
       Box: defineRecord("Box", { docs: "", fields: { a: P.Double, color: P.Optional(P.String) } }),
     });
@@ -128,9 +120,6 @@ describe("provenance — scenarios beyond the demo", () => {
     }));
     const b2 = nextSchema(b1).addSchemaUpdate(split).build();
 
-    // The SDK path strips deprecated fields BEFORE generating internals (exactly
-    // as irGenTypesHandler does). That strip is what turns "color deprecated in
-    // v2" into "color removed at v2" for the upgrade lens.
     const resolved = resolveSchemaChain(b2);
     const stripped = { ...resolved, chain: stripDeprecatedFieldsForSdk(resolved.chain) };
     const internal = generateInternalFromChain(stripped);

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/provenanceScenarios.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/provenanceScenarios.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineRecord, defineSchema, defineSchemaUpdate, nextSchema } from "@palantir/pack.schema";
+import * as P from "@palantir/pack.schema";
+import { describe, expect, it } from "vitest";
+import type {
+  IFieldDef,
+  IModelDef,
+} from "../../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import { generateInternalFromChain } from "../generateInternalFromSchema.js";
+import {
+  resolveSchemaChain,
+  stripDeprecatedFieldsForSdk,
+  type VersionedIrEntry,
+} from "../resolveSchemaChain.js";
+
+function entry(chain: VersionedIrEntry[], v: number): VersionedIrEntry {
+  return chain.find(c => c.version === v)!;
+}
+function recordFields(e: VersionedIrEntry, key: string): Record<string, IFieldDef> {
+  const m: IModelDef = e.ir.models[key]!;
+  if (m.type !== "record") throw new Error(`${key} not a record`);
+  return Object.fromEntries(m.record.fields.map(f => [f.key, f]));
+}
+function unionMeta(e: VersionedIrEntry, key: string) {
+  const m: IModelDef = e.ir.models[key]!;
+  if (m.type !== "union") throw new Error(`${key} not a union`);
+  return m.union.metadata;
+}
+
+describe("provenance — scenarios beyond the demo", () => {
+  // v1: Box(a) + one v1 union.
+  const v1 = defineSchema({
+    Box: defineRecord("Box", { docs: "", fields: { a: P.Double } }),
+    OldUnion: P.defineUnion("OldUnion", {
+      docs: "",
+      variants: { box: defineRecord("UVariant", { docs: "", fields: { z: P.Double } }) },
+    }),
+  });
+
+  // v2: add a NEW record (Circle) AND a NEW union (NewUnion); add field b to Box.
+  const v2update = defineSchemaUpdate("v2", (s: P.SchemaBuilder<typeof v1.models>) => {
+    const Box = s.Box.addField("b", P.Optional(P.String)).build();
+    const Circle = defineRecord("Circle", { docs: "", fields: { r: P.Double } });
+    const NewUnion = P.defineUnion("NewUnion", {
+      docs: "",
+      variants: { c: Circle },
+    });
+    return { Box, Circle, NewUnion };
+  });
+  const v2 = nextSchema(v1).addSchemaUpdate(v2update).build();
+
+  // v3: add field c to Box (3 hops from v1).
+  const v3update = defineSchemaUpdate("v3", (s: P.SchemaBuilder<typeof v2.models>) => ({
+    Box: s.Box.addField("c", P.Optional(P.Double)).build(),
+  }));
+  const v3 = nextSchema(v2).addSchemaUpdate(v3update).build();
+
+  it("union defined in v1 stays addedInVersion 1 in every version", () => {
+    const { chain } = resolveSchemaChain(v3);
+    for (const v of [1, 2, 3]) {
+      expect(unionMeta(entry(chain, v), "OldUnion").addedInVersion).toBe(1);
+    }
+  });
+
+  it("union added in v2 gets addedInVersion 2", () => {
+    const { chain } = resolveSchemaChain(v3);
+    // not present in v1
+    expect(entry(chain, 1).ir.models.NewUnion).toBeUndefined();
+    // present in v2 and v3, stamped 2 in both
+    expect(unionMeta(entry(chain, 2), "NewUnion").addedInVersion).toBe(2);
+    expect(unionMeta(entry(chain, 3), "NewUnion").addedInVersion).toBe(2);
+  });
+
+  it("record added in v2 gets its fields stamped addedInVersion 2", () => {
+    const { chain } = resolveSchemaChain(v3);
+    expect(entry(chain, 1).ir.models.Circle).toBeUndefined();
+    expect(recordFields(entry(chain, 2), "Circle").r!.metadata.addedInVersion).toBe(2);
+    expect(recordFields(entry(chain, 3), "Circle").r!.metadata.addedInVersion).toBe(2);
+  });
+
+  it("field added in v3 to a v1 record gets addedInVersion 3; older fields keep theirs", () => {
+    const { chain } = resolveSchemaChain(v3);
+    const f = recordFields(entry(chain, 3), "Box");
+    expect(f.a!.metadata.addedInVersion).toBe(1); // since v1
+    expect(f.b!.metadata.addedInVersion).toBe(2); // added v2
+    expect(f.c!.metadata.addedInVersion).toBe(3); // added v3
+  });
+
+  it("hand-built schema provenance is derived from first appearance in the chain", () => {
+    // Simulate a SchemaDefinition produced without the DSL builder.
+    const hand: P.SchemaDefinition = {
+      type: "versioned",
+      version: 2,
+      previous: { type: "initial", version: 1, models: v1.models },
+      models: { Box: defineRecord("Box", { docs: "", fields: { a: P.Double, b: P.Double } }) },
+    };
+    const { chain } = resolveSchemaChain(hand);
+    expect(recordFields(entry(chain, 2), "Box").a!.metadata.addedInVersion).toBe(1);
+    expect(recordFields(entry(chain, 2), "Box").b!.metadata.addedInVersion).toBe(2);
+    expect(recordFields(entry(chain, 1), "Box").a!.metadata.addedInVersion).toBe(1);
+  });
+
+  it("upgrade lens still records removedFields + derivedFrom for a deprecated field", () => {
+    // Box: color in v1, split to fillColor/strokeColor + deprecate in v2.
+    const b1 = defineSchema({
+      Box: defineRecord("Box", { docs: "", fields: { a: P.Double, color: P.Optional(P.String) } }),
+    });
+    const split = defineSchemaUpdate("split", (s: P.SchemaBuilder<typeof b1.models>) => ({
+      Box: s.Box
+        .addField("fillColor", P.Optional(P.String), { derivedFrom: ["color"] })
+        .deprecateField("color")
+        .build(),
+    }));
+    const b2 = nextSchema(b1).addSchemaUpdate(split).build();
+
+    // The SDK path strips deprecated fields BEFORE generating internals (exactly
+    // as irGenTypesHandler does). That strip is what turns "color deprecated in
+    // v2" into "color removed at v2" for the upgrade lens.
+    const resolved = resolveSchemaChain(b2);
+    const stripped = { ...resolved, chain: stripDeprecatedFieldsForSdk(resolved.chain) };
+    const internal = generateInternalFromChain(stripped);
+    expect(internal.upgrades).toContain("removedFields: [\"color\"]");
+    expect(internal.upgrades).toContain("derivedFrom: [\"color\"]");
+  });
+
+  it("deprecation with and without message both serialize (spread fix #5)", () => {
+    const b1 = defineSchema({
+      Box: defineRecord("Box", {
+        docs: "",
+        fields: { x: P.Optional(P.String), y: P.Optional(P.String) },
+      }),
+    });
+    const dep = defineSchemaUpdate("dep", (s: P.SchemaBuilder<typeof b1.models>) => ({
+      Box: s.Box.deprecateField("x", "gone").deprecateField("y").build(),
+    }));
+    const b2 = nextSchema(b1).addSchemaUpdate(dep).build();
+    const f = recordFields(entry(resolveSchemaChain(b2).chain, 2), "Box");
+    expect(f.x!.metadata.deprecatedFromVersion).toBe(2);
+    expect(f.x!.metadata.deprecatedMessage).toBe("gone");
+    expect(f.y!.metadata.deprecatedFromVersion).toBe(2);
+    expect(f.y!.metadata.deprecatedMessage ?? undefined).toBeUndefined();
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/resolveSchemaChain.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/resolveSchemaChain.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as P from "@palantir/pack.schema";
+import { defineRecord, defineSchema, defineSchemaUpdate, nextSchema } from "@palantir/pack.schema";
+import { describe, expect, it } from "vitest";
+import type {
+  IFieldDef,
+  IModelDef,
+} from "../../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import {
+  resolveSchemaChain,
+  stripDeprecatedFieldsForSdk,
+  type VersionedIrEntry,
+} from "../resolveSchemaChain.js";
+
+/** Index a record model's fields by key for a given chain entry. */
+function fieldsByKey(entry: VersionedIrEntry, modelKey: string): Record<string, IFieldDef> {
+  const model: IModelDef = entry.ir.models[modelKey]!;
+  if (model.type !== "record") throw new Error(`${modelKey} is not a record`);
+  return Object.fromEntries(model.record.fields.map(f => [f.key, f]));
+}
+
+describe("resolveSchemaChain provenance", () => {
+  const v1 = defineSchema({
+    ShapeBox: defineRecord("ShapeBox", {
+      docs: "A box",
+      fields: { left: P.Double, color: P.Optional(P.String) },
+    }),
+  });
+
+  const colorSplit = defineSchemaUpdate(
+    "colorSplit",
+    (schema: P.SchemaBuilder<typeof v1.models>) => ({
+      ShapeBox: schema.ShapeBox
+        .addField("fillColor", P.Optional(P.String), { derivedFrom: ["color"] })
+        .addField("strokeColor", P.Optional(P.String), { derivedFrom: ["color"] })
+        .deprecateField("color", "use fillColor/strokeColor")
+        .build(),
+    }),
+  );
+
+  const v2 = nextSchema(v1).addSchemaUpdate(colorSplit).build();
+
+  it("derives addedInVersion from first appearance in the chain", () => {
+    const { chain } = resolveSchemaChain(v2);
+    const v2Fields = fieldsByKey(chain.find(c => c.version === 2)!, "ShapeBox");
+
+    expect(v2Fields.left!.metadata.addedInVersion).toBe(1);
+    expect(v2Fields.fillColor!.metadata.addedInVersion).toBe(2);
+    expect(v2Fields.strokeColor!.metadata.addedInVersion).toBe(2);
+  });
+
+  it("keeps a deprecated field present and stamps deprecatedFromVersion + message", () => {
+    const { chain } = resolveSchemaChain(v2);
+    const v2Fields = fieldsByKey(chain.find(c => c.version === 2)!, "ShapeBox");
+
+    expect(v2Fields.color).toBeDefined();
+    expect(v2Fields.color!.metadata.addedInVersion).toBe(1);
+    expect(v2Fields.color!.metadata.deprecatedFromVersion).toBe(2);
+    expect(v2Fields.color!.metadata.deprecatedMessage).toBe("use fillColor/strokeColor");
+  });
+
+  it("does not mark the field deprecated in versions before the deprecation", () => {
+    const { chain } = resolveSchemaChain(v2);
+    const v1Fields = fieldsByKey(chain.find(c => c.version === 1)!, "ShapeBox");
+
+    expect(v1Fields.color).toBeDefined();
+    expect(v1Fields.color!.metadata.deprecatedFromVersion ?? undefined).toBeUndefined();
+    expect(v1Fields.fillColor).toBeUndefined();
+  });
+
+  it("stripDeprecatedFieldsForSdk drops deprecated fields from v>=deprecation only", () => {
+    const { chain } = resolveSchemaChain(v2);
+    const stripped = stripDeprecatedFieldsForSdk(chain);
+
+    const v1Fields = fieldsByKey(stripped.find(c => c.version === 1)!, "ShapeBox");
+    expect(v1Fields.color).toBeDefined();
+
+    const v2Fields = fieldsByKey(stripped.find(c => c.version === 2)!, "ShapeBox");
+    expect(v2Fields.color).toBeUndefined();
+    expect(v2Fields.fillColor).toBeDefined();
+
+    // Original chain not mutated.
+    expect(fieldsByKey(chain.find(c => c.version === 2)!, "ShapeBox").color).toBeDefined();
+  });
+});
+
+describe("resolveSchemaChain — union provenance", () => {
+  const v1 = defineSchema({
+    Box: defineRecord("Box", { docs: "", fields: { a: P.Double } }),
+    NodeShape: P.defineUnion("NodeShape", {
+      docs: "shape",
+      variants: { box: defineRecord("Inner", { docs: "", fields: { z: P.Double } }) },
+    }),
+  });
+  const addB = defineSchemaUpdate(
+    "addB",
+    (schema: P.SchemaBuilder<typeof v1.models>) => ({
+      Box: schema.Box.addField("b", P.Optional(P.String)).build(),
+    }),
+  );
+  const v2 = nextSchema(v1).addSchemaUpdate(addB).build();
+
+  it("a v1-defined union stays addedInVersion 1 in every version", () => {
+    const { chain } = resolveSchemaChain(v2);
+    for (const version of [1, 2]) {
+      const union = chain.find(c => c.version === version)!.ir.models.NodeShape!;
+      if (union.type !== "union") throw new Error("NodeShape should be a union");
+      expect(union.union.metadata.addedInVersion).toBe(1);
+    }
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/resolveSchemaChain.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/resolveSchemaChain.test.ts
@@ -94,7 +94,6 @@ describe("resolveSchemaChain provenance", () => {
     expect(v2Fields.color).toBeUndefined();
     expect(v2Fields.fillColor).toBeDefined();
 
-    // Original chain not mutated.
     expect(fieldsByKey(chain.find(c => c.version === 2)!, "ShapeBox").color).toBeDefined();
   });
 });

--- a/packages/document-schema/type-gen/src/utils/schema/generateInternalFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateInternalFromSchema.ts
@@ -158,7 +158,7 @@ function collectRecordModels(
         }
       }
 
-      // Fields removed in this version
+      // Fields absent from this version relative to the previous one (i.e. deprecated fields).
       const removedFields: string[] = [];
       for (const fieldKey of prevFields) {
         if (!currFields.has(fieldKey)) {

--- a/packages/document-schema/type-gen/src/utils/schema/loadSchemaModule.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/loadSchemaModule.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import type { InitialSchema, SchemaDefinition } from "@palantir/pack.schema";
+import type { SchemaDefinition } from "@palantir/pack.schema";
+import { defineSchema } from "@palantir/pack.schema";
 import fs from "fs-extra";
 import path from "path";
 import { pathToFileURL } from "url";
@@ -39,7 +40,7 @@ export function extractSchemaDefinition(schemaModule: unknown): SchemaDefinition
   }
 
   const models = extractValidSchema(schemaModule);
-  return { type: "initial", version: 1, models } satisfies InitialSchema;
+  return defineSchema(models);
 }
 
 /**

--- a/packages/document-schema/type-gen/src/utils/schema/resolveSchemaChain.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/resolveSchemaChain.ts
@@ -15,7 +15,12 @@
  */
 
 import type { SchemaDefinition, VersionMigrations } from "@palantir/pack.schema";
-import type { IRealTimeDocumentSchema } from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import type {
+  IModelDef,
+  IRealTimeDocumentSchema,
+} from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import { IModelDef as IModelDefCtor } from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import type { SchemaProvenance } from "../steps/convertStepsToIr.js";
 import { convertSchemaToIr } from "../steps/convertStepsToIr.js";
 
 /** JSON-serializable form of a single field migration. */
@@ -57,31 +62,79 @@ function collectVersionedIrChain(
   input: SchemaDefinition,
   identity: SchemaIdentity,
 ): VersionedIrEntry[] {
-  const chain: VersionedIrEntry[] = [];
+  const schemas = collectSchemaDefinitions(input);
+  const provenances = deriveProvenance(schemas);
+
+  return schemas.map((schema, index): VersionedIrEntry => ({
+    version: schema.version,
+    ir: convertSchemaToIr(
+      schema.models,
+      { version: schema.version, name: identity.name, description: identity.description },
+      provenances[index]!,
+    ),
+    ...(schema.type === "versioned" ? { migrations: serializeMigrations(schema.migrations) } : {}),
+  }));
+}
+
+function collectSchemaDefinitions(input: SchemaDefinition): SchemaDefinition[] {
+  const schemas: SchemaDefinition[] = [];
   let current: SchemaDefinition = input;
 
   while (current.type === "versioned") {
-    chain.unshift({
-      version: current.version,
-      ir: convertSchemaToIr(current.models, {
-        version: current.version,
-        name: identity.name,
-        description: identity.description,
-      }),
-      migrations: serializeMigrations(current.migrations),
-    });
+    schemas.unshift(current);
     current = current.previous;
   }
-  chain.unshift({
-    version: current.version,
-    ir: convertSchemaToIr(current.models, {
-      version: current.version,
-      name: identity.name,
-      description: identity.description,
-    }),
-  });
+  schemas.unshift(current);
 
-  return chain;
+  return schemas;
+}
+
+/**
+ * Build field/model provenance by walking the version chain from oldest to
+ * newest. The first version where a model key or record field appears is the
+ * version stamped into IR metadata.
+ */
+function deriveProvenance(schemas: readonly SchemaDefinition[]): SchemaProvenance[] {
+  const firstModelVersions = new Map<string, number>();
+  const firstFieldVersions = new Map<string, Map<string, number>>();
+
+  return schemas.map(schema => {
+    const modelVersions: Record<string, number> = {};
+    const fieldVersions: Record<string, Record<string, number>> = {};
+
+    for (const [modelKey, modelDef] of Object.entries(schema.models)) {
+      if (!firstModelVersions.has(modelKey)) {
+        firstModelVersions.set(modelKey, schema.version);
+      }
+      modelVersions[modelKey] = firstModelVersions.get(modelKey)!;
+
+      if (modelDef.type !== "record") continue;
+
+      let fieldVersionsForModel = firstFieldVersions.get(modelKey);
+      if (fieldVersionsForModel == null) {
+        fieldVersionsForModel = new Map<string, number>();
+        firstFieldVersions.set(modelKey, fieldVersionsForModel);
+      }
+
+      const fields: Record<string, number> = {};
+      for (const fieldKey of Object.keys(modelDef.fields)) {
+        if (!fieldVersionsForModel.has(fieldKey)) {
+          fieldVersionsForModel.set(fieldKey, schema.version);
+        }
+        fields[fieldKey] = fieldVersionsForModel.get(fieldKey)!;
+      }
+
+      if (Object.keys(fields).length > 0) {
+        fieldVersions[modelKey] = fields;
+      }
+    }
+
+    return {
+      fieldVersions,
+      modelVersions,
+      deprecations: "deprecations" in schema ? schema.deprecations : undefined,
+    };
+  });
 }
 
 /** Convert schema-builder migrations to their JSON-serializable form. */
@@ -145,6 +198,35 @@ export function resolveSchemaChain(
   const chain = collectVersionedIrChain(schema, identity);
   const { latestVersion, minVersion } = resolveMinVersion(chain, minSupportedVersion);
   return { chain, latestVersion, minVersion };
+}
+
+/**
+ * Return a copy of the chain with deprecated fields removed from every version
+ * at or after the version in which they were deprecated.
+ *
+ * The SDK type generators (`writeAllSdkFiles` and friends) must treat a
+ * deprecated field exactly as a removed field: it disappears from that version's
+ * public read/write types and per-version internal types, and the prev/curr diff
+ * records it as a `removedField` (driving the upgrade lens). The field is still
+ * collected into the all-versions `__Internal` type from earlier versions, which
+ * are left untouched.
+ */
+export function stripDeprecatedFieldsForSdk(chain: VersionedIrEntry[]): VersionedIrEntry[] {
+  return chain.map((entry): VersionedIrEntry => {
+    const models: Record<string, IModelDef> = {};
+    for (const [modelKey, modelDef] of Object.entries(entry.ir.models)) {
+      if (modelDef.type === "record") {
+        const fields = modelDef.record.fields.filter(field => {
+          const dep = field.metadata.deprecatedFromVersion;
+          return dep == null || entry.version < dep;
+        });
+        models[modelKey] = IModelDefCtor.record({ ...modelDef.record, fields });
+      } else {
+        models[modelKey] = modelDef;
+      }
+    }
+    return { ...entry, ir: { ...entry.ir, models } };
+  });
 }
 
 /**

--- a/packages/document-schema/type-gen/src/utils/steps/convertStepsToIr.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/convertStepsToIr.ts
@@ -42,6 +42,19 @@ export interface SchemaMetadata {
 }
 
 /**
+ * Per-field version provenance for a schema, keyed by model export key then
+ * field name. Supplied by the version-aware caller (`resolveSchemaChain`) so the
+ * IR records the version each field first appeared in (and any deprecation)
+ * instead of a placeholder. When omitted, fields fall back to the schema's
+ * top-level version (correct for single-version / steps-based callers).
+ */
+export interface SchemaProvenance {
+  readonly fieldVersions?: Record<string, Record<string, number>>;
+  readonly modelVersions?: Record<string, number>;
+  readonly deprecations?: P.VersionDeprecations;
+}
+
+/**
  * Converts migration steps to Palantir IR format
  */
 export function convertStepsToIr(
@@ -60,11 +73,15 @@ export function convertStepsToIr(
 }
 
 /**
- * Converts record and union definitions to Palantir IR format
+ * Converts record and union definitions to Palantir IR format. When
+ * `provenance` is supplied (by the version-aware caller), each field/model is
+ * stamped with the version it first appeared in and any deprecation; otherwise
+ * everything falls back to `metadata.version` (default 1).
  */
 export function convertSchemaToIr(
   inputSchema: P.Schema<P.ReturnedSchema>,
   metadata?: SchemaMetadata,
+  provenance?: SchemaProvenance,
 ): IRealTimeDocumentSchema {
   // Build a mapping from declared model name → export key so that union variant
   // refs (which use declared model names) can be remapped to export keys.
@@ -77,12 +94,13 @@ export function convertSchemaToIr(
     );
     nameToExportKey.set(modelDef.name, exportKey);
   }
+  const fallbackVersion = metadata?.version ?? 1;
 
   const primaryModelKeys: IModelTypeKey[] = [];
   const models = new Map<IModelTypeKey, IModelDef>();
 
   for (const [exportKey, modelDef] of Object.entries(inputSchema)) {
-    if (collectModels(exportKey, modelDef, nameToExportKey, models)) {
+    if (collectModels(exportKey, modelDef, nameToExportKey, models, fallbackVersion, provenance)) {
       primaryModelKeys.push(exportKey);
     }
   }
@@ -90,7 +108,7 @@ export function convertSchemaToIr(
   return {
     name: metadata?.name ?? "Generated Schema",
     description: metadata?.description ?? "Schema generated from migration steps",
-    version: metadata?.version ?? 1,
+    version: fallbackVersion,
     primaryModelKeys,
     models: Object.fromEntries(models),
   };
@@ -101,6 +119,8 @@ function collectModels(
   modelDef: P.ModelDef,
   nameToExportKey: Map<string, string>,
   outModels: Map<IModelTypeKey, IModelDef>,
+  fallbackVersion: number,
+  provenance?: SchemaProvenance,
 ): boolean {
   invariant(
     !outModels.has(exportKey),
@@ -111,14 +131,18 @@ function collectModels(
     case "record": {
       outModels.set(
         exportKey,
-        IModelDef.record(convertRecordDefToIr(modelDef, exportKey, nameToExportKey)),
+        IModelDef.record(
+          convertRecordDefToIr(modelDef, exportKey, nameToExportKey, fallbackVersion, provenance),
+        ),
       );
       return true;
     }
     case "union": {
       outModels.set(
         exportKey,
-        IModelDef.union(convertUnionDefToIr(modelDef, exportKey, nameToExportKey)),
+        IModelDef.union(
+          convertUnionDefToIr(modelDef, exportKey, nameToExportKey, fallbackVersion, provenance),
+        ),
       );
       return true;
     }
@@ -131,19 +155,34 @@ export function convertRecordDefToIr(
   recordDef: P.RecordDef,
   exportKey?: string,
   nameToExportKey?: Map<string, string>,
+  fallbackVersion: number = 1,
+  provenance?: SchemaProvenance,
 ): IRecordDef {
-  const key = exportKey ?? recordDef.name;
-  const fields = Object.entries(recordDef.fields).map(([fieldKey, fieldType]): IFieldDef => ({
-    key: fieldKey,
-    name: fieldKey,
-    description: undefined,
-    fieldType: convertTypeToFieldTypeUnion(fieldType, nameToExportKey),
-    metadata: { addedInVersion: 1 },
-    isOptional: fieldType.type === "optional" ? true : undefined,
-  }));
+  const modelKey = exportKey ?? recordDef.name;
+  const fieldVersions = provenance?.fieldVersions?.[modelKey];
+  const deprecations = provenance?.deprecations?.[modelKey];
+  const fields = Object.entries(recordDef.fields).map(([fieldKey, fieldType]): IFieldDef => {
+    const dep = deprecations?.[fieldKey];
+    return {
+      key: fieldKey,
+      name: fieldKey,
+      description: undefined,
+      fieldType: convertTypeToFieldTypeUnion(fieldType, nameToExportKey),
+      metadata: {
+        addedInVersion: fieldVersions?.[fieldKey] ?? fallbackVersion,
+        ...(dep != null
+          ? {
+            deprecatedFromVersion: dep.fromVersion,
+            ...(dep.message != null ? { deprecatedMessage: dep.message } : {}),
+          }
+          : {}),
+      },
+      isOptional: fieldType.type === "optional" ? true : undefined,
+    };
+  });
 
   return {
-    key,
+    key: modelKey,
     name: recordDef.name,
     description: recordDef.docs ?? undefined,
     fields,
@@ -154,8 +193,10 @@ export function convertUnionDefToIr(
   unionDef: P.UnionDef,
   exportKey?: string,
   nameToExportKey?: Map<string, string>,
+  fallbackVersion: number = 1,
+  provenance?: SchemaProvenance,
 ): IUnionDef {
-  const key = exportKey ?? unionDef.name;
+  const modelKey = exportKey ?? unionDef.name;
   const variantEntries = Object.entries(unionDef.variants).map((
     [variantName, modelRef],
   ) =>
@@ -165,13 +206,15 @@ export function convertUnionDefToIr(
     ] as const
   );
 
+  const unionAddedIn = provenance?.modelVersions?.[modelKey] ?? fallbackVersion;
+
   return {
-    key,
+    key: modelKey,
     name: unionDef.name,
     description: unionDef.docs,
     discriminant: unionDef.discriminant,
     variants: Object.fromEntries(variantEntries),
-    metadata: { addedInVersion: 1 },
+    metadata: { addedInVersion: unionAddedIn },
   };
 }
 

--- a/packages/schema/src/__tests__/addFieldOptions.test.ts
+++ b/packages/schema/src/__tests__/addFieldOptions.test.ts
@@ -20,7 +20,6 @@ import { applyMigration, defineMigration } from "../defineMigration.js";
 import { defineRecord } from "../defineRecord.js";
 import { defineSchema, defineSchemaUpdate, nextSchema } from "../defineSchemaUpdate.js";
 import { defineUnion } from "../defineUnion.js";
-import type { RecordDef } from "../defs.js";
 import * as P from "../primitives.js";
 
 describe("addField with upgrade options", () => {
@@ -46,7 +45,7 @@ describe("addField with upgrade options", () => {
           .addField("strokeColor", P.Optional(P.String), {
             derivedFrom: ["color"],
           })
-          .removeField("color")
+          .deprecateField("color")
           .build(),
       }),
     );
@@ -59,7 +58,7 @@ describe("addField with upgrade options", () => {
     expect(Object.keys(v2.migrations?.ShapeBox?.fillColor ?? {})).toEqual(["derivedFrom"]);
   });
 
-  it("removeField strips the field from the resulting record fields", () => {
+  it("deprecateField keeps the field and records the deprecation", () => {
     const colorSplit = defineSchemaUpdate(
       "colorSplit",
       (schema: SchemaBuilder<typeof v1.models>) => ({
@@ -67,7 +66,7 @@ describe("addField with upgrade options", () => {
           .addField("fillColor", P.Optional(P.String), {
             derivedFrom: ["color"],
           })
-          .removeField("color")
+          .deprecateField("color", "use fillColor/strokeColor")
           .build(),
       }),
     );
@@ -75,10 +74,29 @@ describe("addField with upgrade options", () => {
     const v2 = nextSchema(v1).addSchemaUpdate(colorSplit).build();
     const shapeBox = v2.models.ShapeBox;
     expect(Object.keys(shapeBox.fields).sort()).toEqual([
+      "color",
       "fillColor",
       "x",
       "y",
     ]);
+    expect(v2.deprecations?.ShapeBox?.color).toEqual({
+      fromVersion: 2,
+      message: "use fillColor/strokeColor",
+    });
+  });
+
+  it("deprecateField without a message records the version only", () => {
+    const update = defineSchemaUpdate(
+      "deprecateColor",
+      (schema: SchemaBuilder<typeof v1.models>) => ({
+        ShapeBox: schema.ShapeBox.deprecateField("color").build(),
+      }),
+    );
+
+    const v2 = nextSchema(v1).addSchemaUpdate(update).build();
+    expect(v2.deprecations?.ShapeBox?.color).toEqual({ fromVersion: 2 });
+    // Field remains present.
+    expect((v2.models.ShapeBox.fields as Record<string, unknown>).color).toBeDefined();
   });
 
   it("explicit withMigrations is merged with addField sugar", () => {
@@ -151,19 +169,19 @@ describe("addField with upgrade options", () => {
     expect(v2.migrations).toBeUndefined();
   });
 
-  it("removeField drops any upgrade option staged for that field name", () => {
+  it("deprecateField on an existing field does not affect a new field's upgrade option", () => {
     const update = defineSchemaUpdate("update", (schema: SchemaBuilder<typeof v1.models>) => ({
       ShapeBox: schema.ShapeBox
-        .addField("temp", P.Optional(P.String), {
+        .addField("fillColor", P.Optional(P.String), {
           derivedFrom: ["color"],
         })
-        .removeField("temp")
+        .deprecateField("color")
         .build(),
     }));
 
     const v2 = nextSchema(v1).addSchemaUpdate(update).build();
-    expect(v2.migrations).toBeUndefined();
-    expect((v2.models.ShapeBox.fields as Record<string, unknown>).temp).toBeUndefined();
+    expect(v2.migrations?.ShapeBox?.fillColor?.derivedFrom).toEqual(["color"]);
+    expect(v2.deprecations?.ShapeBox?.color).toBeDefined();
   });
 
   it("subsequent addSchemaUpdate does not re-collect options from the prior step", () => {
@@ -286,102 +304,6 @@ describe("addField with upgrade options", () => {
       item: { type: "string" },
     });
     expect(Object.getOwnPropertySymbols(merged.ShapeBox)).toEqual([]);
-  });
-
-  // Type of v1.models after a prior step adds an optional-string `temp` field
-  // to ShapeBox. Used to type the input of a later step that calls
-  // `removeField("temp")` — without this, `temp` is not statically known to
-  // be in the field set and the call would fail to type-check.
-  type V1WithTemp = typeof v1.models & {
-    ShapeBox: RecordDef<
-      typeof v1.models.ShapeBox["fields"] & { readonly temp: P.Optional<P.String> }
-    >;
-  };
-
-  it("a later addSchemaUpdate that removes a field also drops its migration", () => {
-    const addTemp = defineSchemaUpdate(
-      "addTemp",
-      (schema: SchemaBuilder<typeof v1.models>) => ({
-        ShapeBox: schema.ShapeBox
-          .addField("temp", P.Optional(P.String), {
-            derivedFrom: ["color"],
-          })
-          .build(),
-      }),
-    );
-
-    const removeTemp = defineSchemaUpdate(
-      "removeTemp",
-      (schema: SchemaBuilder<V1WithTemp>) => ({
-        ShapeBox: schema.ShapeBox.removeField("temp").build(),
-      }),
-    );
-
-    const v2 = nextSchema(v1).addSchemaUpdate(addTemp).addSchemaUpdate(removeTemp).build();
-
-    expect((v2.models.ShapeBox.fields as Record<string, unknown>).temp).toBeUndefined();
-    expect(v2.migrations).toBeUndefined();
-  });
-
-  it("a later update may remove one upgraded field while adding another", () => {
-    const addTwo = defineSchemaUpdate(
-      "addTwo",
-      (schema: SchemaBuilder<typeof v1.models>) => ({
-        ShapeBox: schema.ShapeBox
-          .addField("temp", P.Optional(P.String), {
-            derivedFrom: ["color"],
-          })
-          .addField("fillColor", P.Optional(P.String), {
-            derivedFrom: ["color"],
-          })
-          .build(),
-      }),
-    );
-
-    const removeTemp = defineSchemaUpdate(
-      "removeTemp",
-      (schema: SchemaBuilder<V1WithTemp>) => ({
-        ShapeBox: schema.ShapeBox.removeField("temp").build(),
-      }),
-    );
-
-    const v2 = nextSchema(v1).addSchemaUpdate(addTwo).addSchemaUpdate(removeTemp).build();
-
-    expect(Object.keys(v2.migrations?.ShapeBox ?? {})).toEqual(["fillColor"]);
-    expect((v2.migrations?.ShapeBox as Record<string, unknown> | undefined)?.temp).toBeUndefined();
-  });
-
-  it("withMigrations entries are pruned when a later update removes the field", () => {
-    const noop = defineSchemaUpdate(
-      "noop",
-      (schema: SchemaBuilder<typeof v1.models>) => ({
-        ShapeBox: schema.ShapeBox
-          .addField("temp", P.Optional(P.String))
-          .build(),
-      }),
-    );
-
-    const removeTemp = defineSchemaUpdate(
-      "removeTemp",
-      (schema: SchemaBuilder<V1WithTemp>) => ({
-        ShapeBox: schema.ShapeBox.removeField("temp").build(),
-      }),
-    );
-
-    const v2 = nextSchema(v1)
-      .addSchemaUpdate(noop)
-      .withMigrations({
-        ShapeBox: {
-          temp: {
-            derivedFrom: ["color"],
-          },
-        },
-      })
-      .addSchemaUpdate(removeTemp)
-      .build();
-
-    expect((v2.models.ShapeBox.fields as Record<string, unknown>).temp).toBeUndefined();
-    expect(v2.migrations).toBeUndefined();
   });
 
   it("withMigrations silently drops entries for fields the model no longer has", () => {

--- a/packages/schema/src/defineMigration.ts
+++ b/packages/schema/src/defineMigration.ts
@@ -117,9 +117,10 @@ export interface RecordBuilder<T extends Record<string, Type>> {
     type: V,
     options?: FieldOptions,
   ): RecordBuilder<T & { [k in K]: V }>;
-  removeField<K extends keyof T & string>(
+  deprecateField<K extends keyof T & string>(
     name: K,
-  ): RecordBuilder<Omit<T, K>>;
+    message?: string,
+  ): RecordBuilder<T>;
   build(): RecordDef<T>;
 }
 
@@ -174,14 +175,29 @@ class UnionBuilderImpl<S extends UnionVariants> implements UnionBuilder<S> {
  */
 const UPGRADE_OPTIONS_CARRIER = "__pack_upgrade_options__";
 
+/**
+ * Non-enumerable carrier property attached to a `RecordDef` by
+ * `RecordBuilderImpl.build()` when the builder has collected one or more
+ * `deprecateField` calls. `applyMigration` reads this and then deletes the
+ * property, so the returned `RecordDef` is structurally clean. Maps field name
+ * → its deprecation info.
+ */
+const DEPRECATED_FIELDS_CARRIER = "__pack_deprecated_fields__";
+
+export interface FieldDeprecation {
+  readonly message?: string;
+}
+
 class RecordBuilderImpl<T extends RecordFields> implements RecordBuilder<T> {
   private readonly name: string;
   private readonly fields: T;
   private readonly upgradeOptions: ReadonlyMap<string, FieldOptions>;
+  private readonly deprecatedFields: ReadonlyMap<string, FieldDeprecation>;
 
   constructor(
     initialRecordDef: RecordDef<T>,
     upgradeOptions?: ReadonlyMap<string, FieldOptions>,
+    deprecatedFields?: ReadonlyMap<string, FieldDeprecation>,
   ) {
     this.name = initialRecordDef.name;
     this.fields = { ...initialRecordDef.fields };
@@ -189,6 +205,7 @@ class RecordBuilderImpl<T extends RecordFields> implements RecordBuilder<T> {
     // they are NOT inherited from the prior version's RecordDef, because each
     // version's upgrades describe a specific version transition.
     this.upgradeOptions = new Map<string, FieldOptions>(upgradeOptions ?? []);
+    this.deprecatedFields = new Map<string, FieldDeprecation>(deprecatedFields ?? []);
   }
 
   // TODO: resolve field value from arg instead
@@ -212,24 +229,26 @@ class RecordBuilderImpl<T extends RecordFields> implements RecordBuilder<T> {
         docs: "",
       },
       next,
+      this.deprecatedFields,
     );
   }
 
-  removeField<K extends keyof T & string>(
+  deprecateField<K extends keyof T & string>(
     name: K,
-  ): RecordBuilder<Omit<T, K>> {
-    const { [name]: _removed, ...rest } = this.fields;
-    const next = new Map(this.upgradeOptions);
-    next.delete(name);
+    message?: string,
+  ): RecordBuilder<T> {
+    const next = new Map(this.deprecatedFields);
+    next.set(name, { message });
     return new RecordBuilderImpl(
       {
         type: ModelDefType.RECORD,
         name: this.name,
-        fields: rest as RecordFields,
+        fields: { ...this.fields },
         docs: "",
       },
+      this.upgradeOptions,
       next,
-    ) as unknown as RecordBuilder<Omit<T, K>>;
+    );
   }
 
   build(): RecordDef<T> {
@@ -242,6 +261,14 @@ class RecordBuilderImpl<T extends RecordFields> implements RecordBuilder<T> {
     if (this.upgradeOptions.size > 0) {
       Object.defineProperty(result, UPGRADE_OPTIONS_CARRIER, {
         value: this.upgradeOptions,
+        enumerable: false,
+        configurable: true,
+        writable: false,
+      });
+    }
+    if (this.deprecatedFields.size > 0) {
+      Object.defineProperty(result, DEPRECATED_FIELDS_CARRIER, {
+        value: this.deprecatedFields,
         enumerable: false,
         configurable: true,
         writable: false,
@@ -270,22 +297,29 @@ export type FieldUpgrades = Record<
   Record<string, UpgradeFieldOptions<Record<string, unknown>>>
 >;
 
+export type FieldDeprecations = Record<
+  string,
+  Record<string, FieldDeprecation>
+>;
+
 export interface MigrationResult<M extends ModelDefs> {
   readonly models: M;
   readonly upgrades?: FieldUpgrades;
+  readonly deprecations?: FieldDeprecations;
 }
 
 /**
- * Lower-level entry point that returns both the merged models AND any
- * `UpgradeFieldOptions` collected via `addField(name, type, options)` during
- * the migration callback. Used by `addSchemaUpdate` to fold sugar-form
- * upgrades into a `VersionedSchema`'s migrations map.
+ * Lower-level entry point that returns the merged models plus the per-field
+ * metadata collected during the migration callback: `UpgradeFieldOptions` from
+ * `addField(name, type, options)` and deprecations from `deprecateField(name)`.
+ * Used by `addSchemaUpdate` to fold sugar-form upgrades into a
+ * `VersionedSchema`'s migrations map and deprecations into its deprecations map.
  *
- * Each `RecordBuilderImpl.build()` attaches its collected options to the
- * produced `RecordDef` via a non-enumerable carrier property; this function
- * walks the merged result, extracts the options keyed by the user's chosen
- * output key (so renames are handled), and strips the carrier so the returned
- * `RecordDef`s are structurally clean.
+ * Each `RecordBuilderImpl.build()` attaches its collected upgrade options and
+ * deprecations to the produced `RecordDef` via two non-enumerable carrier
+ * properties; this function walks the merged result, extracts both keyed by the
+ * user's chosen output key (so renames are handled), and strips the carriers so
+ * the returned `RecordDef`s are structurally clean.
  */
 export function applyMigration<
   const T extends ModelDefs,
@@ -298,35 +332,53 @@ export function applyMigration<
   const merged = { ...models, ...migration(builders) } as T & S;
 
   const upgrades: FieldUpgrades = {};
+  const deprecations: FieldDeprecations = {};
   for (const [modelKey, def] of Object.entries(merged)) {
     if (!isRecordDef(def)) continue;
     const carrier = def as unknown as Record<string, unknown>;
     const opts = carrier[UPGRADE_OPTIONS_CARRIER] as
       | ReadonlyMap<string, FieldOptions>
       | undefined;
-    if (opts == null) continue;
-    // Strip the carrier so the returned RecordDef is structurally clean.
-    delete carrier[UPGRADE_OPTIONS_CARRIER];
-    const fieldEntries: Record<
-      string,
-      UpgradeFieldOptions<Record<string, unknown>>
-    > = {};
-    for (const [fieldName, options] of opts) {
-      // Only `UpgradeFieldOptions` (which declare `derivedFrom`) flow into the
-      // upgrades map; `AdditiveFieldOptions` carry only a literal `default`
-      // and have no read-time lens effect.
-      if ("derivedFrom" in options) {
-        fieldEntries[fieldName] = options;
+    if (opts != null) {
+      // Strip the carrier so the returned RecordDef is structurally clean.
+      delete carrier[UPGRADE_OPTIONS_CARRIER];
+      const fieldEntries: Record<
+        string,
+        UpgradeFieldOptions<Record<string, unknown>>
+      > = {};
+      for (const [fieldName, options] of opts) {
+        // Only `UpgradeFieldOptions` (which declare `derivedFrom`) flow into the
+        // upgrades map; `AdditiveFieldOptions` carry only a literal `default`
+        // and have no read-time lens effect.
+        if ("derivedFrom" in options) {
+          fieldEntries[fieldName] = options;
+        }
+      }
+      if (Object.keys(fieldEntries).length > 0) {
+        upgrades[modelKey] = fieldEntries;
       }
     }
-    if (Object.keys(fieldEntries).length > 0) {
-      upgrades[modelKey] = fieldEntries;
+
+    const deprecated = carrier[DEPRECATED_FIELDS_CARRIER] as
+      | ReadonlyMap<string, FieldDeprecation>
+      | undefined;
+    if (deprecated != null) {
+      // Strip the carrier so the returned RecordDef is structurally clean.
+      delete carrier[DEPRECATED_FIELDS_CARRIER];
+      const fieldEntries: Record<string, FieldDeprecation> = {};
+      for (const [fieldName, info] of deprecated) {
+        fieldEntries[fieldName] = info;
+      }
+      if (Object.keys(fieldEntries).length > 0) {
+        deprecations[modelKey] = fieldEntries;
+      }
     }
   }
 
   return {
     models: merged,
     upgrades: Object.keys(upgrades).length > 0 ? upgrades : undefined,
+    deprecations: Object.keys(deprecations).length > 0 ? deprecations : undefined,
   };
 }
 

--- a/packages/schema/src/defineSchemaUpdate.ts
+++ b/packages/schema/src/defineSchemaUpdate.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import type { SchemaBuilder } from "./defineMigration.js";
+import type { FieldDeprecation, SchemaBuilder } from "./defineMigration.js";
 import { applyMigration } from "./defineMigration.js";
 import type { ModelDefs } from "./defs.js";
+import { isRecordDef } from "./utils.js";
 
 export interface InitialSchema<T extends ModelDefs = ModelDefs> {
   readonly type: "initial";
@@ -30,12 +31,19 @@ export interface FieldMigration {
 
 export type VersionMigrations = Record<string, Record<string, FieldMigration>>;
 
+export interface FieldDeprecationInfo {
+  readonly fromVersion: number;
+  readonly message?: string;
+}
+export type VersionDeprecations = Record<string, Record<string, FieldDeprecationInfo>>;
+
 export interface VersionedSchema<T extends ModelDefs = ModelDefs> {
   readonly type: "versioned";
   readonly models: T;
   readonly version: number;
   readonly previous: SchemaDefinition;
   readonly migrations?: VersionMigrations;
+  readonly deprecations?: VersionDeprecations;
 }
 
 export type SchemaDefinition<T extends ModelDefs = ModelDefs> =
@@ -67,18 +75,18 @@ export interface SchemaVersionBuilder<T extends ModelDefs> {
 }
 
 /**
- * Merge two `VersionMigrations` records. Per-model field migrations from
- * `override` take precedence over `base` for the same field, but the maps are
- * combined at both the model and field level so explicit `withMigrations`
- * calls can supplement (not just replace) the sugar from `addField` options.
+ * Shallow-merge two `[modelKey][fieldName]` maps; `override` wins per field.
+ * Used for both migrations (so `withMigrations` supplements `addField` sugar)
+ * and deprecations (so each version's deprecations accumulate forward). The
+ * maps are combined at both the model and field level.
  */
-function mergeMigrations(
-  base: VersionMigrations | undefined,
-  override: VersionMigrations | undefined,
-): VersionMigrations | undefined {
+function mergeByModelField<V>(
+  base: Record<string, Record<string, V>> | undefined,
+  override: Record<string, Record<string, V>> | undefined,
+): Record<string, Record<string, V>> | undefined {
   if (base == null) return override;
   if (override == null) return base;
-  const result: VersionMigrations = { ...base };
+  const result: Record<string, Record<string, V>> = { ...base };
   for (const [modelKey, fields] of Object.entries(override)) {
     result[modelKey] = { ...result[modelKey], ...fields };
   }
@@ -87,7 +95,7 @@ function mergeMigrations(
 
 /**
  * Drop migration entries that no longer correspond to a field on a record in
- * `models`. Required because `mergeMigrations` is monotonic — a later
+ * `models`. Required because `mergeByModelField` is monotonic — a later
  * `addSchemaUpdate` that removes or retypes a field would otherwise leave a
  * stale entry in the accumulator. Entries are dropped when:
  *   - the model key is no longer present,
@@ -102,7 +110,7 @@ function pruneMigrations(
   const result: VersionMigrations = {};
   for (const [modelKey, fields] of Object.entries(migrations)) {
     const def = models[modelKey];
-    if (def == null || def.type !== "record") continue;
+    if (!isRecordDef(def)) continue;
     const recordFields = def.fields;
     const kept: Record<string, FieldMigration> = {};
     for (const [fieldName, migration] of Object.entries(fields)) {
@@ -117,44 +125,82 @@ function pruneMigrations(
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+/**
+ * Convert the version-agnostic `FieldDeprecations` collected by `applyMigration`
+ * (just `{ message? }`) into `VersionDeprecations` by stamping `fromVersion`.
+ */
+function stampDeprecationVersions(
+  deprecations: Record<string, Record<string, FieldDeprecation>> | undefined,
+  version: number,
+): VersionDeprecations | undefined {
+  if (deprecations == null) return undefined;
+  const result: VersionDeprecations = {};
+  for (const [modelKey, fields] of Object.entries(deprecations)) {
+    const out: Record<string, FieldDeprecationInfo> = {};
+    for (const [fieldName, info] of Object.entries(fields)) {
+      out[fieldName] = { fromVersion: version, ...info };
+    }
+    result[modelKey] = out;
+  }
+  return result;
+}
+
 class SchemaVersionBuilderImpl<T extends ModelDefs> implements SchemaVersionBuilder<T> {
   private readonly models: T;
   private readonly version: number;
   private readonly previous: SchemaDefinition;
   private readonly _migrations: VersionMigrations | undefined;
+  private readonly _deprecations: VersionDeprecations | undefined;
 
   constructor(
     models: T,
     version: number,
     previous: SchemaDefinition,
-    migrations?: VersionMigrations,
+    migrations: VersionMigrations | undefined,
+    deprecations?: VersionDeprecations,
   ) {
     this.models = models;
     this.version = version;
     this.previous = previous;
     this._migrations = migrations;
+    this._deprecations = deprecations;
   }
 
   addSchemaUpdate<S extends ModelDefs>(
     update: SchemaUpdate<T, S>,
   ): SchemaVersionBuilder<T & S> {
-    // applyMigration returns both the merged models and any sugar-form
-    // upgrades collected via `addField(name, type, { derivedFrom, forward })`.
-    const { models, upgrades } = applyMigration(this.models, update.migration);
-    const merged = mergeMigrations(
+    // applyMigration returns the merged models, any sugar-form upgrades from
+    // `addField(name, type, { derivedFrom })`, and any `deprecateField` calls.
+    const { models, upgrades, deprecations } = applyMigration(this.models, update.migration);
+    const merged = mergeByModelField(
       this._migrations,
       upgrades as VersionMigrations | undefined,
     );
-    // Reconcile against the new models: a later update that removes or
-    // retypes a field must drop the prior step's stale migration entry.
+    // Reconcile against the new models: a later update that retypes a field
+    // must drop the prior step's stale migration entry.
     const pruned = pruneMigrations(merged, models);
-    return new SchemaVersionBuilderImpl(models, this.version, this.previous, pruned);
+    // Attach this version to each freshly-deprecated field, then merge forward.
+    const thisVersionDeprecations = stampDeprecationVersions(deprecations, this.version);
+    const mergedDeprecations = mergeByModelField(this._deprecations, thisVersionDeprecations);
+    return new SchemaVersionBuilderImpl(
+      models,
+      this.version,
+      this.previous,
+      pruned,
+      mergedDeprecations,
+    );
   }
 
   withMigrations(migrations: VersionMigrations): SchemaVersionBuilder<T> {
-    const merged = mergeMigrations(this._migrations, migrations);
+    const merged = mergeByModelField(this._migrations, migrations);
     const pruned = pruneMigrations(merged, this.models);
-    return new SchemaVersionBuilderImpl(this.models, this.version, this.previous, pruned);
+    return new SchemaVersionBuilderImpl(
+      this.models,
+      this.version,
+      this.previous,
+      pruned,
+      this._deprecations,
+    );
   }
 
   build(): VersionedSchema<T> {
@@ -164,6 +210,7 @@ class SchemaVersionBuilderImpl<T extends ModelDefs> implements SchemaVersionBuil
       version: this.version,
       previous: this.previous,
       ...(this._migrations != null ? { migrations: this._migrations } : {}),
+      ...(this._deprecations != null ? { deprecations: this._deprecations } : {}),
     };
   }
 }
@@ -171,5 +218,13 @@ class SchemaVersionBuilderImpl<T extends ModelDefs> implements SchemaVersionBuil
 export function nextSchema<T extends ModelDefs>(
   previous: SchemaDefinition<T>,
 ): SchemaVersionBuilder<T> {
-  return new SchemaVersionBuilderImpl(previous.models, previous.version + 1, previous);
+  const version = previous.version + 1;
+  const deprecations = "deprecations" in previous ? previous.deprecations : undefined;
+  return new SchemaVersionBuilderImpl(
+    previous.models,
+    version,
+    previous,
+    undefined,
+    deprecations,
+  );
 }


### PR DESCRIPTION
Schema (IR) requires addedInVersion fields correctly versioned (previously hardcoded with placeholder) and also carry forward the deprecations, including them in the output schema so that backend schema validation works correctly.

When resolving a schema chain, we walk versions from oldest to newest and derive provenance from first appearance: the first version where a model or record field appears becomes its addedInVersion. Field deprecations are explicit builder metadata from deprecateField(...) and are carried forward through later versions.

Example manual deploy document type in version 1:
```
pnpm exec type-gen asset deploy -i build/asset.json -o ri.ontology.main.ontology.6ae2b235-997d-4b5e-9611-85fa88742697 -a $FOUNDRY_TOKEN -b https://danube-staging.palantircloud.com
ℹ Reading asset file from: /Volumes/git/pack/demos/canvas/schema/build/asset.json                                                               3:35:31 PM
ℹ Creating first-party document type { requestBody:                                                                                             3:35:31 PM
   { name: 'com.palantir.pack.demo.migration-doctype2',
     ontologyRid: 'ri.ontology.main.ontology.6ae2b235-997d-4b5e-9611-85fa88742697',
     schema: { primaryModelKeys: [Array], models: [Object] },
     fileSystemType: 'ARTIFACTS',
     version: 1 } }
✔ Successfully created first-party document type { rid: 'ri.backpack..document-type.de5b92b1-3d43-4133-9064-a9e72942d671',                      3:35:33 PM
  name: 'com.palantir.pack.demo.migration-doctype2',
  fileSystemType: 'ARTIFACTS',
  version: 1 }
```

Manually update schema to version 3:
```
pnpm exec type-gen asset update-schema -i build/asset.json -o ri.ontology.main.ontology.6ae2b235-997d-4b5e-9611-85fa88742697 -a $FOUNDRY_TOKEN -b https://danube-staging.palantircloud.com
ℹ Reading asset file from: /Volumes/git/pack/demos/canvas/schema/build/asset.json                                                               3:36:02 PM
ℹ Updating schema for document type "com.palantir.pack.demo.migration-doctype2" -> version 2                                                    3:36:02 PM
✔ Schema updated successfully (version 2)
```