### PR TITLE
Calculate maximum write version on updates

### DIFF
--- a/.changeset/quick-camels-hunt.md
+++ b/.changeset/quick-camels-hunt.md
@@ -1,0 +1,9 @@
+---
+"@palantir/pack.document-schema.model-types": minor
+"@palantir/pack.document-schema.type-gen": minor
+"@palantir/pack.state.foundry-event": minor
+"@palantir/pack.state.foundry": minor
+"@palantir/pack.state.core": minor
+---
+
+calculate document maximum write version

--- a/demos/canvas/app/src/components/canvas/CanvasPage.tsx
+++ b/demos/canvas/app/src/components/canvas/CanvasPage.tsx
@@ -114,10 +114,12 @@ export const CanvasPage = () => {
       <CanvasToolbar
         canDelete={interaction.selectedShapeId != null}
         currentColor={interaction.currentColor}
+        currentOpacity={interaction.currentOpacity}
         currentTool={interaction.currentTool}
         doc={doc}
         onColorChange={interaction.setColor}
         onDelete={interaction.deleteSelected}
+        onOpacityChange={interaction.setOpacity}
         onToolChange={interaction.setTool}
       />
       <CanvasContent

--- a/demos/canvas/app/src/components/canvas/CanvasToolbar.module.css
+++ b/demos/canvas/app/src/components/canvas/CanvasToolbar.module.css
@@ -87,6 +87,16 @@
   padding: 4px 8px;
 }
 
+.slider {
+  width: 120px;
+}
+
+.opacityValue {
+  color: #5f6b7c;
+  font-size: 12px;
+  min-width: 36px;
+}
+
 .toolGroupRight {
   align-items: center;
   display: flex;

--- a/demos/canvas/app/src/components/canvas/CanvasToolbar.tsx
+++ b/demos/canvas/app/src/components/canvas/CanvasToolbar.tsx
@@ -27,20 +27,24 @@ import { EditCanvasDialog } from "./EditCanvasDialog.js";
 export interface CanvasToolbarProps {
   readonly canDelete: boolean;
   readonly currentColor: string;
+  readonly currentOpacity: number | undefined;
   readonly currentTool: ToolMode;
   readonly doc: VersionedDocRef;
   onColorChange: (color: string) => void;
   onDelete: () => void;
+  onOpacityChange: (opacity: number) => void;
   onToolChange: (tool: ToolMode) => void;
 }
 
 export const CanvasToolbar = memo(function CanvasToolbar({
   canDelete,
   currentColor,
+  currentOpacity,
   currentTool,
   doc,
   onColorChange,
   onDelete,
+  onOpacityChange,
   onToolChange,
 }: CanvasToolbarProps) {
   const { metadata } = useDocMetadata(doc);
@@ -48,6 +52,10 @@ export const CanvasToolbar = memo(function CanvasToolbar({
 
   const handleColorChange = (e: ChangeEvent<HTMLSelectElement>) => {
     onColorChange(e.target.value);
+  };
+
+  const handleOpacityChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onOpacityChange(Number(e.target.value));
   };
 
   return (
@@ -107,6 +115,25 @@ export const CanvasToolbar = memo(function CanvasToolbar({
           </select>
         </label>
       </div>
+
+      {doc.version >= 2 && currentOpacity != null && (
+        <div className={styles.toolGroup}>
+          <label className={styles.label}>
+            Opacity:
+            <input
+              className={styles.slider}
+              disabled={!canDelete}
+              max={1}
+              min={0.1}
+              onChange={handleOpacityChange}
+              step={0.05}
+              type="range"
+              value={currentOpacity}
+            />
+            <span className={styles.opacityValue}>{Math.round(currentOpacity * 100)}%</span>
+          </label>
+        </div>
+      )}
 
       <div className={styles.toolGroup}>
         <button

--- a/demos/canvas/app/src/hooks/useCanvasInteraction.ts
+++ b/demos/canvas/app/src/hooks/useCanvasInteraction.ts
@@ -39,11 +39,13 @@ export interface UseCanvasInteractionResult {
     onMouseUp: (e: MouseEvent<SVGSVGElement>) => void;
   };
   readonly currentColor: string;
+  readonly currentOpacity: number | undefined;
   readonly currentTool: ToolMode;
   deleteSelected: () => void;
   readonly penPoints: readonly [number, number, number][] | undefined;
   readonly selectedShapeId: string | undefined;
   setColor: (color: string) => void;
+  setOpacity: (opacity: number) => void;
   setTool: (tool: ToolMode) => void;
   readonly shapeRefs: readonly RecordRef<typeof NodeShapeModel>[];
   readonly strokeRefs: readonly RecordRef<typeof FreehandStrokeModel>[];
@@ -59,6 +61,7 @@ export function useCanvasInteraction(
   const { clearSelection, selectedShapeRef, selectShape } = useShapeSelection();
   const [currentTool, setCurrentTool] = useState<ToolMode>("select");
   const [currentColor, setCurrentColor] = useState<string>(getDefaultColor());
+  const [currentOpacity, setCurrentOpacity] = useState<number | undefined>();
 
   const creationStateRef = useRef<{ startX: number; startY: number } | undefined>(undefined);
   const [penPoints, setPenPoints] = useState<[number, number, number][] | undefined>(undefined);
@@ -67,6 +70,14 @@ export function useCanvasInteraction(
     (ref: RecordRef<typeof NodeShapeModel> | undefined) => {
       selectShape(ref);
       broadcastSelection(ref != null ? [ref.id] : []);
+      if (ref == null) {
+        setCurrentOpacity(undefined);
+        return;
+      }
+      setCurrentOpacity(undefined);
+      void ref.getSnapshot().then(shape => {
+        setCurrentOpacity(shape?.opacity);
+      });
     },
     [broadcastSelection, selectShape],
   );
@@ -92,6 +103,7 @@ export function useCanvasInteraction(
       );
       clearSelection();
       broadcastSelection([]);
+      setCurrentOpacity(undefined);
     }
   }, [broadcastSelection, clearSelection, doc, selectedShapeRef]);
 
@@ -124,6 +136,38 @@ export function useCanvasInteraction(
           }),
         );
       }
+    },
+    [doc, selectedShapeRef],
+  );
+
+  const setOpacity = useCallback(
+    async (opacity: number) => {
+      if (selectedShapeRef == null) {
+        return;
+      }
+
+      const normalizedOpacity = normalizeOpacity(opacity);
+      setCurrentOpacity(normalizedOpacity);
+
+      const oldShape = await selectedShapeRef.getSnapshot();
+      if (oldShape == null) return;
+
+      const newShape = { ...oldShape, opacity: normalizedOpacity };
+      doc.withTransaction(
+        () => {
+          matchVersion(doc, {
+            1: () => {},
+            2: doc => doc.updateRecord(selectedShapeRef, { opacity: normalizedOpacity }),
+            3: doc => doc.updateRecord(selectedShapeRef, { opacity: normalizedOpacity }),
+          });
+        },
+        ActivityEvents.describeEdit(CanvasActivityModel, {
+          activityType: "shapeUpdated",
+          nodeId: selectedShapeRef.id,
+          oldShape,
+          newShape,
+        }),
+      );
     },
     [doc, selectedShapeRef],
   );
@@ -246,13 +290,19 @@ export function useCanvasInteraction(
       onMouseUp,
     },
     currentColor,
+    currentOpacity,
     currentTool,
     deleteSelected,
     penPoints,
     selectedShapeId: selectedShapeRef?.id,
     setColor,
+    setOpacity,
     setTool,
     shapeRefs,
     strokeRefs,
   };
+}
+
+function normalizeOpacity(opacity: number): number {
+  return Math.min(1, Math.max(0.1, Math.round(opacity * 100) / 100));
 }

