### PR TITLE
Add demos/canvas/schema script for upgrade:schema

### DIFF
--- a/.changeset/bright-hats-own.md
+++ b/.changeset/bright-hats-own.md
@@ -1,0 +1,20 @@
+---
+"@palantir/pack.sdkgen.pack-versioned-template": patch
+"@palantir/pack.document-schema.model-types": patch
+"@palantir/pack.sdkgen.demo-template": patch
+"@palantir/pack.sdkgen.pack-template": patch
+"@palantir/pack.document-schema.type-gen": patch
+"@palantir/pack.state.foundry-event": patch
+"@palantir/pack.sdkgen": patch
+"@palantir/pack.state.foundry": patch
+"@palantir/pack.auth.foundry": patch
+"@palantir/pack.state.react": patch
+"@palantir/pack.state.core": patch
+"@palantir/pack.state.demo": patch
+"@palantir/pack.auth": patch
+"@palantir/pack.schema": patch
+"@palantir/pack.core": patch
+"@palantir/pack.app": patch
+---
+
+Add `max-version` parameter to schema IR generation to cap generation at a given version

--- a/demos/canvas/schema/package.json
+++ b/demos/canvas/schema/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/palantir/pack.git"
   },
   "scripts": {
+    "build:asset": "pnpm run build:ir && type-gen ir asset -i build/ir.json -o build/asset.json",
     "build:ir": "type-gen schema ir -i src/schema.mjs -o build/ir.json --config pack-config.json",
     "clean": "rimraf .turbo build dist lib test-output *.tgz tsconfig.tsbuildinfo",
     "deploy:document-type": "bash scripts/deploy-document-type.sh",
@@ -17,7 +18,8 @@
     "sdk-gen": "bash scripts/build-sdk.sh",
     "test": "vitest run --passWithNoTests -u",
     "test:watch": "vitest --passWithNoTests",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "upgrade:schema": "bash scripts/upgrade-schema.sh"
   },
   "devDependencies": {
     "@palantir/pack.document-schema.type-gen": "workspace:*",

--- a/demos/canvas/schema/scripts/upgrade-schema.sh
+++ b/demos/canvas/schema/scripts/upgrade-schema.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCHEMA_DIR="demos/canvas/schema" # Relative to git root
+APP_DIR="demos/canvas/app" # Relative to git root
+REPO_DIR="$(git rev-parse --show-toplevel)"
+
+cd "$REPO_DIR" || exit 1
+
+load_env_file() {
+  local env_file="$1"
+  if [[ -f "$env_file" ]]; then
+    echo "Loading env from $env_file"
+    set -a
+    # shellcheck disable=SC1090
+    source "$env_file"
+    set +a
+  fi
+}
+
+# Mirror the Vite dev-server env file order so this schema upgrade uses the
+# same app configuration. Later files override earlier ones:
+# defaults -> local overrides -> development defaults -> development overrides.
+load_env_file "$APP_DIR/.env"
+load_env_file "$APP_DIR/.env.local"
+load_env_file "$APP_DIR/.env.development"
+load_env_file "$APP_DIR/.env.development.local"
+
+SCHEMA_VERSION="${SCHEMA_VERSION:-}"
+PASSTHROUGH_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --)
+      shift
+      ;;
+    --version)
+      if [[ $# -lt 2 || "$2" == --* ]]; then
+        echo "ERROR: --version requires a value."
+        exit 1
+      fi
+      SCHEMA_VERSION="$2"
+      shift 2
+      ;;
+    --version=*)
+      SCHEMA_VERSION="${1#*=}"
+      shift
+      ;;
+    *)
+      PASSTHROUGH_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$SCHEMA_VERSION" && ! "$SCHEMA_VERSION" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: --version must be a positive integer."
+  exit 1
+fi
+
+FOUNDRY_BASE_URL="${FOUNDRY_BASE_URL:-${VITE_FOUNDRY_URL:-https://danube-staging.palantircloud.com}}"
+AUTH_TOKEN="${FOUNDRY_TOKEN:-${VITE_DEV_FOUNDRY_TOKEN:-}}"
+ONTOLOGY_RID="${ONTOLOGYRID:-${VITE_FOUNDRY_ONTOLOGY_RID:-}}"
+
+if [[ -z "$AUTH_TOKEN" ]]; then
+  echo "ERROR: VITE_DEV_FOUNDRY_TOKEN or FOUNDRY_TOKEN must be set before upgrading the schema."
+  exit 1
+fi
+
+if [[ -z "$ONTOLOGY_RID" ]]; then
+  echo "ERROR: VITE_FOUNDRY_ONTOLOGY_RID or ONTOLOGYRID must be set before upgrading the schema."
+  exit 1
+fi
+
+echo "Building type-gen CLI..."
+pnpm --filter @palantir/pack.document-schema.type-gen transpileEsm
+
+echo "Building canvas document type asset..."
+pnpm --filter @demo/canvas.schema build:asset
+
+echo "Upgrading schema on $FOUNDRY_BASE_URL..."
+cd "$SCHEMA_DIR" || exit 1
+UPDATE_SCHEMA_ARGS=(
+  --input build/asset.json
+  --ontology-rid "$ONTOLOGY_RID"
+  --auth "$AUTH_TOKEN"
+  --base-url "$FOUNDRY_BASE_URL"
+)
+
+if [[ -n "$SCHEMA_VERSION" ]]; then
+  UPDATE_SCHEMA_ARGS+=(--version "$SCHEMA_VERSION")
+fi
+
+UPDATE_SCHEMA_ARGS+=("${PASSTHROUGH_ARGS[@]}")
+
+pnpm exec type-gen asset update-schema "${UPDATE_SCHEMA_ARGS[@]}"
+
+echo "Schema upgrade submitted."

