### PR TITLE
Use real backend operational version

### DIFF
--- a/.changeset/wicked-cars-sniff.md
+++ b/.changeset/wicked-cars-sniff.md
@@ -1,0 +1,9 @@
+---
+"@palantir/pack.document-schema.model-types": minor
+"@palantir/pack.state.foundry-event": minor
+"@palantir/pack.state.foundry": minor
+"@palantir/pack.state.core": minor
+"@palantir/pack.state.demo": minor
+---
+
+use backend calculated operational version for schema versions

--- a/.changeset/wicked-cars-sniff.md
+++ b/.changeset/wicked-cars-sniff.md
@@ -4,6 +4,9 @@
 "@palantir/pack.state.foundry": minor
 "@palantir/pack.state.core": minor
 "@palantir/pack.state.demo": minor
+"@palantir/pack.state.react": patch
 ---
 
-use backend calculated operational version for schema versions
+Use backend-calculated document operational versions for schema version gating.
+
+Foundry document loads now provide the document's operational version, which Pack stores on document metadata and uses as the fallback version for writes that do not have a lower calculated update schema version.

--- a/packages/document-schema/model-types/src/types/DocumentMetadata.ts
+++ b/packages/document-schema/model-types/src/types/DocumentMetadata.ts
@@ -59,10 +59,9 @@ export interface DocumentMetadata {
   readonly ontologyRid: string;
   /**
    * The schema version this document is currently operating at.
-   * All connected clients must read and write at this version.
-   * Set by the backend; only increases (one-way ratchet).
+   * Calculated and set by the backend; only increases (one-way ratchet).
    */
-  readonly schemaVersion?: number;
+  readonly operationalVersion?: number;
   readonly security: DocumentSecurity;
   readonly updatedBy?: string;
   readonly updatedTime?: string;

--- a/packages/document-schema/model-types/src/types/DocumentRef.ts
+++ b/packages/document-schema/model-types/src/types/DocumentRef.ts
@@ -139,6 +139,10 @@ export interface DocumentRef<D extends DocumentSchema = DocumentSchema> {
   /**
    * Subscribe to metadata changes for the document.
    *
+   * In Foundry, metadata update events are sent for metadata edits/deletion.
+   * Name and description changes are not identified in the event payload, and
+   * operational-version-only changes do not currently trigger this callback.
+   *
    * @returns An unsubscribe function.
    * @example
    * ```ts
@@ -263,10 +267,10 @@ export interface DocumentRef<D extends DocumentSchema = DocumentSchema> {
   withTransaction(fn: () => void, description?: EditDescription): void;
 
   /**
-   * The document's current operating schema version.
+   * The document's current schema operational version.
    *
-   * All connected clients operate at this version. The version is determined
-   * by the backend and may change during a session (version bump).
+   * The backend determines the highest schema version this document currently
+   * accepts. This may change during a session.
    */
   readonly version: number;
 

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -189,12 +189,12 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     ontologyRid?: string,
   ) => Promise<number | undefined>;
 
-  readonly getDocumentSchemaVersion = (
+  readonly getDocumentSchemaOperationalVersion = (
     docRef: DocumentRef,
   ): number => {
     const { internalDoc } = this.getCreateInternalDoc(docRef);
     const schemaMeta = getMetadata(internalDoc.schema);
-    return internalDoc.metadata?.schemaVersion
+    return internalDoc.metadata?.operationalVersion
       ?? schemaMeta.minSupportedVersion
       ?? schemaMeta.version;
   };
@@ -473,12 +473,10 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     this.documents.set(id, internalDoc);
 
     const schemaMeta = getMetadata(schema);
-    const documentSchemaVersion = internalDoc.metadata?.schemaVersion
-      ?? schemaMeta.minSupportedVersion
-      ?? schemaMeta.version;
+    const documentSchemaOperationalVersion = this.getDocumentSchemaOperationalVersion(ref);
     this.logger.debug("Document loaded", {
       docId: id,
-      documentSchemaVersion,
+      documentSchemaOperationalVersion,
       clientSchemaRange: `[${
         schemaMeta.minSupportedVersion ?? schemaMeta.version
       }, ${schemaMeta.version}]`,

--- a/packages/state/core/src/types/DocumentRefImpl.ts
+++ b/packages/state/core/src/types/DocumentRefImpl.ts
@@ -169,7 +169,7 @@ class DocumentRefImpl<T extends DocumentSchema> implements DocumentRef<T> {
   }
 
   get version(): number {
-    return this.#stateModule.getDocumentSchemaVersion(this);
+    return this.#stateModule.getDocumentSchemaOperationalVersion(this);
   }
 
   updateRecord(ref: RecordRef, data: unknown): Promise<void> {

--- a/packages/state/core/src/types/DocumentService.ts
+++ b/packages/state/core/src/types/DocumentService.ts
@@ -119,7 +119,7 @@ export interface DocumentType {
 export interface UpdateDocumentMetadata {
   readonly name?: string;
   readonly description?: string;
-  readonly schemaVersion?: number;
+  readonly operationalVersion?: number;
   readonly security?: DocumentSecurity;
 }
 
@@ -165,11 +165,11 @@ export interface DocumentService {
   ) => Promise<void>;
 
   /**
-   * Get the schema version a document is currently operating at.
-   * Returns the version from the document's metadata if available,
-   * falling back to minSupportedVersion from the schema.
+   * Get the schema operational version a document is currently operating at.
+   * Returns the version from the document's metadata if available, falling back
+   * to minSupportedVersion from the schema.
    */
-  readonly getDocumentSchemaVersion: (
+  readonly getDocumentSchemaOperationalVersion: (
     docRef: DocumentRef,
   ) => number;
 

--- a/packages/state/core/src/types/StateModule.ts
+++ b/packages/state/core/src/types/StateModule.ts
@@ -226,8 +226,8 @@ export class StateModuleImpl implements StateModule {
     private readonly documentService: DocumentService,
   ) {}
 
-  getDocumentSchemaVersion(docRef: DocumentRef): number {
-    return this.documentService.getDocumentSchemaVersion(docRef);
+  getDocumentSchemaOperationalVersion(docRef: DocumentRef): number {
+    return this.documentService.getDocumentSchemaOperationalVersion(docRef);
   }
 
   createDocRef<const T extends DocumentSchema>(

--- a/packages/state/demo/src/DemoDocumentService.ts
+++ b/packages/state/demo/src/DemoDocumentService.ts
@@ -115,7 +115,7 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
    * localStorage is used because the metadata from IndexedDB is loaded
    * asynchronously and not available on first render.
    */
-  override readonly getDocumentSchemaVersion = (
+  override readonly getDocumentSchemaOperationalVersion = (
     docRef: DocumentRef,
   ): number => {
     try {
@@ -128,8 +128,8 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
     }
     // Inline the base class logic — class fields can't call `super`.
     const internalDoc = this.documents.get(docRef.id);
-    if (internalDoc?.metadata?.schemaVersion != null) {
-      return internalDoc.metadata.schemaVersion;
+    if (internalDoc?.metadata?.operationalVersion != null) {
+      return internalDoc.metadata.operationalVersion;
     }
     const schemaMeta = getMetadata(docRef.schema);
     return schemaMeta.minSupportedVersion ?? schemaMeta.version;
@@ -151,7 +151,9 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
     } catch {
       // localStorage may be unavailable
     }
-    void this.updateDocument(docRef, { schemaVersion: version });
+    void this.updateDocument(docRef, {
+      operationalVersion: version,
+    });
   };
 
   override createInternalDoc(
@@ -246,13 +248,13 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
     const docRef = createDocRef(this.app, id, schema);
 
     const schemaMeta = getMetadata(schema);
-    const schemaVersion = schemaMeta.minSupportedVersion ?? schemaMeta.version;
+    const operationalVersion = schemaMeta.minSupportedVersion ?? schemaMeta.version;
 
     const metadata: DocumentMetadata = {
       documentTypeName,
       name,
+      operationalVersion,
       ontologyRid,
-      schemaVersion,
       security, // TODO: may want to add in auth.getUserId() as owner here
     };
 
@@ -294,8 +296,7 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
 
     this.logger.debug("updateDocument", {
       docId: docRef.id,
-      existingSchemaVersion: existing.schemaVersion,
-      newSchemaVersion: metadata.schemaVersion,
+      newOperationalVersion: metadata.operationalVersion,
       updateKeys: Object.keys(update),
     });
 

--- a/packages/state/demo/src/__tests__/DemoDocumentService.test.ts
+++ b/packages/state/demo/src/__tests__/DemoDocumentService.test.ts
@@ -181,6 +181,26 @@ describe("DemoDocumentService", () => {
     expect(typeof docRef.id).toBe("string");
   });
 
+  it("should expose operationalVersion in demo metadata", async () => {
+    const stateModule = getStateModule(app);
+
+    const metadata: DocumentMetadata = {
+      documentTypeName: "TestType",
+      name: "Versioned Document",
+      ontologyRid: "test-ontology-rid",
+      security: TEST_SECURITY,
+    };
+
+    const schema = createTestSchema();
+    const docRef = await stateModule.createDocument(metadata, schema);
+    const updatedMetadata = await stateModule.updateDocument(docRef, {
+      operationalVersion: 2,
+    });
+
+    expect(updatedMetadata.operationalVersion).toBe(2);
+    expect(docRef.version).toBe(2);
+  });
+
   it("should persist document and load it across service instances", async () => {
     const stateModule1 = getStateModule(app);
 

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -136,6 +136,7 @@ export interface FoundryEventService {
     yDoc: y.Doc,
     clientSupportedVersionRange: ClientSupportedVersionRange,
     onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
+    getDocumentSchemaOperationalVersion?: () => number,
   ): SyncSession;
 
   stopDocumentSync(session: SyncSession): void;
@@ -201,6 +202,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     yDoc: y.Doc,
     clientSupportedVersionRange: ClientSupportedVersionRange,
     onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
+    getDocumentSchemaOperationalVersion?: () => number,
   ): SyncSession {
     const session = this.getOrCreateSession(documentId, yDoc);
 
@@ -233,6 +235,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         ? createDocumentEditDescription(origin)
         : undefined;
       const documentUpdateSchemaVersion = getDocumentUpdateSchemaVersionFromTransaction(transaction)
+        ?? getDocumentSchemaOperationalVersion?.()
         ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange);
       const publishMessage: DocumentPublishMessage = {
         clientId: session.clientId,

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -115,4 +115,77 @@ describe("FoundryEventService", () => {
     expect(typeof publishCall?.[1].yjsUpdate?.data).toBe("string");
     expect(statusUpdates.at(-1)?.error).toBeUndefined();
   });
+
+  it("uses the document operational version when a local Yjs update has no version metadata", async () => {
+    let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+    mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+      updateCallback = callback as (message: DocumentUpdateMessage) => void;
+      return Promise.resolve("sub-1" as SubscriptionId);
+    });
+
+    const yDoc = new Y.Doc();
+    const service = createFoundryEventService(app);
+
+    service.startDocumentSync(
+      "doc-1" as DocumentId,
+      yDoc,
+      { maxVersion: 3, minVersion: 1 },
+      () => {},
+      () => 2,
+    );
+
+    await Promise.resolve();
+    updateCallback?.({
+      baseRevisionId: "0",
+      clientId: "server",
+      editIds: [],
+      revisionId: "1",
+      type: "update",
+    });
+
+    yDoc.getMap("Shape").set("shape-1", new Y.Map());
+
+    const publishCall = mocks.eventService.publish.mock.calls[0] as
+      | [unknown, PublishedDocumentUpdate]
+      | undefined;
+    expect(publishCall?.[1].documentUpdateSchemaVersion).toBe(2);
+  });
+
+  it("preserves a calculated update schema version below the document operational version", async () => {
+    let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+    mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+      updateCallback = callback as (message: DocumentUpdateMessage) => void;
+      return Promise.resolve("sub-1" as SubscriptionId);
+    });
+
+    const yDoc = new Y.Doc();
+    const service = createFoundryEventService(app);
+
+    service.startDocumentSync(
+      "doc-1" as DocumentId,
+      yDoc,
+      { maxVersion: 3, minVersion: 1 },
+      () => {},
+      () => 2,
+    );
+
+    await Promise.resolve();
+    updateCallback?.({
+      baseRevisionId: "0",
+      clientId: "server",
+      editIds: [],
+      revisionId: "1",
+      type: "update",
+    });
+
+    yDoc.transact(transaction => {
+      addDocumentUpdateSchemaVersionToTransaction(transaction, 1);
+      yDoc.getMap("Shape").set("shape-1", new Y.Map());
+    });
+
+    const publishCall = mocks.eventService.publish.mock.calls[0] as
+      | [unknown, PublishedDocumentUpdate]
+      | undefined;
+    expect(publishCall?.[1].documentUpdateSchemaVersion).toBe(1);
+  });
 });

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -19,6 +19,7 @@ import type {
   CreateDocumentRequest,
   DiscretionaryPrincipal,
   DiscretionaryPrincipal as WireDiscretionaryPrincipal,
+  Document as WireDocument,
   DocumentSecurity as WireDocumentSecurity,
   DocumentType as WireDocumentType,
   SearchDocumentsRequest,
@@ -98,6 +99,11 @@ export function internalCreateFoundryDocumentService(
 interface FoundryInternalDoc extends InternalYjsDoc {
   metadataUpdateUnsubscribed?: boolean;
   syncSession?: SyncSession;
+}
+
+// TODO: remove once foundry sdk is updated.
+interface WireDocumentWithOperationalVersion extends WireDocument {
+  readonly operationalVersion?: number;
 }
 
 export class FoundryDocumentService extends BaseYjsDocumentService<FoundryInternalDoc> {
@@ -196,16 +202,8 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
 
     return {
       data: searchResponse.data.map(doc => ({
-        createdBy: doc.createdBy,
-        createdTime: doc.createdTime,
-        documentTypeName: doc.documentTypeName,
+        ...getLocalDocumentMetadata(doc),
         id: doc.id as DocumentId,
-        name: doc.name,
-        operations: doc.operations,
-        ontologyRid: doc.ontologyRid,
-        security: getLocalSecurity(doc.security),
-        updatedBy: doc.updatedBy,
-        updatedTime: doc.updatedTime,
       })),
       nextPageToken: searchResponse.nextPageToken,
     };
@@ -230,14 +228,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
       },
     );
 
-    const metadata: DocumentMetadata = {
-      description: document.description,
-      documentTypeName: document.documentTypeName,
-      name: document.name,
-      operations: document.operations,
-      ontologyRid: document.ontologyRid,
-      security: getLocalSecurity(document.security),
-    };
+    const metadata = getLocalDocumentMetadata(document);
 
     this.updateMetadata(docRef.id, metadata);
 
@@ -326,14 +317,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         if (!this.documents.has(docRef.id)) {
           return;
         }
-        const metadata: DocumentMetadata = {
-          description: document.description,
-          documentTypeName: document.documentTypeName,
-          name: document.name,
-          operations: document.operations,
-          ontologyRid: document.ontologyRid,
-          security: getLocalSecurity(document.security),
-        };
+        const metadata = getLocalDocumentMetadata(document);
 
         internalDoc.metadata = metadata;
         this.notifyMetadataSubscribers(internalDoc, docRef, metadata);
@@ -341,6 +325,9 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
           load: DocumentLoadStatus.LOADED,
         });
 
+        // The metadata channel is for document metadata edits/deletion. Name
+        // and description changes arrive as generic updates; operationalVersion
+        // only refreshes here if it changed by the time this Document is loaded again.
         this.eventService
           .subscribeToMetadataUpdates(docRef.id, _event => {
             if (!internalDoc.metadataUpdateUnsubscribed) {
@@ -382,6 +369,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
       status => {
         this.updateDataStatus(internalDoc, docRef, status);
       },
+      () => this.getDocumentSchemaOperationalVersion(docRef),
     );
   }
 
@@ -444,14 +432,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         if (!this.documents.has(docRef.id)) {
           return;
         }
-        const metadata: DocumentMetadata = {
-          description: document.description,
-          documentTypeName: document.documentTypeName,
-          name: document.name,
-          operations: document.operations,
-          ontologyRid: document.ontologyRid,
-          security: getLocalSecurity(document.security),
-        };
+        const metadata = getLocalDocumentMetadata(document);
 
         this.updateMetadata(docRef.id, metadata);
       })
@@ -589,6 +570,24 @@ function getLocalPrincipal(
     default:
       assertNever(wirePrincipal);
   }
+}
+
+function getLocalDocumentMetadata(
+  wireDocument: WireDocumentWithOperationalVersion,
+): DocumentMetadata {
+  return {
+    createdBy: wireDocument.createdBy,
+    createdTime: wireDocument.createdTime,
+    description: wireDocument.description,
+    documentTypeName: wireDocument.documentTypeName,
+    name: wireDocument.name,
+    operationalVersion: wireDocument.operationalVersion,
+    operations: wireDocument.operations,
+    ontologyRid: wireDocument.ontologyRid,
+    security: getLocalSecurity(wireDocument.security),
+    updatedBy: wireDocument.updatedBy,
+    updatedTime: wireDocument.updatedTime,
+  };
 }
 
 function getLocalDocumentType(wireDocumentType: WireDocumentType): DocumentType {

--- a/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
@@ -73,11 +73,17 @@ const testSchema = {
   },
 } as const satisfies DocumentSchema;
 
-const WIRE_DOCUMENT_WITH_SECURITY: Document = {
+// TODO: remove once foundry sdk is updated.
+type WireDocumentWithOperationalVersion = Document & {
+  readonly operationalVersion?: number;
+};
+
+const WIRE_DOCUMENT_WITH_SECURITY: WireDocumentWithOperationalVersion = {
   id: "test-doc-security",
   name: "Secure Document",
   documentTypeName: "SecureType",
   ontologyRid: "ri.ontology..test-ontology-rid",
+  operationalVersion: 2,
   createdBy: "user-1",
   createdTime: "2025-01-01T00:00:00Z",
   updatedBy: "user-2",
@@ -171,6 +177,17 @@ describe("Foundry Security Conversion", () => {
 
       expect(result.data[0]?.ontologyRid).toBe("ri.ontology..test-ontology-rid");
     });
+
+    it("should preserve operationalVersion from response", async () => {
+      const searchResponse: DocumentSearchResponse = {
+        data: [WIRE_DOCUMENT_WITH_SECURITY],
+      };
+      vi.mocked(Documents.search).mockResolvedValue(searchResponse);
+
+      const result = await service.searchDocuments("SecureType", testSchema);
+
+      expect(result.data[0]?.operationalVersion).toBe(2);
+    });
   });
 
   describe("onMetadataSubscriptionOpened", () => {
@@ -227,6 +244,24 @@ describe("Foundry Security Conversion", () => {
 
       expect(metadataUpdates).toHaveLength(1);
       expect(metadataUpdates[0]?.ontologyRid).toBe("ri.ontology..test-ontology-rid");
+    });
+
+    it("should preserve operationalVersion in metadata", async () => {
+      const docRef = createDocRef(mockApp, "test-doc-security" as DocumentId, testSchema);
+
+      const metadataUpdates: DocumentMetadata[] = [];
+
+      unsubscribes.push(
+        service.onMetadataChange(docRef, (_, metadata) => {
+          metadataUpdates.push(metadata);
+        }),
+      );
+
+      await vi.runAllTimersAsync();
+
+      expect(metadataUpdates).toHaveLength(1);
+      expect(metadataUpdates[0]?.operationalVersion).toBe(2);
+      expect(service.getDocumentSchemaOperationalVersion(docRef)).toBe(2);
     });
   });
 });

--- a/packages/state/react/src/__tests__/useDocumentSchemaVersion.test.tsx
+++ b/packages/state/react/src/__tests__/useDocumentSchemaVersion.test.tsx
@@ -27,7 +27,7 @@ import { useDocumentSchemaVersion } from "../hooks/useDocumentSchemaVersion.js";
 
 type MetadataCallback = (docRef: DocumentRef<DocumentSchema>, metadata: DocumentMetadata) => void;
 
-function metadata(schemaVersion?: number): DocumentMetadata {
+function metadata(operationalVersion?: number): DocumentMetadata {
   const baseMetadata = {
     documentTypeName: "TestType",
     name: "Test Document",
@@ -37,7 +37,7 @@ function metadata(schemaVersion?: number): DocumentMetadata {
       mandatory: {},
     },
   };
-  return schemaVersion != null ? { ...baseMetadata, schemaVersion } : baseMetadata;
+  return operationalVersion != null ? { ...baseMetadata, operationalVersion } : baseMetadata;
 }
 
 function createTestDocRef(initialVersion: number): {
@@ -66,8 +66,8 @@ function createTestDocRef(initialVersion: number): {
   return {
     docRef,
     emitMetadata: newMetadata => {
-      if (newMetadata.schemaVersion != null) {
-        currentVersion = newMetadata.schemaVersion;
+      if (newMetadata.operationalVersion != null) {
+        currentVersion = newMetadata.operationalVersion;
       }
       callback?.(docRef, newMetadata);
     },
@@ -79,7 +79,7 @@ function createTestDocRef(initialVersion: number): {
 }
 
 describe("useDocumentSchemaVersion", () => {
-  it("updates when document metadata reports a new schema version", () => {
+  it("updates when document metadata reports a new operational version", () => {
     const { docRef, emitMetadata, unsubscribe } = createTestDocRef(1);
 
     const { result, unmount } = renderHook(() => useDocumentSchemaVersion(docRef));
@@ -96,7 +96,7 @@ describe("useDocumentSchemaVersion", () => {
     expect(unsubscribe).toHaveBeenCalledOnce();
   });
 
-  it("falls back to docRef.version when metadata omits schemaVersion", () => {
+  it("falls back to docRef.version when metadata omits operationalVersion", () => {
     const { docRef, emitMetadata, setCurrentVersion } = createTestDocRef(1);
 
     const { result } = renderHook(() => useDocumentSchemaVersion(docRef));

--- a/packages/state/react/src/hooks/useDocumentSchemaVersion.ts
+++ b/packages/state/react/src/hooks/useDocumentSchemaVersion.ts
@@ -19,13 +19,17 @@ import { isValidDocRef } from "@palantir/pack.state.core";
 import { useEffect, useState } from "react";
 
 /**
- * Returns the schema version the document is currently operating at.
+ * Returns the document's schema operational version.
  *
- * Subscribes to metadata changes so callers update when the backend ratchets a
- * document to a new schema version.
+ * This reflects the current loaded metadata. Foundry does not send metadata
+ * update events for operational-version-only bumps, so this hook will not live
+ * update for those changes.
  *
- * @param docRef The document reference to read the schema version from.
- * @returns The document's current operating schema version number.
+ * TODO: Revisit this hook when the backend evicts document subscribers on
+ * operational version bumps and clients must refresh their document state.
+ *
+ * @param docRef The document reference to read the schema operational version from.
+ * @returns The document's current schema operational version number.
  */
 export function useDocumentSchemaVersion<D extends DocumentSchema>(
   docRef: DocumentRef<D>,
@@ -40,7 +44,7 @@ export function useDocumentSchemaVersion<D extends DocumentSchema>(
     }
 
     return docRef.onMetadataChange((_docRef, metadata) => {
-      setVersion(metadata.schemaVersion ?? docRef.version);
+      setVersion(metadata.operationalVersion ?? docRef.version);
     });
   }, [docRef]);
 


### PR DESCRIPTION
Use calculated schema's operational version from backend. Some minor renaming for additional clarity on 'version' semantics.

Testing for 3rd party schema:
1. Backend schema currently at version 1.
2. Document metadata retrieved is at operationalVersion 1.
3. Document writes occur at v1.
4. Update backend persisted schema to version 2.
5. Reload document -> operationalVersion is 2.
6. Document writes occur at v2 now.
<img width="463" height="280" alt="Screenshot 2026-06-15 at 12 48 53 PM" src="https://github.com/user-attachments/assets/d345c4ac-0be6-4c00-b37d-9d5cc7287dbe" />

Todo in next PR: fix duplicate load document types.