### PR TITLE
Refactor type-gen ir deploy command

### DIFF
--- a/.changeset/busy-hands-dress.md
+++ b/.changeset/busy-hands-dress.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.document-schema.type-gen": minor
+---
+
+refactor deploy command for chained ir schema input and demo build document type script for easier deployment.

--- a/demos/canvas/README.md
+++ b/demos/canvas/README.md
@@ -151,12 +151,19 @@ The generated SDK also emits this value as `DOCUMENT_TYPE_NAME`, so app code can
 use the SDK constant as the code-level source of truth when runtime env
 overrides are not needed.
 
-To test the demo app against a real backend, manually deploy the document type
-to Foundry first. The app creates documents by document type name, so create
-will fail if that type has not been registered in the target stack.
+To test the demo app against a real backend with your own document type,
+manually deploy the document type to Foundry first. The app creates documents
+by document type name, so create will fail if that type has not been registered in the target stack.
 
-TODO: Update this section with the deploy command after the deploy handler is
-updated for the current IR pipeline.
+From the repository root, run:
+
+```bash
+pnpm --filter @demo/canvas.schema deploy:document-type
+```
+
+This script reads the same app env files used by the Vite dev server, builds
+the current schema IR, and deploys the document type to `VITE_FOUNDRY_URL`
+using `VITE_DEV_FOUNDRY_TOKEN`.
 
 Use `VITE_PACK_FILE_SYSTEM_TYPE=ARTIFACTS` for artifact-backed documents. Use
 `VITE_PACK_FILE_SYSTEM_TYPE=COMPASS` for Compass-backed documents and provide

--- a/demos/canvas/schema/package.json
+++ b/demos/canvas/schema/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build:ir": "type-gen schema ir -i src/schema.mjs -o build/ir.json --config pack-config.json",
     "clean": "rimraf .turbo build dist lib test-output *.tgz tsconfig.tsbuildinfo",
+    "deploy:document-type": "bash scripts/deploy-document-type.sh",
     "lint": "eslint ./src && dprint check --config $(find-up dprint.json) --allow-no-files",
     "lint:fix": "eslint ./src --fix && dprint fmt --config $(find-up dprint.json) --allow-no-files",
     "sdk-gen": "bash scripts/build-sdk.sh",

--- a/demos/canvas/schema/scripts/deploy-document-type.sh
+++ b/demos/canvas/schema/scripts/deploy-document-type.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCHEMA_DIR="demos/canvas/schema" # Relative to git root
+APP_DIR="demos/canvas/app" # Relative to git root
+REPO_DIR="$(git rev-parse --show-toplevel)"
+
+cd "$REPO_DIR" || exit 1
+
+load_env_file() {
+  local env_file="$1"
+  if [[ -f "$env_file" ]]; then
+    echo "Loading env from $env_file"
+    set -a
+    # shellcheck disable=SC1090
+    source "$env_file"
+    set +a
+  fi
+}
+
+# Mirror the Vite dev-server env file order so this schema deploy uses the
+# same app configuration. Later files override earlier ones:
+# defaults -> local overrides -> development defaults -> development overrides.
+load_env_file "$APP_DIR/.env"
+load_env_file "$APP_DIR/.env.local"
+load_env_file "$APP_DIR/.env.development"
+load_env_file "$APP_DIR/.env.development.local"
+
+FOUNDRY_BASE_URL="${VITE_FOUNDRY_URL:-}"
+AUTH_TOKEN="${VITE_DEV_FOUNDRY_TOKEN:-}"
+PARENT_FOLDER_RID="${VITE_PACK_PARENT_FOLDER_RID:-}"
+FILE_SYSTEM_TYPE="${VITE_PACK_FILE_SYSTEM_TYPE:-ARTIFACTS}"
+
+if [[ -z "$FOUNDRY_BASE_URL" ]]; then
+  echo "ERROR: VITE_FOUNDRY_URL must be set in the environment or app env files."
+  exit 1
+fi
+
+if [[ -z "$AUTH_TOKEN" ]]; then
+  echo "ERROR: VITE_DEV_FOUNDRY_TOKEN must be set before deploying."
+  exit 1
+fi
+
+if [[ -z "$PARENT_FOLDER_RID" ]]; then
+  echo "ERROR: VITE_PACK_PARENT_FOLDER_RID must be set for type-gen ir deploy."
+  exit 1
+fi
+
+if [[ "$FILE_SYSTEM_TYPE" != "ARTIFACTS" && "$FILE_SYSTEM_TYPE" != "COMPASS" ]]; then
+  echo "ERROR: VITE_PACK_FILE_SYSTEM_TYPE must be ARTIFACTS or COMPASS."
+  exit 1
+fi
+
+echo "Building canvas IR..."
+pnpm --filter @demo/canvas.schema build:ir
+
+echo "Building type-gen CLI..."
+pnpm --filter @palantir/pack.document-schema.type-gen transpileEsm
+
+echo "Deploying document type to $FOUNDRY_BASE_URL..."
+cd "$SCHEMA_DIR" || exit 1
+pnpm exec type-gen ir deploy \
+  --ir build/ir.json \
+  --base-url "$FOUNDRY_BASE_URL" \
+  --auth "$AUTH_TOKEN" \
+  --parent-folder "$PARENT_FOLDER_RID" \
+  --file-system-type "$FILE_SYSTEM_TYPE"
+
+echo "Document type deploy submitted. Verify your document type has been created in your designated project parent folder."