--- a/demos/canvas/schema/scripts/upgrade-schema.sh
+++ b/demos/canvas/schema/scripts/upgrade-schema.sh
@@ -75,20 +75,45 @@ fi
 echo "Building type-gen CLI..."
 pnpm --filter @palantir/pack.document-schema.type-gen transpileEsm
 
+cd "$SCHEMA_DIR" || exit 1
+
+IR_PATH="build/ir.json"
+ASSET_PATH="build/asset.json"
+SCHEMA_IR_ARGS=(
+  schema ir
+  -i src/schema.mjs
+  -o "$IR_PATH"
+  --config pack-config.json
+)
+
+if [[ -n "$SCHEMA_VERSION" ]]; then
+  IR_PATH="build/upgrade-ir-v${SCHEMA_VERSION}.json"
+  ASSET_PATH="build/upgrade-asset-v${SCHEMA_VERSION}.json"
+  SCHEMA_IR_ARGS=(
+    schema ir
+    -i src/schema.mjs
+    -o "$IR_PATH"
+    --config pack-config.json
+    --max-version "$SCHEMA_VERSION"
+  )
+fi
+
+echo "Building canvas IR..."
+pnpm exec type-gen "${SCHEMA_IR_ARGS[@]}"
+
 echo "Building canvas document type asset..."
-pnpm --filter @demo/canvas.schema build:asset
+pnpm exec type-gen ir asset -i "$IR_PATH" -o "$ASSET_PATH"
 
 echo "Upgrading schema on $FOUNDRY_BASE_URL..."
-cd "$SCHEMA_DIR" || exit 1
 UPDATE_SCHEMA_ARGS=(
-  --input build/asset.json
+  --input "$ASSET_PATH"
   --ontology-rid "$ONTOLOGY_RID"
   --auth "$AUTH_TOKEN"
   --base-url "$FOUNDRY_BASE_URL"
 )
 
 if [[ -n "$SCHEMA_VERSION" ]]; then
-  UPDATE_SCHEMA_ARGS+=(--version "$SCHEMA_VERSION")
+  UPDATE_SCHEMA_ARGS+=(--force-overwrite)
 fi
 
 UPDATE_SCHEMA_ARGS+=("${PASSTHROUGH_ARGS[@]}")

--- a/packages/document-schema/type-gen/src/commands/asset/assetUpdateSchemaHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/assetUpdateSchemaHandler.ts
@@ -29,11 +29,28 @@ interface AssetUpdateSchemaOptions {
   readonly baseUrl: string;
   readonly auth: string;
   readonly ontologyRid: string;
+  readonly version?: string;
   readonly forceOverwrite?: boolean;
   readonly firstPartyPrefix?: string;
 }
 
 const DEFAULT_API_PREFIX = "/api";