--- a/demos/canvas/app/src/pack.ts
+++ b/demos/canvas/app/src/pack.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { asVersioned, DocumentModel } from "@demo/canvas.sdk";
 import type { SupportedVersions, VersionedDocRef } from "@demo/canvas.sdk";
+import { asVersioned, DocumentModel } from "@demo/canvas.sdk";
 import type { PackApp } from "@palantir/pack.core";
 import type { DocumentId } from "@palantir/pack.document-schema.model-types";
 import type { WithStateModule } from "@palantir/pack.state.core";
@@ -31,14 +31,14 @@ export const CanvasSchema = DocumentModel({
     v2: {
       fillColor: ({ color }) => color,
       strokeColor: ({ color }) => color,
-      opacity: () => 1.0,
+      opacity: () => 0.5,
     },
   },
   ShapeCircle: {
     v2: {
       fillColor: ({ color }) => color,
       strokeColor: ({ color }) => color,
-      opacity: () => 1.0,
+      opacity: () => 0.5,
     },
   },
 });

--- a/demos/canvas/sdk/src/_internal/upgrades.ts
+++ b/demos/canvas/sdk/src/_internal/upgrades.ts
@@ -5,8 +5,8 @@ import type { UpgradeRegistry, UnionUpgradeRegistry } from "@palantir/pack.docum
 export const CursorPresenceUpgrades: UpgradeRegistry<"CursorPresence"> = {
   modelName: "CursorPresence",
   allFields: {
-    x: { type: { kind: "primitive" } },
-    y: { type: { kind: "primitive" } },
+    x: { type: { kind: "primitive" }, addedInVersion: 1 },
+    y: { type: { kind: "primitive" }, addedInVersion: 1 },
   },
   steps: [
   ],
@@ -15,8 +15,8 @@ export const CursorPresenceUpgrades: UpgradeRegistry<"CursorPresence"> = {
 export const FreehandStrokeUpgrades: UpgradeRegistry<"FreehandStroke"> = {
   modelName: "FreehandStroke",
   allFields: {
-    color: { type: { kind: "optional", inner: { kind: "primitive" } } },
-    points: { type: { kind: "primitive" } },
+    color: { type: { kind: "optional", inner: { kind: "primitive" } }, addedInVersion: 3 },
+    points: { type: { kind: "primitive" }, addedInVersion: 3 },
   },
   steps: [
   ],
@@ -25,7 +25,7 @@ export const FreehandStrokeUpgrades: UpgradeRegistry<"FreehandStroke"> = {
 export const SelectionPresenceUpgrades: UpgradeRegistry<"SelectionPresence"> = {
   modelName: "SelectionPresence",
   allFields: {
-    selectedNodeIds: { type: { kind: "array", element: { kind: "primitive" } } },
+    selectedNodeIds: { type: { kind: "array", element: { kind: "primitive" } }, addedInVersion: 1 },
   },
   steps: [
   ],
@@ -34,7 +34,7 @@ export const SelectionPresenceUpgrades: UpgradeRegistry<"SelectionPresence"> = {
 export const ShapeAddedActivityUpgrades: UpgradeRegistry<"ShapeAddedActivity"> = {
   modelName: "ShapeAddedActivity",
   allFields: {
-    nodeId: { type: { kind: "primitive" } },
+    nodeId: { type: { kind: "primitive" }, addedInVersion: 1 },
   },
   steps: [
   ],
@@ -43,14 +43,14 @@ export const ShapeAddedActivityUpgrades: UpgradeRegistry<"ShapeAddedActivity"> =
 export const ShapeBoxUpgrades: UpgradeRegistry<"ShapeBox"> = {
   modelName: "ShapeBox",
   allFields: {
-    bottom: { type: { kind: "primitive" } },
-    color: { type: { kind: "optional", inner: { kind: "primitive" } } },
-    fillColor: { type: { kind: "optional", inner: { kind: "primitive" } } },
-    left: { type: { kind: "primitive" } },
-    opacity: { type: { kind: "primitive" } },
-    right: { type: { kind: "primitive" } },
-    strokeColor: { type: { kind: "optional", inner: { kind: "primitive" } } },
-    top: { type: { kind: "primitive" } },
+    bottom: { type: { kind: "primitive" }, addedInVersion: 1 },
+    color: { type: { kind: "optional", inner: { kind: "primitive" } }, addedInVersion: 1 },
+    fillColor: { type: { kind: "optional", inner: { kind: "primitive" } }, addedInVersion: 2 },
+    left: { type: { kind: "primitive" }, addedInVersion: 1 },
+    opacity: { type: { kind: "primitive" }, addedInVersion: 2 },
+    right: { type: { kind: "primitive" }, addedInVersion: 1 },
+    strokeColor: { type: { kind: "optional", inner: { kind: "primitive" } }, addedInVersion: 2 },
+    top: { type: { kind: "primitive" }, addedInVersion: 1 },
   },
   steps: [
     {
@@ -74,14 +74,14 @@ export const ShapeBoxUpgrades: UpgradeRegistry<"ShapeBox"> = {
 export const ShapeCircleUpgrades: UpgradeRegistry<"ShapeCircle"> = {
   modelName: "ShapeCircle",
   allFields: {
-    bottom: { type: { kind: "primitive" } },
-    color: { type: { kind: "optional", inner: { kind: "primitive" } } },
-    fillColor: { type: { kind: "optional", inner: { kind: "primitive" } } },
-    left: { type: { kind: "primitive" } },
-    opacity: { type: { kind: "primitive" } },
-    right: { type: { kind: "primitive" } },
-    strokeColor: { type: { kind: "optional", inner: { kind: "primitive" } } },
-    top: { type: { kind: "primitive" } },
+    bottom: { type: { kind: "primitive" }, addedInVersion: 1 },
+    color: { type: { kind: "optional", inner: { kind: "primitive" } }, addedInVersion: 1 },
+    fillColor: { type: { kind: "optional", inner: { kind: "primitive" } }, addedInVersion: 2 },
+    left: { type: { kind: "primitive" }, addedInVersion: 1 },
+    opacity: { type: { kind: "primitive" }, addedInVersion: 2 },
+    right: { type: { kind: "primitive" }, addedInVersion: 1 },
+    strokeColor: { type: { kind: "optional", inner: { kind: "primitive" } }, addedInVersion: 2 },
+    top: { type: { kind: "primitive" }, addedInVersion: 1 },
   },
   steps: [
     {
@@ -105,7 +105,7 @@ export const ShapeCircleUpgrades: UpgradeRegistry<"ShapeCircle"> = {
 export const ShapeDeletedActivityUpgrades: UpgradeRegistry<"ShapeDeletedActivity"> = {
   modelName: "ShapeDeletedActivity",
   allFields: {
-    nodeId: { type: { kind: "primitive" } },
+    nodeId: { type: { kind: "primitive" }, addedInVersion: 1 },
   },
   steps: [
   ],
@@ -114,9 +114,9 @@ export const ShapeDeletedActivityUpgrades: UpgradeRegistry<"ShapeDeletedActivity
 export const ShapeUpdatedActivityUpgrades: UpgradeRegistry<"ShapeUpdatedActivity"> = {
   modelName: "ShapeUpdatedActivity",
   allFields: {
-    newShape: { type: { kind: "modelRef", model: "NodeShape" } },
-    nodeId: { type: { kind: "primitive" } },
-    oldShape: { type: { kind: "modelRef", model: "NodeShape" } },
+    newShape: { type: { kind: "modelRef", model: "NodeShape" }, addedInVersion: 1 },
+    nodeId: { type: { kind: "primitive" }, addedInVersion: 1 },
+    oldShape: { type: { kind: "modelRef", model: "NodeShape" }, addedInVersion: 1 },
   },
   steps: [
   ],

--- a/packages/document-schema/model-types/src/types/UpgradeLens.ts
+++ b/packages/document-schema/model-types/src/types/UpgradeLens.ts
@@ -34,6 +34,7 @@ export interface FieldLensDef {
 
 export interface FieldDef {
   type: FieldTypeDescriptor;
+  addedInVersion?: number;
 }
 
 export interface UpgradeStepDef {

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/nested-optionals.snap
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/nested-optionals.snap
@@ -22,18 +22,23 @@ import type { UpgradeRegistry } from '@palantir/pack.document-schema.model-types
 export const ConfigUpgrades: UpgradeRegistry<'Config'> = {
   modelName: 'Config',
   allFields: {
-    label: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
+    label: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 1,
+    },
     scores: {
       type: {
         kind: 'array',
         element: { kind: 'optional', inner: { kind: 'primitive' } },
       },
+      addedInVersion: 1,
     },
     tags: {
       type: {
         kind: 'array',
         element: { kind: 'optional', inner: { kind: 'primitive' } },
       },
+      addedInVersion: 1,
     },
   },
   steps: [],

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/nested-union.snap
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/nested-union.snap
@@ -28,7 +28,7 @@ import type {
 export const AnimalUpgrades: UpgradeRegistry<'Animal'> = {
   modelName: 'Animal',
   allFields: {
-    species: { type: { kind: 'primitive' } },
+    species: { type: { kind: 'primitive' }, addedInVersion: 1 },
   },
   steps: [],
 };
@@ -36,7 +36,7 @@ export const AnimalUpgrades: UpgradeRegistry<'Animal'> = {
 export const PlantUpgrades: UpgradeRegistry<'Plant'> = {
   modelName: 'Plant',
   allFields: {
-    genus: { type: { kind: 'primitive' } },
+    genus: { type: { kind: 'primitive' }, addedInVersion: 1 },
   },
   steps: [],
 };

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/single-version.snap
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/single-version.snap
@@ -24,11 +24,14 @@ import type { UpgradeRegistry } from '@palantir/pack.document-schema.model-types
 export const ShapeBoxUpgrades: UpgradeRegistry<'ShapeBox'> = {
   modelName: 'ShapeBox',
   allFields: {
-    bottom: { type: { kind: 'primitive' } },
-    color: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    left: { type: { kind: 'primitive' } },
-    right: { type: { kind: 'primitive' } },
-    top: { type: { kind: 'primitive' } },
+    bottom: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    color: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 1,
+    },
+    left: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    right: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    top: { type: { kind: 'primitive' }, addedInVersion: 1 },
   },
   steps: [],
 };

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/two-version-derived-fields.snap
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/two-version-derived-fields.snap
@@ -47,14 +47,26 @@ import type { UpgradeRegistry } from '@palantir/pack.document-schema.model-types
 export const ShapeBoxUpgrades: UpgradeRegistry<'ShapeBox'> = {
   modelName: 'ShapeBox',
   allFields: {
-    bottom: { type: { kind: 'primitive' } },
-    color: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    fillColor: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    left: { type: { kind: 'primitive' } },
-    opacity: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    right: { type: { kind: 'primitive' } },
-    strokeColor: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    top: { type: { kind: 'primitive' } },
+    bottom: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    color: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 1,
+    },
+    fillColor: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 2,
+    },
+    left: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    opacity: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 2,
+    },
+    right: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    strokeColor: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 2,
+    },
+    top: { type: { kind: 'primitive' }, addedInVersion: 1 },
   },
   steps: [
     {

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/two-version-field-removal.snap
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/two-version-field-removal.snap
@@ -27,14 +27,26 @@ import type { UpgradeRegistry } from '@palantir/pack.document-schema.model-types
 export const ShapeBoxUpgrades: UpgradeRegistry<'ShapeBox'> = {
   modelName: 'ShapeBox',
   allFields: {
-    bottom: { type: { kind: 'primitive' } },
-    color: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    fillColor: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    left: { type: { kind: 'primitive' } },
-    opacity: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    right: { type: { kind: 'primitive' } },
-    strokeColor: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    top: { type: { kind: 'primitive' } },
+    bottom: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    color: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 1,
+    },
+    fillColor: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 2,
+    },
+    left: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    opacity: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 2,
+    },
+    right: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    strokeColor: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 2,
+    },
+    top: { type: { kind: 'primitive' }, addedInVersion: 1 },
   },
   steps: [
     {

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/two-version-optional-fields.snap
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/two-version-optional-fields.snap
@@ -21,8 +21,11 @@ import type { UpgradeRegistry } from '@palantir/pack.document-schema.model-types
 export const ItemUpgrades: UpgradeRegistry<'Item'> = {
   modelName: 'Item',
   allFields: {
-    label: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    name: { type: { kind: 'primitive' } },
+    label: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 1,
+    },
+    name: { type: { kind: 'primitive' }, addedInVersion: 1 },
   },
   steps: [],
 };

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/two-version-required-additive.snap
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/__snapshots__/generateInternalFromSchema/two-version-required-additive.snap
@@ -44,12 +44,15 @@ import type { UpgradeRegistry } from '@palantir/pack.document-schema.model-types
 export const ShapeBoxUpgrades: UpgradeRegistry<'ShapeBox'> = {
   modelName: 'ShapeBox',
   allFields: {
-    bottom: { type: { kind: 'primitive' } },
-    color: { type: { kind: 'optional', inner: { kind: 'primitive' } } },
-    left: { type: { kind: 'primitive' } },
-    opacity: { type: { kind: 'primitive' } },
-    right: { type: { kind: 'primitive' } },
-    top: { type: { kind: 'primitive' } },
+    bottom: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    color: {
+      type: { kind: 'optional', inner: { kind: 'primitive' } },
+      addedInVersion: 1,
+    },
+    left: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    opacity: { type: { kind: 'primitive' }, addedInVersion: 2 },
+    right: { type: { kind: 'primitive' }, addedInVersion: 1 },
+    top: { type: { kind: 'primitive' }, addedInVersion: 1 },
   },
   steps: [
     {

--- a/packages/document-schema/type-gen/src/utils/schema/generateInternalFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateInternalFromSchema.ts
@@ -81,6 +81,10 @@ function sortedEntries<V>(map: Map<string, V>): [string, V][] {
   return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
 }
 
+function getAddedInVersion(fieldInfo: AllFieldInfo): number {
+  return Math.min(...fieldInfo.presentInVersions);
+}
+
 /**
  * Collect all record model info across all versions and compute upgrade steps.
  */
@@ -306,7 +310,9 @@ function generateUpgrades(
         fieldInfo.fieldType,
         fieldInfo.isOptional,
       );
-      output += `    ${fieldName}: { type: ${typeDescriptor} },\n`;
+      output += `    ${fieldName}: { type: ${typeDescriptor}, addedInVersion: ${
+        getAddedInVersion(fieldInfo)
+      } },\n`;
     }
     output += `  },\n`;
 

--- a/packages/state/core/src/__tests__/DocumentUpdateSchemaVersion.test.ts
+++ b/packages/state/core/src/__tests__/DocumentUpdateSchemaVersion.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  DocumentSchema,
+  UpgradeRegistryMap,
+} from "@palantir/pack.document-schema.model-types";
+import { Metadata } from "@palantir/pack.document-schema.model-types";
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import {
+  addDocumentUpdateSchemaVersionToTransaction,
+  getDocumentUpdateSchemaVersionFromTransaction,
+  getModelDataSchemaVersion,
+  getPartialModelDataSchemaVersion,
+} from "../service/DocumentUpdateSchemaVersion.js";
+
+const upgrades: UpgradeRegistryMap = {
+  Activity: {
+    modelName: "Activity",
+    allFields: {
+      newShape: { type: { kind: "modelRef", model: "NodeShape" }, addedInVersion: 1 },
+      title: { type: { kind: "primitive" }, addedInVersion: 1 },
+    },
+    steps: [],
+  },
+  ShapeBox: {
+    modelName: "ShapeBox",
+    allFields: {
+      color: { type: { kind: "primitive" }, addedInVersion: 1 },
+      fillColor: { type: { kind: "primitive" }, addedInVersion: 2 },
+      opacity: { type: { kind: "primitive" }, addedInVersion: 3 },
+    },
+    steps: [],
+  },
+  ShapeCircle: {
+    modelName: "ShapeCircle",
+    allFields: {
+      radius: { type: { kind: "primitive" }, addedInVersion: 1 },
+    },
+    steps: [],
+  },
+  NodeShape: {
+    modelName: "NodeShape",
+    discriminant: "shapeType",
+    variants: {
+      box: "ShapeBox",
+      circle: "ShapeCircle",
+    },
+  },
+};
+
+const schema = {
+  [Metadata]: {
+    minSupportedVersion: 1,
+    upgrades,
+    version: 3,
+  },
+} as DocumentSchema;
+
+describe("DocumentUpdateSchemaVersion", () => {
+  it("uses the max addedInVersion across changed top-level fields", () => {
+    expect(
+      getPartialModelDataSchemaVersion(schema, "ShapeBox", {
+        color: "red",
+        opacity: 0.5,
+      }),
+    ).toBe(3);
+  });
+
+  it("recurses through model refs and unions", () => {
+    expect(
+      getModelDataSchemaVersion(schema, "Activity", {
+        newShape: {
+          fillColor: "red",
+          shapeType: "box",
+        },
+        title: "added",
+      }),
+    ).toBe(2);
+  });
+
+  it("resolves a partial nested union from the current value", () => {
+    expect(
+      getPartialModelDataSchemaVersion(
+        schema,
+        "Activity",
+        {
+          newShape: {
+            fillColor: "blue",
+          },
+        },
+        {
+          newShape: {
+            color: "red",
+            shapeType: "box",
+          },
+          title: "existing",
+        },
+      ),
+    ).toBe(2);
+  });
+
+  it("resolves a partial root union from the current value", () => {
+    expect(
+      getPartialModelDataSchemaVersion(
+        schema,
+        "NodeShape",
+        {
+          opacity: 0.5,
+        },
+        {
+          color: "red",
+          shapeType: "box",
+        },
+      ),
+    ).toBe(3);
+  });
+
+  it("stores the max write version on a Yjs transaction", () => {
+    const yDoc = new Y.Doc();
+    let transaction: Y.Transaction | undefined;
+
+    yDoc.on("update", (_update, _origin, _doc, updateTransaction) => {
+      transaction = updateTransaction;
+    });
+
+    yDoc.transact(activeTransaction => {
+      addDocumentUpdateSchemaVersionToTransaction(activeTransaction, 2);
+      addDocumentUpdateSchemaVersionToTransaction(activeTransaction, 3);
+      yDoc.getMap("ShapeBox").set("shape-1", new Y.Map());
+    });
+
+    expect(transaction).toBeDefined();
+    expect(getDocumentUpdateSchemaVersionFromTransaction(transaction!)).toBe(3);
+  });
+});

--- a/packages/state/core/src/index.ts
+++ b/packages/state/core/src/index.ts
@@ -20,6 +20,13 @@ export {
   type BaseYjsDocumentServiceOptions,
   type InternalYjsDoc,
 } from "./service/BaseYjsDocumentService.js";
+export {
+  addDocumentUpdateSchemaVersionToTransaction,
+  DOCUMENT_UPDATE_SCHEMA_VERSION_META_KEY,
+  getDocumentUpdateSchemaVersionFromTransaction,
+  getModelDataSchemaVersion,
+  getPartialModelDataSchemaVersion,
+} from "./service/DocumentUpdateSchemaVersion.js";
 export { createInMemoryDocumentServiceConfig } from "./service/InMemoryDocumentService.js";
 export { FileSystemType } from "./types/CreateDocumentMetadata.js";
 export type { CreateDocumentMetadata } from "./types/CreateDocumentMetadata.js";

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -59,6 +59,11 @@ import type {
 import { DocumentLiveStatus, DocumentLoadStatus } from "../types/DocumentService.js";
 import { createRecordCollectionRef } from "../types/RecordCollectionRefImpl.js";
 import { createRecordRef } from "../types/RecordRefImpl.js";
+import {
+  addDocumentUpdateSchemaVersionToTransaction,
+  getModelDataSchemaVersion,
+  getPartialModelDataSchemaVersion,
+} from "./DocumentUpdateSchemaVersion.js";
 import * as YjsSchemaMapper from "./YjsSchemaMapper.js";
 
 export interface RecordCollectionSubscriptions<M extends Model = Model> {
@@ -535,11 +540,17 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     // TODO: perhaps we just call this via onRecordSet instead?
 
     const storageName = getMetadata(recordRef.model).name;
+    const documentUpdateSchemaVersion = getModelDataSchemaVersion(
+      internalDoc.schema,
+      storageName,
+      state,
+    );
     YjsSchemaMapper.setRecord(
       internalDoc.yDoc,
       storageName,
       recordRef.id,
       state,
+      documentUpdateSchemaVersion,
     );
 
     this.logger.debug("setRecord", {
@@ -566,11 +577,19 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     );
 
     const storageName = getMetadata(recordRef.model).name;
+    const currentState = this.getRecordSnapshotInternal(internalDoc, recordRef);
+    const documentUpdateSchemaVersion = getPartialModelDataSchemaVersion(
+      internalDoc.schema,
+      storageName,
+      partialState,
+      currentState,
+    );
     const wasUpdated = YjsSchemaMapper.updateRecord(
       internalDoc.yDoc,
       storageName,
       recordRef.id,
       partialState,
+      documentUpdateSchemaVersion,
     );
 
     if (!wasUpdated) {
@@ -882,7 +901,15 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
 
     const existed = recordsCollection.has(record.id as string);
     if (existed) {
-      recordsCollection.delete(record.id as string);
+      const documentUpdateSchemaVersion = getModelDataSchemaVersion(
+        internalDoc.schema,
+        storageName,
+        this.getRecordSnapshotInternal(internalDoc, record),
+      );
+      internalDoc.yDoc.transact(transaction => {
+        addDocumentUpdateSchemaVersionToTransaction(transaction, documentUpdateSchemaVersion);
+        recordsCollection.delete(record.id as string);
+      });
     }
 
     return Promise.resolve();

--- a/packages/state/core/src/service/DocumentUpdateSchemaVersion.ts
+++ b/packages/state/core/src/service/DocumentUpdateSchemaVersion.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  DocumentSchema,
+  FieldDef,
+  FieldTypeDescriptor,
+  UnionUpgradeRegistry,
+  UpgradeRegistry,
+  UpgradeRegistryEntry,
+  UpgradeRegistryMap,
+} from "@palantir/pack.document-schema.model-types";
+import { getMetadata } from "@palantir/pack.document-schema.model-types";
+import type * as Y from "yjs";
+
+export const DOCUMENT_UPDATE_SCHEMA_VERSION_META_KEY =
+  "@palantir/pack.state.core/documentUpdateSchemaVersion";
+
+interface VersionContext {
+  readonly defaultVersion: number;
+  readonly upgrades?: UpgradeRegistryMap;
+}
+
+export function addDocumentUpdateSchemaVersionToTransaction(
+  transaction: Y.Transaction,
+  documentUpdateSchemaVersion: number,
+): void {
+  const currentVersion = getDocumentUpdateSchemaVersionFromTransaction(transaction);
+  transaction.meta.set(
+    DOCUMENT_UPDATE_SCHEMA_VERSION_META_KEY,
+    Math.max(currentVersion ?? 0, documentUpdateSchemaVersion),
+  );
+}
+
+export function getDocumentUpdateSchemaVersionFromTransaction(
+  transaction: Y.Transaction,
+): number | undefined {
+  const value = transaction.meta.get(DOCUMENT_UPDATE_SCHEMA_VERSION_META_KEY);
+  return typeof value === "number" ? value : undefined;
+}
+
+export function getModelDataSchemaVersion(
+  schema: DocumentSchema,
+  modelName: string,
+  value: unknown,
+): number {
+  return getModelValueSchemaVersion(modelName, value, getVersionContext(schema));
+}
+
+export function getPartialModelDataSchemaVersion(
+  schema: DocumentSchema,
+  modelName: string,
+  partialValue: unknown,
+  currentValue?: unknown,
+): number {
+  return getModelValueSchemaVersion(
+    modelName,
+    partialValue,
+    getVersionContext(schema),
+    currentValue,
+  );
+}
+
+function getVersionContext(schema: DocumentSchema): VersionContext {
+  const schemaMeta = getMetadata(schema);
+  return {
+    defaultVersion: schemaMeta.minSupportedVersion ?? schemaMeta.version,
+    upgrades: schemaMeta.upgrades,
+  };
+}
+
+function getModelValueSchemaVersion(
+  modelName: string,
+  value: unknown,
+  context: VersionContext,
+  currentValue?: unknown,
+): number {
+  const entry = context.upgrades?.[modelName];
+  if (entry == null) {
+    return context.defaultVersion;
+  }
+
+  if (isUnionUpgradeRegistry(entry)) {
+    const variantModelName = getUnionVariantModelName(entry, value)
+      ?? getUnionVariantModelName(entry, currentValue);
+    return variantModelName == null
+      ? context.defaultVersion
+      : getModelValueSchemaVersion(variantModelName, value, context, currentValue);
+  }
+
+  return getRecordFieldsSchemaVersion(modelName, value, context, currentValue);
+}
+
+function getRecordFieldsSchemaVersion(
+  modelName: string,
+  value: unknown,
+  context: VersionContext,
+  currentValue?: unknown,
+): number {
+  const entry = context.upgrades?.[modelName];
+  if (!isRecordUpgradeRegistry(entry)) {
+    return context.defaultVersion;
+  }
+
+  const state = toPlainObject(value);
+  if (state == null) {
+    return context.defaultVersion;
+  }
+
+  const currentState = toPlainObject(currentValue);
+  let maxVersion = context.defaultVersion;
+  for (const [fieldName, fieldValue] of Object.entries(state)) {
+    const fieldDef = entry.allFields[fieldName];
+    if (fieldDef == null) {
+      continue;
+    }
+
+    maxVersion = Math.max(
+      maxVersion,
+      getFieldAddedInVersion(fieldDef, context.defaultVersion),
+      getFieldTypeValueSchemaVersion(
+        fieldDef.type,
+        fieldValue,
+        context,
+        currentState?.[fieldName],
+      ),
+    );
+  }
+  return maxVersion;
+}
+
+function getFieldTypeValueSchemaVersion(
+  descriptor: FieldTypeDescriptor,
+  value: unknown,
+  context: VersionContext,
+  currentValue?: unknown,
+): number {
+  const normalizedDescriptor = unwrapOptional(descriptor);
+  switch (normalizedDescriptor.kind) {
+    case "modelRef":
+      return getModelValueSchemaVersion(
+        normalizedDescriptor.model,
+        value,
+        context,
+        currentValue,
+      );
+    case "array":
+      if (!Array.isArray(value)) {
+        return context.defaultVersion;
+      }
+      {
+        const currentItems = Array.isArray(currentValue) ? currentValue : undefined;
+        return value.reduce<number>(
+          (maxVersion, item, index) =>
+            Math.max(
+              maxVersion,
+              getFieldTypeValueSchemaVersion(
+                normalizedDescriptor.element,
+                item,
+                context,
+                currentItems?.[index],
+              ),
+            ),
+          context.defaultVersion,
+        );
+      }
+    case "map": {
+      const entries = toPlainObject(value);
+      const currentEntries = toPlainObject(currentValue);
+      if (entries == null) {
+        return context.defaultVersion;
+      }
+      let maxVersion = context.defaultVersion;
+      for (const [key, mapValue] of Object.entries(entries)) {
+        maxVersion = Math.max(
+          maxVersion,
+          getFieldTypeValueSchemaVersion(
+            normalizedDescriptor.value,
+            mapValue,
+            context,
+            currentEntries?.[key],
+          ),
+        );
+      }
+      return maxVersion;
+    }
+    case "primitive":
+      return context.defaultVersion;
+    case "optional":
+      return context.defaultVersion;
+  }
+}
+
+function getUnionVariantModelName(
+  entry: UnionUpgradeRegistry,
+  value: unknown,
+): string | undefined {
+  const state = toPlainObject(value);
+  if (state == null) {
+    return undefined;
+  }
+
+  const variantKey = state[entry.discriminant];
+  return typeof variantKey === "string" ? entry.variants[variantKey] : undefined;
+}
+
+function getFieldAddedInVersion(fieldDef: FieldDef, defaultVersion: number): number {
+  return fieldDef.addedInVersion ?? defaultVersion;
+}
+
+function unwrapOptional(descriptor: FieldTypeDescriptor): FieldTypeDescriptor {
+  let current = descriptor;
+  while (current.kind === "optional") {
+    current = current.inner;
+  }
+  return current;
+}
+
+function toPlainObject(value: unknown): Record<string, unknown> | undefined {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function isRecordUpgradeRegistry(
+  entry: UpgradeRegistryEntry | undefined,
+): entry is UpgradeRegistry {
+  return entry != null && "allFields" in entry;
+}
+
+function isUnionUpgradeRegistry(
+  entry: UpgradeRegistryEntry | undefined,
+): entry is UnionUpgradeRegistry {
+  return entry != null && "variants" in entry;
+}

--- a/packages/state/core/src/service/YjsSchemaMapper.ts
+++ b/packages/state/core/src/service/YjsSchemaMapper.ts
@@ -25,6 +25,7 @@ import {
 } from "@palantir/pack.document-schema.model-types";
 import * as Y from "yjs";
 import { resolveAndApplyLens } from "../upgrade/UpgradeLens.js";
+import { addDocumentUpdateSchemaVersionToTransaction } from "./DocumentUpdateSchemaVersion.js";
 
 export function initializeDocumentStructure(
   yDoc: Y.Doc,
@@ -57,13 +58,17 @@ export function setRecord(
   storageName: string,
   recordId: RecordId,
   state: ModelData<Model>,
+  documentUpdateSchemaVersion?: number,
 ): boolean {
   const recordsCollection = getRecordsMap(yDoc, storageName);
   const currentRecord = recordsCollection.get(recordId as string) as Y.Map<unknown> | undefined;
   const wasExisting = currentRecord != null;
 
   // Use transaction for atomic update
-  yDoc.transact(() => {
+  yDoc.transact(transaction => {
+    if (documentUpdateSchemaVersion != null) {
+      addDocumentUpdateSchemaVersionToTransaction(transaction, documentUpdateSchemaVersion);
+    }
     if (currentRecord != null) {
       // Clear existing record completely
       currentRecord.clear();
@@ -107,6 +112,7 @@ export function updateRecord(
   storageName: string,
   recordId: RecordId,
   partialState: Partial<ModelData<Model>>,
+  documentUpdateSchemaVersion?: number,
 ): boolean {
   const recordsCollection = getRecordsMap(yDoc, storageName);
   const currentRecord = recordsCollection.get(recordId as string) as Y.Map<unknown> | undefined;
@@ -116,7 +122,10 @@ export function updateRecord(
   }
 
   // Use transaction for atomic partial update
-  yDoc.transact(() => {
+  yDoc.transact(transaction => {
+    if (documentUpdateSchemaVersion != null) {
+      addDocumentUpdateSchemaVersionToTransaction(transaction, documentUpdateSchemaVersion);
+    }
     updateYMapFromPartialState(currentRecord, partialState);
   });
 

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -36,7 +36,11 @@ import {
   getMetadata,
   hasMetadata,
 } from "@palantir/pack.document-schema.model-types";
-import { DocumentLoadStatus, type DocumentSyncStatus } from "@palantir/pack.state.core";
+import {
+  DocumentLoadStatus,
+  type DocumentSyncStatus,
+  getDocumentUpdateSchemaVersionFromTransaction,
+} from "@palantir/pack.state.core";
 import { Base64 } from "js-base64";
 import * as y from "yjs";
 import { type CometDLoader, EventServiceCometD } from "./cometd/EventServiceCometD.js";
@@ -103,7 +107,12 @@ interface SyncSessionInternal extends SyncSession {
   activitySubscriptionId?: SubscriptionId;
   documentSubscriptionId?: SubscriptionId;
   lastRevisionId?: number;
-  localYDocUpdateHandler?: (update: Uint8Array, origin: unknown) => void;
+  localYDocUpdateHandler?: (
+    update: Uint8Array,
+    origin: unknown,
+    doc: y.Doc,
+    transaction: y.Transaction,
+  ) => void;
   metadataSubscriptionId?: SubscriptionId;
   presenceSubscriptionId?: SubscriptionId;
   yDoc?: y.Doc;
@@ -199,7 +208,12 @@ class FoundryEventServiceImpl implements FoundryEventService {
       throw new Error(`Document data sync already active for document ${documentId}`);
     }
 
-    const localYDocUpdateHandler = (update: Uint8Array, origin: unknown) => {
+    const localYDocUpdateHandler = (
+      update: Uint8Array,
+      origin: unknown,
+      _doc: y.Doc,
+      transaction: y.Transaction,
+    ) => {
       if (origin === UPDATE_ORIGIN_REMOTE) {
         return;
       }
@@ -218,17 +232,21 @@ class FoundryEventServiceImpl implements FoundryEventService {
       const description = isEditDescription(origin)
         ? createDocumentEditDescription(origin)
         : undefined;
+      const documentUpdateSchemaVersion = getDocumentUpdateSchemaVersionFromTransaction(transaction)
+        ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange);
+      const publishMessage: DocumentPublishMessage = {
+        clientId: session.clientId,
+        clientSupportedVersionRange,
+        description,
+        documentUpdateSchemaVersion,
+        editId,
+        yjsUpdate: {
+          data: Base64.fromUint8Array(update),
+        },
+      };
       void this.eventService.publish(
         publishChannelId,
-        {
-          clientId: session.clientId,
-          clientSupportedVersionRange,
-          description,
-          editId,
-          yjsUpdate: {
-            data: Base64.fromUint8Array(update),
-          },
-        },
+        publishMessage,
       ).catch((error: unknown) => {
         this.logger.error("Failed to publish document update", error, {
           docId: documentId,
@@ -598,4 +616,14 @@ function createDocumentEditDescription(editDescription: EditDescription): Docume
     // TODO: remove duplicate after updating platform sdk
     eventType,
   };
+}
+
+function getFallbackDocumentUpdateSchemaVersion(
+  clientSupportedVersionRange: ClientSupportedVersionRange,
+): number {
+  const { maxVersion } = clientSupportedVersionRange;
+  if (Number.isFinite(maxVersion)) {
+    return maxVersion;
+  }
+  return clientSupportedVersionRange.minVersion;
 }

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DocumentUpdateMessage } from "@osdk/foundry.pack";
+import type { PackAppInternal } from "@palantir/pack.core";
+import type { DocumentId } from "@palantir/pack.document-schema.model-types";
+import {
+  addDocumentUpdateSchemaVersionToTransaction,
+  type DocumentSyncStatus,
+} from "@palantir/pack.state.core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+import { createFoundryEventService } from "../FoundryEventService.js";
+import type { SubscriptionId } from "../types/EventService.js";
+
+interface PublishedDocumentUpdate {
+  readonly documentUpdateSchemaVersion?: number;
+  readonly yjsUpdate?: {
+    readonly data?: unknown;
+  };
+}
+
+const mocks = vi.hoisted(() => {
+  const eventService = {
+    publish: vi.fn(),
+    setLogLevel: vi.fn(),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+  };
+  return { eventService };
+});
+
+vi.mock("../cometd/EventServiceCometD.js", () => ({
+  EventServiceCometD: vi.fn(function() {
+    return mocks.eventService;
+  }),
+}));
+
+const logger = {
+  child: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+logger.child.mockReturnValue(logger);
+
+const app = {
+  config: {
+    logger,
+  },
+} as unknown as PackAppInternal;
+
+describe("FoundryEventService", () => {
+  beforeEach(() => {
+    mocks.eventService.publish.mockReset();
+    mocks.eventService.publish.mockResolvedValue(undefined);
+    mocks.eventService.subscribe.mockReset();
+    mocks.eventService.unsubscribe.mockReset();
+  });
+
+  it("publishes documentUpdateSchemaVersion for local Yjs updates", async () => {
+    let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+    mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+      updateCallback = callback as (message: DocumentUpdateMessage) => void;
+      return Promise.resolve("sub-1" as SubscriptionId);
+    });
+
+    const yDoc = new Y.Doc();
+    const service = createFoundryEventService(app);
+    const statusUpdates: Array<Partial<DocumentSyncStatus>> = [];
+
+    service.startDocumentSync(
+      "doc-1" as DocumentId,
+      yDoc,
+      { maxVersion: 2, minVersion: 1 },
+      status => statusUpdates.push(status),
+    );
+
+    await Promise.resolve();
+    updateCallback?.({
+      baseRevisionId: "0",
+      clientId: "server",
+      editIds: [],
+      revisionId: "1",
+      type: "update",
+    });
+
+    yDoc.transact(transaction => {
+      addDocumentUpdateSchemaVersionToTransaction(transaction, 2);
+      yDoc.getMap("Shape").set("shape-1", new Y.Map());
+    });
+
+    expect(mocks.eventService.publish).toHaveBeenCalledWith(
+      "/document/doc-1/publish",
+      expect.any(Object),
+    );
+    const publishCall = mocks.eventService.publish.mock.calls[0] as
+      | [unknown, PublishedDocumentUpdate]
+      | undefined;
+    expect(publishCall?.[1].documentUpdateSchemaVersion).toBe(2);
+    expect(typeof publishCall?.[1].yjsUpdate?.data).toBe("string");
+    expect(statusUpdates.at(-1)?.error).toBeUndefined();
+  });
+});

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -521,9 +521,11 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
 }
 
 function getClientSupportedVersionRange(schema: DocumentSchema): ClientSupportedVersionRange {
-  const version = getMetadata(schema).version;
-  // TODO: Placeholder versions from schema now, update when migration story is complete and implemented
-  return { minVersion: version, maxVersion: version };
+  const schemaMeta = getMetadata(schema);
+  return {
+    minVersion: schemaMeta.minSupportedVersion ?? schemaMeta.version,
+    maxVersion: schemaMeta.version,
+  };
 }
 
 function getWireSecurity({


### PR DESCRIPTION
The client now stamps each local Yjs update with the correct document schema version so backend can bump/validate document versions as necessary.

  ```text
  User edit
    -> BaseYjsDocumentService set/update/delete record
    -> DocumentUpdateSchemaVersion walks the edited model data
    -> computes max addedInVersion among fields touched by the edit
    -> stores that value on the Yjs transaction meta
    -> FoundryEventService reads transaction meta during yDoc "update"
    -> publishes DocumentPublishMessage.documentUpdateSchemaVersion
    -> backend compares to document canonical version and bumps if higher, also prevents writes if somehow a leaky write occurred > operational version 

  Example:
  Shape opacity added in v2

  updateRecord(shape, { opacity: 0.5 })
    -> touched field: opacity
    -> required write version: 2
    -> publish message includes documentUpdateSchemaVersion: 2

If client is on v2 and sends only v1 updates, documentUpdateSchemaVersion will = 1