--- a/packages/document-schema/type-gen/src/commands/ir/__tests__/resolveIrInput.test.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/__tests__/resolveIrInput.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { IRealTimeDocumentSchema } from "../../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import { resolveIrInput } from "../resolveIrInput.js";
+
+function ir(version: number): IRealTimeDocumentSchema {
+  return {
+    name: `Test v${version}`,
+    description: "Test schema",
+    version,
+    primaryModelKeys: [],
+    models: {},
+  };
+}
+
+describe("resolveIrInput", () => {
+  it("passes through legacy single-version IR", () => {
+    const resolved = resolveIrInput(ir(2), "legacy.json");
+
+    expect(resolved).toEqual({
+      ir: ir(2),
+      latestVersion: 2,
+      minSupportedVersion: 2,
+    });
+  });
+
+  it("selects the latest entry from a versioned IR chain", () => {
+    const resolved = resolveIrInput({
+      latestVersion: 3,
+      minSupportedVersion: 1,
+      chain: [
+        { version: 1, ir: ir(1) },
+        { version: 3, ir: ir(3) },
+      ],
+    }, "chain.json");
+
+    expect(resolved).toEqual({
+      ir: ir(3),
+      latestVersion: 3,
+      minSupportedVersion: 1,
+    });
+  });
+
+  it("defaults chain minSupportedVersion to latestVersion", () => {
+    const resolved = resolveIrInput({
+      latestVersion: 3,
+      chain: [
+        { version: 1, ir: ir(1) },
+        { version: 3, ir: ir(3) },
+      ],
+    }, "chain.json");
+
+    expect(resolved.minSupportedVersion).toBe(3);
+  });
+
+  it("rejects an empty chain", () => {
+    expect(() =>
+      resolveIrInput({
+        latestVersion: 1,
+        chain: [],
+      }, "empty.json")
+    ).toThrow("chain");
+  });
+
+  it("rejects a chain with an invalid minSupportedVersion", () => {
+    expect(() =>
+      resolveIrInput({
+        latestVersion: 3,
+        minSupportedVersion: 2,
+        chain: [
+          { version: 1, ir: ir(1) },
+          { version: 3, ir: ir(3) },
+        ],
+      }, "missing.json")
+    ).toThrow("minSupportedVersion 2");
+  });
+});

--- a/packages/document-schema/type-gen/src/commands/ir/irDeployHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irDeployHandler.ts
@@ -21,9 +21,9 @@ import { CommanderError } from "commander";
 import { consola } from "consola";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import type { IRealTimeDocumentSchema } from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
 import { convertIrToWireSchema } from "../../utils/ir/convertIrToWireSchema.js";
 import type { FileSystemType } from "../types.js";