+
+function resolveSchemaVersion(assetVersion: number, versionOverride?: string): number {
+  if (versionOverride == null) {
+    return assetVersion;
+  }
+
+  if (!/^[1-9]\d*$/.test(versionOverride)) {
+    throw new CommanderError(
+      1,
+      "EINVAL",
+      `Invalid --version "${versionOverride}". Must be a positive integer.`,
+    );
+  }
+
+  return Number(versionOverride);
+}
 
 /** Updates the schema of an existing document type using a generated asset JSON file. */
 export async function assetUpdateSchemaHandler(
@@ -46,6 +63,7 @@ export async function assetUpdateSchemaHandler(
 
     const assetContent = readFileSync(assetPath, "utf8");
     const asset = JSON.parse(assetContent) as DocumentTypeAsset;
+    const schemaVersion = resolveSchemaVersion(asset.schemaVersion, options.version);
 
     const fetchFn = options.firstPartyPrefix != null
       ? buildPrefixRewriteFetch(options.firstPartyPrefix)
@@ -66,7 +84,7 @@ export async function assetUpdateSchemaHandler(
       requestBody: {
         ontologyRid: options.ontologyRid,
         schema: asset.documentStorageType.yjs.schema,
-        version: asset.schemaVersion,
+        version: schemaVersion,
         ...(options.forceOverwrite ? { forceOverwrite: true } : {}),
       },
     };
@@ -76,7 +94,7 @@ export async function assetUpdateSchemaHandler(
     }
 
     consola.info(
-      `Updating schema for document type "${asset.documentTypeName}" -> version ${asset.schemaVersion}`,
+      `Updating schema for document type "${asset.documentTypeName}" -> version ${schemaVersion}`,
     );
 
     const result = await DocumentTypes.updateSchema(osdkClient, request, { preview: true });

--- a/packages/document-schema/type-gen/src/commands/asset/assetUpdateSchemaHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/assetUpdateSchemaHandler.ts
@@ -29,28 +29,11 @@ interface AssetUpdateSchemaOptions {
   readonly baseUrl: string;
   readonly auth: string;
   readonly ontologyRid: string;
-  readonly version?: string;
   readonly forceOverwrite?: boolean;
   readonly firstPartyPrefix?: string;
 }
 
 const DEFAULT_API_PREFIX = "/api";
-
-function resolveSchemaVersion(assetVersion: number, versionOverride?: string): number {
-  if (versionOverride == null) {
-    return assetVersion;
-  }
-
-  if (!/^[1-9]\d*$/.test(versionOverride)) {
-    throw new CommanderError(
-      1,
-      "EINVAL",
-      `Invalid --version "${versionOverride}". Must be a positive integer.`,
-    );
-  }
-
-  return Number(versionOverride);
-}
 
 /** Updates the schema of an existing document type using a generated asset JSON file. */
 export async function assetUpdateSchemaHandler(
@@ -63,7 +46,7 @@ export async function assetUpdateSchemaHandler(
 
     const assetContent = readFileSync(assetPath, "utf8");
     const asset = JSON.parse(assetContent) as DocumentTypeAsset;
-    const schemaVersion = resolveSchemaVersion(asset.schemaVersion, options.version);
+    const schemaVersion = asset.schemaVersion;
 
     const fetchFn = options.firstPartyPrefix != null
       ? buildPrefixRewriteFetch(options.firstPartyPrefix)

--- a/packages/document-schema/type-gen/src/commands/asset/registerAssetCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/registerAssetCommands.ts
@@ -46,10 +46,6 @@ export function registerAssetCommands(program: Command): void {
     .requiredOption("-a, --auth <token>", "Authentication token for Foundry API")
     .requiredOption("-o, --ontology-rid <rid>", "Target ontology RID")
     .option(
-      "--version <version>",
-      "Override the schema version from the asset JSON",
-    )
-    .option(
       "--force-overwrite",
       "Skip backwards-compatibility validation when updating the schema",
       false,

--- a/packages/document-schema/type-gen/src/commands/asset/registerAssetCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/asset/registerAssetCommands.ts
@@ -46,6 +46,10 @@ export function registerAssetCommands(program: Command): void {
     .requiredOption("-a, --auth <token>", "Authentication token for Foundry API")
     .requiredOption("-o, --ontology-rid <rid>", "Target ontology RID")
     .option(
+      "--version <version>",
+      "Override the schema version from the asset JSON",
+    )
+    .option(
       "--force-overwrite",
       "Skip backwards-compatibility validation when updating the schema",
       false,

--- a/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/registerSchemaCommands.ts
@@ -39,5 +39,9 @@ export function registerSchemaCommands(program: Command): void {
       "--config <file>",
       "Path to the SDK's pack-config JSON file. Its optional 'minSupportedVersion' field declares the oldest schema version this SDK supports; omit the field to track latest only.",
     )
+    .option(
+      "--max-version <version>",
+      "Generate an IR chain capped at this schema version",
+    )
     .action(schemaIrHandler);
 }

--- a/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
@@ -25,6 +25,7 @@ interface SchemaIrOptions {
   input: string;
   output: string;
   config: string;
+  maxVersion?: string;
 }
 
 interface PackConfigLike {
@@ -96,6 +97,20 @@ export async function readPackConfig(configPath: string): Promise<PackConfigValu
   return { documentTypeName, documentTypeDescription, minSupportedVersion };
 }
 
+function parseMaxVersion(maxVersion: string | undefined): number | undefined {
+  if (maxVersion == null) {
+    return undefined;
+  }
+
+  if (!/^[1-9]\d*$/.test(maxVersion)) {
+    throw new Error(
+      `--max-version must be a positive integer, got: ${JSON.stringify(maxVersion)}`,
+    );
+  }
+
+  return Number(maxVersion);
+}
+
 /**
  * Resolve a TypeScript schema module to a versioned IR chain JSON file.
  *
@@ -125,6 +140,7 @@ export async function readPackConfig(configPath: string): Promise<PackConfigValu
  */
 export async function schemaIrHandler(options: SchemaIrOptions): Promise<void> {
   const { input, output, config } = options;
+  const maxVersion = parseMaxVersion(options.maxVersion);
   const { documentTypeName, documentTypeDescription, minSupportedVersion } = await readPackConfig(
     config,
   );
@@ -141,10 +157,15 @@ export async function schemaIrHandler(options: SchemaIrOptions): Promise<void> {
   const schema = await loadSchemaModule(input);
 
   consola.info("Resolving versioned IR chain...");
-  const { chain, latestVersion } = resolveSchemaChain(schema, minSupportedVersion, {
-    name: documentTypeName,
-    description: documentTypeDescription,
-  });
+  const { chain, latestVersion } = resolveSchemaChain(
+    schema,
+    minSupportedVersion,
+    {
+      name: documentTypeName,
+      description: documentTypeDescription,
+    },
+    maxVersion,
+  );
 
   const outputPath = path.resolve(output);
   await fs.ensureDir(path.dirname(outputPath));

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/resolveSchemaChain.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/resolveSchemaChain.test.ts
@@ -64,6 +64,20 @@ describe("resolveSchemaChain provenance", () => {
     expect(v2Fields.strokeColor!.metadata.addedInVersion).toBe(2);
   });
 
+  it("caps the chain at maxVersion", () => {
+    const { chain, latestVersion, minVersion } = resolveSchemaChain(v2, 1, {}, 1);
+
+    expect(chain.map(entry => entry.version)).toEqual([1]);
+    expect(latestVersion).toBe(1);
+    expect(minVersion).toBe(1);
+  });
+
+  it("rejects a maxVersion that is not in the chain", () => {
+    expect(() => resolveSchemaChain(v2, undefined, {}, 3)).toThrow(
+      "maxVersion 3 is not in the schema chain",
+    );
+  });
+
   it("keeps a deprecated field present and stamps deprecatedFromVersion + message", () => {
     const { chain } = resolveSchemaChain(v2);
     const v2Fields = fieldsByKey(chain.find(c => c.version === 2)!, "ShapeBox");

--- a/packages/document-schema/type-gen/src/utils/schema/resolveSchemaChain.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/resolveSchemaChain.ts
@@ -182,6 +182,24 @@ export function resolveMinVersion(
   };
 }
 
+function capVersionedIrChain(
+  chain: VersionedIrEntry[],
+  maxVersion: number | undefined,
+): VersionedIrEntry[] {
+  if (maxVersion == null) {
+    return chain;
+  }
+
+  if (!chain.some(c => c.version === maxVersion)) {
+    throw new Error(
+      `maxVersion ${maxVersion} is not in the schema chain `
+        + `(available versions: ${chain.map(c => c.version).join(", ")})`,
+    );
+  }
+
+  return chain.filter(c => c.version <= maxVersion);
+}
+
 /**
  * Collect the version chain and resolve min/latest versions.
  * Each version's models are converted to IR (IRealTimeDocumentSchema).
@@ -194,8 +212,9 @@ export function resolveSchemaChain(
   schema: SchemaDefinition,
   minSupportedVersion?: number,
   identity: SchemaIdentity = {},
+  maxVersion?: number,
 ): ResolvedIrChain {
-  const chain = collectVersionedIrChain(schema, identity);
+  const chain = capVersionedIrChain(collectVersionedIrChain(schema, identity), maxVersion);
   const { latestVersion, minVersion } = resolveMinVersion(chain, minSupportedVersion);
   return { chain, latestVersion, minVersion };
 }


### PR DESCRIPTION
After creating a new document type, it starts out at V1. This script now allows upgrading. By default, it will upgrade to the max version, and the `--version` flag will allow providing a single version.