+import { resolveIrInput } from "./resolveIrInput.js";
 
 interface DeployOptions {
   readonly ir: string;
@@ -41,8 +41,7 @@ export async function irDeployHandler(options: DeployOptions): Promise<void> {
 
     const irContent = readFileSync(irPath, "utf8");
 
-    // TODO: conjureToZod based validation that IR content matches the conjure IR shape
-    const ir = JSON.parse(irContent) as IRealTimeDocumentSchema;
+    const { ir } = resolveIrInput(JSON.parse(irContent) as unknown, irPath);
 
     const osdkClient = createPlatformClient(
       options.baseUrl,

--- a/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
@@ -18,11 +18,10 @@ import { CommanderError } from "commander";
 import { consola } from "consola";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { basename, dirname, extname, join, resolve } from "path";
-import type { IRealTimeDocumentSchema } from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
 import { GENERATED_JSON_COMMENT } from "../../utils/generatedFileHeader.js";
 import { convertIrToWireSchema } from "../../utils/ir/convertIrToWireSchema.js";
-import { type IrChainPayload, resolveMinVersion } from "../../utils/schema/resolveSchemaChain.js";
 import type { DocumentTypeAsset, FileSystemType } from "../types.js";
+import { resolveIrInput } from "./resolveIrInput.js";
 
 interface IrGenAssetOptions {
   readonly ir: string;
@@ -34,50 +33,6 @@ interface IrGenAssetOptions {
 interface SchemaCompatibilityRangeFile {
   readonly min: number;
   readonly max: number;
-}
-
-interface ResolvedIrInput {
-  readonly ir: IRealTimeDocumentSchema;
-  readonly latestVersion: number;
-  readonly minSupportedVersion: number;
-}
-
-function isChainPayload(parsed: unknown): parsed is IrChainPayload {
-  return (
-    typeof parsed === "object"
-    && parsed != null
-    && "chain" in parsed
-    && Array.isArray((parsed as IrChainPayload).chain)
-    && typeof (parsed as IrChainPayload).latestVersion === "number"
-  );
-}
-
-function resolveFromChain(payload: IrChainPayload, irPath: string): ResolvedIrInput {
-  if (payload.chain.length === 0) {
-    throw new CommanderError(
-      1,
-      "EINVAL",
-      `Invalid IR chain payload at ${irPath}: 'chain' is empty`,
-    );
-  }
-  const { latestVersion, minVersion } = resolveMinVersion(
-    payload.chain,
-    payload.minSupportedVersion,
-  );
-  const latestEntry = payload.chain.find(c => c.version === latestVersion);
-  if (latestEntry == null) {
-    throw new CommanderError(
-      1,
-      "EINVAL",
-      `IR chain payload at ${irPath} has no entry matching latestVersion ${latestVersion}`,
-    );
-  }
-  return { ir: latestEntry.ir, latestVersion, minSupportedVersion: minVersion };
-}
-
-function resolveFromSingleIr(ir: IRealTimeDocumentSchema): ResolvedIrInput {
-  // Legacy single-IR input has no chain, so min defaults to max (no back-compat claim).
-  return { ir, latestVersion: ir.version, minSupportedVersion: ir.version };
 }
 
 function deriveCompatibilityRangePath(assetOutputPath: string): string {
@@ -117,9 +72,7 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
     consola.info(`Reading IR schema from: ${irPath}`);
     const parsed = JSON.parse(readFileSync(irPath, "utf8")) as unknown;
 
-    const resolved = isChainPayload(parsed)
-      ? resolveFromChain(parsed, irPath)
-      : resolveFromSingleIr(parsed as IRealTimeDocumentSchema);
+    const resolved = resolveIrInput(parsed, irPath);
 
     const { ir: irSchema, latestVersion, minSupportedVersion } = resolved;
     const { name: documentTypeName } = irSchema;

--- a/packages/document-schema/type-gen/src/commands/ir/registerIrCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/registerIrCommands.ts
@@ -66,7 +66,10 @@ export function registerIrCommands(program: Command): void {
   irCmd
     .command("deploy")
     .description("Create a document type on a Foundry stack using an IR document schema")
-    .requiredOption("-i, --ir <file>", "Path to IR JSON file")
+    .requiredOption(
+      "-i, --ir <file>",
+      "Path to IR JSON file (chain payload from 'schema ir', or legacy single-version IR)",
+    )
     .requiredOption("-b, --base-url <url>", "Base URL for Foundry API")
     .requiredOption("-a, --auth <token>", "Authentication token for Foundry API")
     .requiredOption("-p, --parent-folder <rid>", "Parent folder RID for the document type")

--- a/packages/document-schema/type-gen/src/commands/ir/resolveIrInput.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/resolveIrInput.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommanderError } from "commander";
+import type { IRealTimeDocumentSchema } from "../../lib/pack-docschema-api/pack-docschema-ir/index.js";
+import { type IrChainPayload, resolveMinVersion } from "../../utils/schema/resolveSchemaChain.js";
+
+export interface ResolvedIrInput {
+  readonly ir: IRealTimeDocumentSchema;
+  readonly latestVersion: number;
+  readonly minSupportedVersion: number;
+}
+
+function isChainPayload(parsed: unknown): parsed is IrChainPayload {
+  return (
+    typeof parsed === "object"
+    && parsed != null
+    && "chain" in parsed
+    && Array.isArray((parsed as IrChainPayload).chain)
+    && typeof (parsed as IrChainPayload).latestVersion === "number"
+  );
+}
+
+function resolveFromChain(payload: IrChainPayload, irPath: string): ResolvedIrInput {
+  if (payload.chain.length === 0) {
+    throw new CommanderError(
+      1,
+      "EINVAL",
+      `Invalid IR chain payload at ${irPath}: 'chain' is empty`,
+    );
+  }
+  const { latestVersion, minVersion } = resolveMinVersion(
+    payload.chain,
+    payload.minSupportedVersion,
+  );
+  const latestEntry = payload.chain.find(c => c.version === latestVersion);
+  if (latestEntry == null) {
+    throw new CommanderError(
+      1,
+      "EINVAL",
+      `IR chain payload at ${irPath} has no entry matching latestVersion ${latestVersion}`,
+    );
+  }
+  return { ir: latestEntry.ir, latestVersion, minSupportedVersion: minVersion };
+}
+
+function resolveFromSingleIr(ir: IRealTimeDocumentSchema): ResolvedIrInput {
+  return { ir, latestVersion: ir.version, minSupportedVersion: ir.version };
+}
+
+export function resolveIrInput(parsed: unknown, irPath: string): ResolvedIrInput {
+  return isChainPayload(parsed)
+    ? resolveFromChain(parsed, irPath)
+    : resolveFromSingleIr(parsed as IRealTimeDocumentSchema);
+}

--- a/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
@@ -119,9 +119,9 @@ export async function readPackConfig(configPath: string): Promise<PackConfigValu
  *    downstream tools default to supporting only the latest schema version.
  *
  * Note: this is distinct from the legacy single-version IR JSON consumed by
- * `ir deploy` / `ir zod`, which is a bare `IRealTimeDocumentSchema` (no chain,
- * no migrations). Tools that previously read that format should pick the
- * entry matching `latestVersion` from `chain` and use its `ir` field.
+ * `ir zod`, which is a bare `IRealTimeDocumentSchema` (no chain, no migrations).
+ * Tools that previously read that format should pick the entry matching
+ * `latestVersion` from `chain` and use its `ir` field.
  */
 export async function schemaIrHandler(options: SchemaIrOptions): Promise<void> {
   const { input, output, config } = options;


### PR DESCRIPTION
Refactors the `type-gen ir deploy` for ODSK apps using the new chained schema ir input. The command will still be backwards compatible with legacy schema ir for the time-being. PR also includes a deploy:document-type script in the canvas demo both as a template and for convenience in deploying document types. Script rebuilds type-gen and rewrites ir schema and then deploys document type.

```
`pnpm --filter @demo/canvas.schema deploy:document-type

> @demo/canvas.schema@0.1.0 deploy:document-type /Volumes/git/pack/demos/canvas/schema
> bash scripts/deploy-document-type.sh

Loading env from demos/canvas/app/.env.development
Loading env from demos/canvas/app/.env.development.local
Building canvas IR...

> @demo/canvas.schema@0.1.0 build:ir /Volumes/git/pack/demos/canvas/schema
> type-gen schema ir -i src/schema.mjs -o build/ir.json --config pack-config.json

ℹ Loading schema from: src/schema.mjs                                                                       11:19:01 AM
ℹ Resolving versioned IR chain...                                                                           11:19:01 AM
✔ Wrote IR chain (3 version(s), min=1, max=3) to: /Volumes/git/pack/demos/canvas/schema/build/ir.json       11:19:01 AM
Building type-gen CLI...

> @palantir/pack.document-schema.type-gen@0.13.0 transpileEsm /Volumes/git/pack/packages/document-schema/type-gen
> monorepo-transpile -f esm -m normal -t node

[baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
👍
Deploying document type to https://danube-staging.palantircloud.com...
ℹ Reading schema from: /Volumes/git/pack/demos/canvas/schema/build/ir.json                                  11:19:02 AM
ℹ Creating document type with schema { name: 'yt-canvas-demo-test-ir-deploy8',                              11:19:02 AM
  parentFolderRid: 'ri.compass.main.folder.a8f3904d-4363-495e-9051-56958b56a86f',
  schema:
   { primaryModelKeys:
      [ 'NodeShape',
        'ShapeBox',
        'ShapeCircle',
        'CanvasActivity',
        'ShapeAddedActivity',
        'ShapeDeletedActivity',
        'ShapeUpdatedActivity',
        'CursorPresence',
        'SelectionPresence',
        'FreehandStroke' ],
     models:
      { NodeShape: [Object],
        ShapeBox: [Object],
        ShapeCircle: [Object],
        CanvasActivity: [Object],
        ShapeAddedActivity: [Object],
        ShapeDeletedActivity: [Object],
        ShapeUpdatedActivity: [Object],
        CursorPresence: [Object],
        SelectionPresence: [Object],
        FreehandStroke: [Object] } },
  fileSystemType: 'ARTIFACTS' }
[11:19:02 AM] ℹ Deploy fetch attempt 1: POST https://danube-staging.palantircloud.com/api/v2/pack/documentTypes?preview=true
ℹ Deploy fetch attempt 1 response: 200 OK                                                                   11:19:03 AM
Document type deploy submitted.`
```