### PR TITLE
Deduplicate schema version / lense logic

### DIFF
--- a/.changeset/big-bushes-jump.md
+++ b/.changeset/big-bushes-jump.md
@@ -1,0 +1,20 @@
+---
+"@palantir/pack.sdkgen.pack-versioned-template": patch
+"@palantir/pack.document-schema.model-types": patch
+"@palantir/pack.sdkgen.demo-template": patch
+"@palantir/pack.sdkgen.pack-template": patch
+"@palantir/pack.document-schema.type-gen": patch
+"@palantir/pack.state.foundry-event": patch
+"@palantir/pack.sdkgen": patch
+"@palantir/pack.state.foundry": patch
+"@palantir/pack.auth.foundry": patch
+"@palantir/pack.state.react": patch
+"@palantir/pack.state.core": patch
+"@palantir/pack.state.demo": patch
+"@palantir/pack.auth": patch
+"@palantir/pack.schema": patch
+"@palantir/pack.core": patch
+"@palantir/pack.app": patch
+---
+
+Deduplicate schema version / lense logic

--- a/packages/state/core/src/__tests__/CustomPayloadMapping.test.ts
+++ b/packages/state/core/src/__tests__/CustomPayloadMapping.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  DocumentSchema,
+  Model,
+  UpgradeFns,
+  UpgradeRegistry,
+} from "@palantir/pack.document-schema.model-types";
+import { Metadata } from "@palantir/pack.document-schema.model-types";
+import { describe, expect, it } from "vitest";
+import {
+  CustomPayloadReadFailureReason,
+  parseCustomPayloadSchemaVersion,
+  readCustomPayload,
+} from "../service/CustomPayloadMapping.js";
+
+interface TestPayload {
+  readonly nodeId: string;
+  readonly summary: string;
+}
+
+function createModel<T>(
+  name: string,
+  isValid?: (data: unknown) => boolean,
+): Model<T> {
+  return {
+    __type: {} as T,
+    [Metadata]: { name },
+    zodSchema: isValid == null ? {} : {
+      safeParse: (data: unknown) => ({
+        success: isValid(data),
+      }),
+    },
+  } as unknown as Model<T>;
+}
+
+function isRecord(data: unknown): data is Record<string, unknown> {
+  return data != null && typeof data === "object" && !Array.isArray(data);
+}
+
+function isTestPayload(data: unknown): boolean {
+  return isRecord(data)
+    && typeof data.nodeId === "string"
+    && typeof data.summary === "string";
+}
+
+const TestModel = createModel<TestPayload>("TestModel", isTestPayload);
+
+function createSchema(model: Model = TestModel): DocumentSchema {
+  return {
+    [Metadata]: {
+      version: 1,
+    },
+    TestModel: model,
+  } as const satisfies DocumentSchema;
+}
+
+function createLensedSchema(): DocumentSchema {
+  const registry: UpgradeRegistry = {
+    allFields: {
+      nodeId: { type: { kind: "primitive" } },
+      summary: { type: { kind: "primitive" } },
+    },
+    modelName: "TestModel",
+    steps: [
+      {
+        addedInVersion: 2,
+        fields: {
+          summary: {
+            derivedFrom: ["nodeId"],
+          },
+        },
+      },
+    ],
+  };
+  const upgradeFns: UpgradeFns = {
+    TestModel: {
+      v2: {
+        summary: ({ nodeId }: { readonly nodeId: string }) => `Updated ${nodeId}`,
+      },
+    },
+  };
+
+  return {
+    [Metadata]: {
+      minSupportedVersion: 1,
+      upgradeFns,
+      upgrades: {
+        TestModel: registry,
+      },
+      version: 2,
+    },
+    TestModel,
+  } as const satisfies DocumentSchema;
+}
+
+describe("parseCustomPayloadSchemaVersion", () => {
+  it("defaults missing and null schema versions to the legacy version", () => {
+    expect(parseCustomPayloadSchemaVersion(undefined)).toBe(1);
+    expect(parseCustomPayloadSchemaVersion(null)).toBe(1);
+  });
+
+  it("rejects non-positive, non-integer, and non-number schema versions", () => {
+    expect(parseCustomPayloadSchemaVersion(0)).toBeUndefined();
+    expect(parseCustomPayloadSchemaVersion(1.5)).toBeUndefined();
+    expect(parseCustomPayloadSchemaVersion("1")).toBeUndefined();
+  });
+});
+
+describe("readCustomPayload", () => {
+  it("finds a model by metadata name and validates the payload when possible", () => {
+    const data = {
+      nodeId: "shape-1",
+      summary: "Updated shape-1",
+    };
+
+    const result = readCustomPayload({
+      data,
+      docSchema: createSchema(),
+      modelName: "TestModel",
+      schemaVersion: undefined,
+    });
+
+    expect(result).toMatchObject({
+      data,
+      model: TestModel,
+      schemaVersion: 1,
+      type: "readable",
+    });
+  });
+
+  it("applies the read lens before validation", () => {
+    const result = readCustomPayload({
+      data: {
+        nodeId: "shape-1",
+      },
+      docSchema: createLensedSchema(),
+      modelName: "TestModel",
+      schemaVersion: 1,
+    });
+
+    expect(result).toMatchObject({
+      data: {
+        nodeId: "shape-1",
+        summary: "Updated shape-1",
+      },
+      schemaVersion: 1,
+      type: "readable",
+    });
+  });
+
+  it("returns unreadable for an invalid schema version", () => {
+    const result = readCustomPayload({
+      data: {},
+      docSchema: createSchema(),
+      modelName: "TestModel",
+      schemaVersion: "future",
+    });
+
+    expect(result).toEqual({
+      modelName: "TestModel",
+      rawData: {},
+      reason: CustomPayloadReadFailureReason.INVALID_SCHEMA_VERSION,
+      schemaVersion: undefined,
+      type: "unreadable",
+    });
+  });
+
+  it("returns unreadable for an unsupported schema version", () => {
+    const result = readCustomPayload({
+      data: {},
+      docSchema: createLensedSchema(),
+      modelName: "TestModel",
+      schemaVersion: 3,
+    });
+
+    expect(result).toMatchObject({
+      reason: CustomPayloadReadFailureReason.UNSUPPORTED_SCHEMA_VERSION,
+      schemaVersion: 3,
+      type: "unreadable",
+    });
+  });
+
+  it("returns unreadable for an unknown model name", () => {
+    const result = readCustomPayload({
+      data: {},
+      docSchema: createSchema(),
+      modelName: "UnknownModel",
+      schemaVersion: 1,
+    });
+
+    expect(result).toMatchObject({
+      reason: CustomPayloadReadFailureReason.UNKNOWN_MODEL,
+      schemaVersion: 1,
+      type: "unreadable",
+    });
+  });
+
+  it("returns unreadable when a payload cannot be lensed", () => {
+    const result = readCustomPayload({
+      data: "not an object",
+      docSchema: createLensedSchema(),
+      modelName: "TestModel",
+      schemaVersion: 1,
+    });
+
+    expect(result).toMatchObject({
+      reason: CustomPayloadReadFailureReason.UNREADABLE_PAYLOAD,
+      schemaVersion: 1,
+      type: "unreadable",
+    });
+  });
+
+  it("returns unreadable when validation fails after lensing", () => {
+    const result = readCustomPayload({
+      data: {
+        other: "shape-1",
+      },
+      docSchema: createLensedSchema(),
+      modelName: "TestModel",
+      schemaVersion: 1,
+    });
+
+    expect(result).toMatchObject({
+      reason: CustomPayloadReadFailureReason.INVALID_PAYLOAD,
+      schemaVersion: 1,
+      type: "unreadable",
+    });
+  });
+});

--- a/packages/state/core/src/index.ts
+++ b/packages/state/core/src/index.ts
@@ -27,7 +27,6 @@ export {
   readCustomPayload,
 } from "./service/CustomPayloadMapping.js";
 export type {
-  CustomPayloadReadFailureReason as CustomPayloadReadFailureReasonType,
   ReadableCustomPayload,
   ReadCustomPayloadOptions,
   ReadCustomPayloadResult,
@@ -65,4 +64,3 @@ export {
 export { createRecordRef, invalidRecordRef, isValidRecordRef } from "./types/RecordRefImpl.js";
 export { getStateModule, STATE_MODULE_ACCESSOR } from "./types/StateModule.js";
 export type { StateModule, WithStateModule } from "./types/StateModule.js";
-export { applyLensToValue, applyReadLens, resolveAndApplyLens } from "./upgrade/UpgradeLens.js";

--- a/packages/state/core/src/index.ts
+++ b/packages/state/core/src/index.ts
@@ -21,6 +21,19 @@ export {
   type InternalYjsDoc,
 } from "./service/BaseYjsDocumentService.js";
 export {
+  CustomPayloadReadFailureReason,
+  LEGACY_CUSTOM_PAYLOAD_SCHEMA_VERSION,
+  parseCustomPayloadSchemaVersion,
+  readCustomPayload,
+} from "./service/CustomPayloadMapping.js";
+export type {
+  CustomPayloadReadFailureReason as CustomPayloadReadFailureReasonType,
+  ReadableCustomPayload,
+  ReadCustomPayloadOptions,
+  ReadCustomPayloadResult,
+  UnreadableCustomPayload,
+} from "./service/CustomPayloadMapping.js";
+export {
   addDocumentUpdateSchemaVersionToTransaction,
   DOCUMENT_UPDATE_SCHEMA_VERSION_META_KEY,
   getDocumentUpdateSchemaVersionFromTransaction,

--- a/packages/state/core/src/service/CustomPayloadMapping.ts
+++ b/packages/state/core/src/service/CustomPayloadMapping.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DocumentSchema, Model, ModelData } from "@palantir/pack.document-schema.model-types";
+import { getMetadata, hasMetadata } from "@palantir/pack.document-schema.model-types";
+import { resolveAndApplyLens } from "../upgrade/UpgradeLens.js";
+
+export const LEGACY_CUSTOM_PAYLOAD_SCHEMA_VERSION: 1 = 1;
+
+export type CustomPayloadReadFailureReason =
+  | "invalidSchemaVersion"
+  | "unsupportedSchemaVersion"
+  | "unknownModel"
+  | "unreadablePayload"
+  | "invalidPayload";
+
+export const CustomPayloadReadFailureReason: Readonly<{
+  INVALID_PAYLOAD: "invalidPayload";
+  INVALID_SCHEMA_VERSION: "invalidSchemaVersion";
+  UNKNOWN_MODEL: "unknownModel";
+  UNREADABLE_PAYLOAD: "unreadablePayload";
+  UNSUPPORTED_SCHEMA_VERSION: "unsupportedSchemaVersion";
+}> = {
+  INVALID_PAYLOAD: "invalidPayload",
+  INVALID_SCHEMA_VERSION: "invalidSchemaVersion",
+  UNKNOWN_MODEL: "unknownModel",
+  UNREADABLE_PAYLOAD: "unreadablePayload",
+  UNSUPPORTED_SCHEMA_VERSION: "unsupportedSchemaVersion",
+};
+
+export interface ReadCustomPayloadOptions {
+  readonly data: unknown;
+  readonly docSchema: DocumentSchema;
+  readonly modelName: string;
+  readonly schemaVersion?: unknown;
+}
+
+export interface ReadableCustomPayload {
+  readonly data: ModelData<Model>;
+  readonly model: Model;
+  readonly schemaVersion: number;
+  readonly type: "readable";
+}
+
+export interface UnreadableCustomPayload {
+  readonly modelName: string;
+  readonly rawData: unknown;
+  readonly reason: CustomPayloadReadFailureReason;
+  readonly schemaVersion?: number;
+  readonly type: "unreadable";
+}
+
+export type ReadCustomPayloadResult =
+  | ReadableCustomPayload
+  | UnreadableCustomPayload;
+
+export function parseCustomPayloadSchemaVersion(schemaVersion: unknown): number | undefined {
+  if (schemaVersion == null) {
+    return LEGACY_CUSTOM_PAYLOAD_SCHEMA_VERSION;
+  }
+
+  return typeof schemaVersion === "number"
+      && Number.isInteger(schemaVersion)
+      && schemaVersion > 0
+    ? schemaVersion
+    : undefined;
+}
+
+export function readCustomPayload({
+  data,
+  docSchema,
+  modelName,
+  schemaVersion,
+}: ReadCustomPayloadOptions): ReadCustomPayloadResult {
+  const parsedSchemaVersion = parseCustomPayloadSchemaVersion(schemaVersion);
+  if (parsedSchemaVersion == null) {
+    return unreadable(
+      modelName,
+      data,
+      CustomPayloadReadFailureReason.INVALID_SCHEMA_VERSION,
+    );
+  }
+
+  if (!isSupportedSchemaVersion(docSchema, parsedSchemaVersion)) {
+    return unreadable(
+      modelName,
+      data,
+      CustomPayloadReadFailureReason.UNSUPPORTED_SCHEMA_VERSION,
+      parsedSchemaVersion,
+    );
+  }
+
+  const model = getModelByName(docSchema, modelName);
+  if (model == null) {
+    return unreadable(
+      modelName,
+      data,
+      CustomPayloadReadFailureReason.UNKNOWN_MODEL,
+      parsedSchemaVersion,
+    );
+  }
+
+  const lensResult = applyReadLensIfNeeded(docSchema, modelName, data);
+  if (lensResult.type === "unreadable") {
+    return unreadable(
+      modelName,
+      data,
+      CustomPayloadReadFailureReason.UNREADABLE_PAYLOAD,
+      parsedSchemaVersion,
+    );
+  }
+
+  if (!isValidModelData(model, lensResult.data)) {
+    return unreadable(
+      modelName,
+      data,
+      CustomPayloadReadFailureReason.INVALID_PAYLOAD,
+      parsedSchemaVersion,
+    );
+  }
+
+  return {
+    data: lensResult.data as ModelData<Model>,
+    model,
+    schemaVersion: parsedSchemaVersion,
+    type: "readable",
+  };
+}
+
+function unreadable(
+  modelName: string,
+  rawData: unknown,
+  reason: CustomPayloadReadFailureReason,
+  schemaVersion?: number,
+): UnreadableCustomPayload {
+  return {
+    modelName,
+    rawData,
+    reason,
+    schemaVersion,
+    type: "unreadable",
+  };
+}
+
+function isSupportedSchemaVersion(docSchema: DocumentSchema, schemaVersion: number): boolean {
+  const schemaMetadata = getMetadata(docSchema);
+  const minSupportedVersion = schemaMetadata.minSupportedVersion ?? schemaMetadata.version;
+  return schemaVersion >= minSupportedVersion && schemaVersion <= schemaMetadata.version;
+}
+
+function getModelByName(docSchema: DocumentSchema, modelName: string): Model | undefined {
+  for (const candidate of Object.values(docSchema)) {
+    if (candidate != null && typeof candidate === "object" && hasMetadata(candidate)) {
+      const metadata = getMetadata(candidate);
+      if (isNamedMetadata(metadata) && metadata.name === modelName) {
+        return candidate as Model;
+      }
+    }
+  }
+  return undefined;
+}
+
+function isNamedMetadata(metadata: unknown): metadata is { readonly name: string } {
+  return metadata != null
+    && typeof metadata === "object"
+    && "name" in metadata
+    && typeof metadata.name === "string";
+}
+
+function applyReadLensIfNeeded(
+  docSchema: DocumentSchema,
+  modelName: string,
+  data: unknown,
+): ApplyReadLensResult {
+  const schemaMetadata = getMetadata(docSchema);
+  const upgradeEntry = schemaMetadata.upgrades?.[modelName];
+  if (upgradeEntry == null) {
+    return {
+      data,
+      type: "readable",
+    };
+  }
+
+  if (data == null || typeof data !== "object" || Array.isArray(data)) {
+    return {
+      type: "unreadable",
+    };
+  }
+
+  try {
+    return {
+      data: resolveAndApplyLens(
+        data as Record<string, unknown>,
+        upgradeEntry,
+        schemaMetadata.upgrades ?? {},
+        schemaMetadata.upgradeFns,
+      ),
+      type: "readable",
+    };
+  } catch {
+    return {
+      type: "unreadable",
+    };
+  }
+}
+
+type ApplyReadLensResult =
+  | {
+    readonly data: unknown;
+    readonly type: "readable";
+  }
+  | {
+    readonly type: "unreadable";
+  };
+
+function isValidModelData(model: Model, data: unknown): boolean {
+  const zodSchema = model.zodSchema as {
+    readonly safeParse?: (data: unknown) => { readonly success: boolean };
+  };
+  const safeParse = zodSchema.safeParse;
+  if (safeParse == null) {
+    return true;
+  }
+
+  return safeParse.call(model.zodSchema, data).success;
+}

--- a/packages/state/demo/src/PresenceManager.ts
+++ b/packages/state/demo/src/PresenceManager.ts
@@ -16,28 +16,32 @@
 
 import type {
   ActivityEvent,
+  ActivityEventData,
   DocumentId,
   DocumentSchema,
-  Model,
   PresenceEvent,
-  PresenceEventDataType,
+  PresenceEventData,
   UserId,
 } from "@palantir/pack.document-schema.model-types";
-import { getMetadata, hasMetadata } from "@palantir/pack.document-schema.model-types";
-import { resolveAndApplyLens } from "@palantir/pack.state.core";
+import {
+  ActivityEventDataType,
+  getMetadata,
+  PresenceEventDataType,
+} from "@palantir/pack.document-schema.model-types";
+import { readCustomPayload } from "@palantir/pack.state.core";
 
 const HEARTBEAT_INTERVAL_MS = 5000;
 const STALE_CLIENT_TIMEOUT_MS = 15000;
 
+type SerializableActivityCustomEventData = {
+  readonly type: typeof ActivityEventDataType.CUSTOM_EVENT;
+  readonly data: unknown;
+  readonly eventType: string;
+  readonly schemaVersion?: unknown;
+};
+
 type SerializableActivityEvent = Omit<ActivityEvent, "eventData"> & {
-  readonly eventData:
-    | {
-      readonly type: "customEvent";
-      readonly data: unknown;
-      readonly eventType: string;
-      readonly schemaVersion?: number;
-    }
-    | ActivityEvent["eventData"];
+  readonly eventData: SerializableActivityCustomEventData | ActivityEvent["eventData"];
 };
 
 type PresenceChannelMessage =
@@ -54,15 +58,15 @@ type ActivityChannelMessage = {
   readonly event: SerializableActivityEvent;
 };
 
+type SerializablePresenceCustomEventData = {
+  readonly type: typeof PresenceEventDataType.CUSTOM_EVENT;
+  readonly eventData: unknown;
+  readonly modelName: string;
+  readonly schemaVersion?: unknown;
+};
+
 type SerializablePresenceEvent = Omit<PresenceEvent, "eventData"> & {
-  readonly eventData:
-    | {
-      readonly type: "customEvent";
-      readonly eventData: unknown;
-      readonly modelName: string;
-      readonly schemaVersion?: number;
-    }
-    | PresenceEvent["eventData"];
+  readonly eventData: SerializablePresenceCustomEventData | PresenceEvent["eventData"];
 };
 
 export class PresenceManager {
@@ -212,7 +216,7 @@ export class PresenceManager {
     if (!wasActive) {
       const event: PresenceEvent = {
         eventData: {
-          type: "presenceArrived" as typeof PresenceEventDataType.ARRIVED,
+          type: PresenceEventDataType.ARRIVED,
         },
         userId,
       };
@@ -226,44 +230,11 @@ export class PresenceManager {
     if (
       event.eventData.type === "customEvent"
       && "eventType" in event.eventData
-      && this.schema != null
     ) {
-      const { eventType } = event.eventData;
-      let model: Model | undefined;
-
-      for (const key of Object.keys(this.schema)) {
-        const candidate = this.schema[key as keyof DocumentSchema];
-        if (
-          candidate != null
-          && typeof candidate === "object"
-          && hasMetadata(candidate)
-        ) {
-          const metadata = getMetadata(candidate);
-          if ("name" in metadata && metadata.name === eventType) {
-            model = candidate as Model;
-            break;
-          }
-        }
-      }
-
-      if (model != null) {
-        const data = getReadableCustomPayload(
-          this.schema,
-          eventType,
-          event.eventData.data,
-          event.eventData.schemaVersion,
-        );
-        reconstructedEvent = {
-          ...event,
-          eventData: {
-            data,
-            eventType,
-            model,
-            schemaVersion: event.eventData.schemaVersion,
-            type: "customEvent",
-          },
-        };
-      }
+      reconstructedEvent = {
+        ...event,
+        eventData: this.getActivityCustomEventData(event.eventData),
+      };
     }
 
     for (const callback of this.activityCallbacks) {
@@ -277,43 +248,11 @@ export class PresenceManager {
     if (
       event.eventData.type === "customEvent"
       && "modelName" in event.eventData
-      && this.schema != null
     ) {
-      const modelName = event.eventData.modelName;
-      let model: Model | undefined;
-
-      for (const key of Object.keys(this.schema)) {
-        const candidate = this.schema[key as keyof DocumentSchema];
-        if (
-          candidate != null
-          && typeof candidate === "object"
-          && hasMetadata(candidate)
-        ) {
-          const metadata = getMetadata(candidate);
-          if ("name" in metadata && metadata.name === modelName) {
-            model = candidate as Model;
-            break;
-          }
-        }
-      }
-
-      if (model != null) {
-        const eventData = getReadableCustomPayload(
-          this.schema,
-          modelName,
-          event.eventData.eventData,
-          event.eventData.schemaVersion,
-        );
-        reconstructedEvent = {
-          ...event,
-          eventData: {
-            eventData,
-            model,
-            schemaVersion: event.eventData.schemaVersion,
-            type: "customEvent",
-          },
-        };
-      }
+      reconstructedEvent = {
+        ...event,
+        eventData: this.getPresenceCustomEventData(event.eventData),
+      };
     }
 
     for (const callback of this.presenceCallbacks) {
@@ -335,7 +274,7 @@ export class PresenceManager {
       this.activeClients.delete(userId);
       const event: PresenceEvent = {
         eventData: {
-          type: "presenceDeparted" as typeof PresenceEventDataType.DEPARTED,
+          type: PresenceEventDataType.DEPARTED,
         },
         userId,
       };
@@ -348,41 +287,73 @@ export class PresenceManager {
       callback(event);
     }
   }
-}
 
-function getReadableCustomPayload(
-  schema: DocumentSchema,
-  modelName: string,
-  data: unknown,
-  schemaVersion = 1,
-): unknown {
-  if (!Number.isInteger(schemaVersion) || schemaVersion <= 0) {
-    return data;
+  private getActivityCustomEventData(
+    eventData: SerializableActivityCustomEventData,
+  ): ActivityEventData {
+    const { data, eventType, schemaVersion } = eventData;
+    if (this.schema == null) {
+      return {
+        rawData: data,
+        rawType: eventType,
+        type: ActivityEventDataType.UNKNOWN,
+      };
+    }
+
+    const customPayload = readCustomPayload({
+      data,
+      docSchema: this.schema,
+      modelName: eventType,
+      schemaVersion,
+    });
+    if (customPayload.type !== "readable") {
+      return {
+        rawData: data,
+        rawType: eventType,
+        type: ActivityEventDataType.UNKNOWN,
+      };
+    }
+
+    return {
+      data: customPayload.data,
+      eventType,
+      model: customPayload.model,
+      schemaVersion: customPayload.schemaVersion,
+      type: ActivityEventDataType.CUSTOM_EVENT,
+    };
   }
 
-  const metadata = getMetadata(schema);
-  const minSupportedVersion = metadata.minSupportedVersion ?? metadata.version;
-  if (schemaVersion < minSupportedVersion || schemaVersion > metadata.version) {
-    return data;
-  }
+  private getPresenceCustomEventData(
+    eventData: SerializablePresenceCustomEventData,
+  ): PresenceEventData {
+    const { eventData: data, modelName, schemaVersion } = eventData;
+    if (this.schema == null) {
+      return {
+        rawData: data,
+        rawType: modelName,
+        type: PresenceEventDataType.UNKNOWN,
+      };
+    }
 
-  const upgradeEntry = metadata.upgrades?.[modelName];
-  if (upgradeEntry == null) {
-    return data;
-  }
+    const customPayload = readCustomPayload({
+      data,
+      docSchema: this.schema,
+      modelName,
+      schemaVersion,
+    });
+    if (customPayload.type !== "readable") {
+      return {
+        rawData: data,
+        rawType: modelName,
+        type: PresenceEventDataType.UNKNOWN,
+      };
+    }
 
-  if (data == null || typeof data !== "object" || Array.isArray(data)) {
-    return data;
-  }
-
-  try {
-    return resolveAndApplyLens(
-      data as Record<string, unknown>,
-      upgradeEntry,
-      metadata.upgrades ?? {},
-      metadata.upgradeFns,
-    );
-  } catch {
-    return data;
+    return {
+      eventData: customPayload.data,
+      model: customPayload.model,
+      schemaVersion: customPayload.schemaVersion,
+      type: PresenceEventDataType.CUSTOM_EVENT,
+    };
   }
 }

--- a/packages/state/demo/src/__tests__/PresenceManager.test.ts
+++ b/packages/state/demo/src/__tests__/PresenceManager.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ActivityEvent,
+  ActivityEventId,
+  DocumentId,
+  DocumentSchema,
+  Model,
+  PresenceEvent,
+  UserId,
+} from "@palantir/pack.document-schema.model-types";
+import {
+  ActivityEventDataType,
+  Metadata,
+  PresenceEventDataType,
+} from "@palantir/pack.document-schema.model-types";
+import { describe, expect, it, vi } from "vitest";
+import { PresenceManager } from "../PresenceManager.js";
+
+interface TestPayload {
+  readonly id: string;
+}
+
+const TestModel = {
+  __type: {} as TestPayload,
+  [Metadata]: { name: "TestModel" },
+  zodSchema: {},
+} as unknown as Model<TestPayload>;
+
+const schema = {
+  [Metadata]: {
+    version: 1,
+  },
+  TestModel,
+} as const satisfies DocumentSchema;
+
+function createDocumentId(): DocumentId {
+  return `presence-manager-test-${Date.now()}-${Math.random()}` as DocumentId;
+}
+
+describe("PresenceManager custom payload mapping", () => {
+  it("maps unsupported custom activity payload versions to UNKNOWN", async () => {
+    const documentId = createDocumentId();
+    const sender = new PresenceManager(documentId, "sender", schema);
+    const receiver = new PresenceManager(documentId, "receiver", schema);
+    const receivedEvents: ActivityEvent[] = [];
+
+    try {
+      receiver.onActivity(event => {
+        receivedEvents.push(event);
+      });
+
+      sender.broadcastActivity({
+        aggregationKey: "agg-1",
+        createdBy: "sender" as UserId,
+        createdInstant: 1,
+        eventData: {
+          data: { id: "payload-1" },
+          eventType: "TestModel",
+          model: TestModel,
+          schemaVersion: 99,
+          type: ActivityEventDataType.CUSTOM_EVENT,
+        },
+        eventId: "event-1" as ActivityEventId,
+        isRead: false,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          receivedEvents.some(event =>
+            event.eventData.type === ActivityEventDataType.UNKNOWN
+            && event.eventData.rawType === "TestModel"
+          ),
+        ).toBe(true);
+      });
+    } finally {
+      sender.dispose();
+      receiver.dispose();
+    }
+  });
+
+  it("maps unsupported custom presence payload versions to UNKNOWN", async () => {
+    const documentId = createDocumentId();
+    const sender = new PresenceManager(documentId, "sender", schema);
+    const receiver = new PresenceManager(documentId, "receiver", schema);
+    const receivedEvents: PresenceEvent[] = [];
+
+    try {
+      receiver.onPresence(event => {
+        receivedEvents.push(event);
+      });
+
+      sender.broadcastPresence({
+        eventData: {
+          eventData: { id: "payload-1" },
+          model: TestModel,
+          schemaVersion: 99,
+          type: PresenceEventDataType.CUSTOM_EVENT,
+        },
+        userId: "sender" as UserId,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          receivedEvents.some(event =>
+            event.eventData.type === PresenceEventDataType.UNKNOWN
+            && event.eventData.rawType === "TestModel"
+          ),
+        ).toBe(true);
+      });
+    } finally {
+      sender.dispose();
+      receiver.dispose();
+    }
+  });
+});

--- a/packages/state/foundry/src/eventMappers.ts
+++ b/packages/state/foundry/src/eventMappers.ts
@@ -29,8 +29,6 @@ import type {
   ActivityEventDataDocumentMandatorySecurityUpdate,
   ActivityEventDataDocumentRename,
   DocumentSchema,
-  Model,
-  ModelData,
   PresenceEvent,
   PresenceEventData,
   PresenceEventDataArrived,
@@ -39,13 +37,9 @@ import type {
 } from "@palantir/pack.document-schema.model-types";
 import {
   ActivityEventDataType,
-  getMetadata,
-  hasMetadata,
   PresenceEventDataType,
 } from "@palantir/pack.document-schema.model-types";
-import { resolveAndApplyLens } from "@palantir/pack.state.core";
-
-const LEGACY_CUSTOM_PAYLOAD_VERSION = 1;
+import { readCustomPayload } from "@palantir/pack.state.core";
 
 export function getActivityEvent(
   documentSchema: DocumentSchema,
@@ -114,22 +108,13 @@ function getActivityEventData(
 
     case "documentCustomEvent": {
       const { eventType, data } = eventData;
-      const schemaVersion = getCustomPayloadSchemaVersion(eventData);
-      if (schemaVersion == null) {
-        return {
-          rawData: data,
-          rawType: eventType,
-          type: ActivityEventDataType.UNKNOWN,
-        };
-      }
-
-      const customPayload = getReadableCustomPayload(
-        docSchema,
-        eventType,
+      const customPayload = readCustomPayload({
         data,
-        schemaVersion,
-      );
-      if (customPayload == null) {
+        docSchema,
+        modelName: eventType,
+        schemaVersion: eventData.version,
+      });
+      if (customPayload.type !== "readable") {
         return {
           rawData: data,
           rawType: eventType,
@@ -141,7 +126,7 @@ function getActivityEventData(
         data: customPayload.data,
         eventType,
         model: customPayload.model,
-        schemaVersion,
+        schemaVersion: customPayload.schemaVersion,
         type: ActivityEventDataType.CUSTOM_EVENT,
       };
     }
@@ -181,14 +166,12 @@ export function getPresenceEvent(
 
     case "customPresenceEvent": {
       const { userId, eventData, eventType } = foundryUpdate;
-      const schemaVersion = getCustomPayloadSchemaVersion(foundryUpdate);
-      const presenceEventData = schemaVersion == null
-        ? {
-          rawData: eventData,
-          rawType: eventType,
-          type: PresenceEventDataType.UNKNOWN,
-        }
-        : getPresenceEventData(documentSchema, eventType, eventData, schemaVersion);
+      const presenceEventData = getPresenceEventData(
+        documentSchema,
+        eventType,
+        eventData,
+        getEnvelopeSchemaVersion(foundryUpdate),
+      );
       return {
         eventData: presenceEventData,
         userId: userId as UserId,
@@ -214,15 +197,15 @@ function getPresenceEventData(
   docSchema: DocumentSchema,
   eventType: string,
   eventData: unknown,
-  schemaVersion: number,
+  schemaVersion: unknown,
 ): PresenceEventData {
-  const customPayload = getReadableCustomPayload(
+  const customPayload = readCustomPayload({
+    data: eventData,
     docSchema,
-    eventType,
-    eventData,
+    modelName: eventType,
     schemaVersion,
-  );
-  if (customPayload == null) {
+  });
+  if (customPayload.type !== "readable") {
     return {
       rawData: eventData,
       rawType: eventType,
@@ -233,90 +216,11 @@ function getPresenceEventData(
   return {
     eventData: customPayload.data,
     model: customPayload.model,
-    schemaVersion,
+    schemaVersion: customPayload.schemaVersion,
     type: PresenceEventDataType.CUSTOM_EVENT,
   };
 }
 
-function getCustomPayloadSchemaVersion(payload: object): number | undefined {
-  if (!("version" in payload) || payload.version == null) {
-    return LEGACY_CUSTOM_PAYLOAD_VERSION;
-  }
-
-  return typeof payload.version === "number"
-      && Number.isInteger(payload.version)
-      && payload.version > 0
-    ? payload.version
-    : undefined;
-}
-
-function getReadableCustomPayload(
-  docSchema: DocumentSchema,
-  modelName: string,
-  data: unknown,
-  schemaVersion: number,
-): { readonly data: ModelData<Model>; readonly model: Model } | undefined {
-  if (!isSupportedSchemaVersion(docSchema, schemaVersion)) {
-    return undefined;
-  }
-
-  const model = getModelByName(docSchema, modelName);
-  if (model == null) {
-    return undefined;
-  }
-
-  let readableData = data;
-  const schemaMetadata = getMetadata(docSchema);
-  const upgradeEntry = schemaMetadata.upgrades?.[modelName];
-  if (upgradeEntry != null) {
-    if (data == null || typeof data !== "object" || Array.isArray(data)) {
-      return undefined;
-    }
-    try {
-      readableData = resolveAndApplyLens(
-        data as Record<string, unknown>,
-        upgradeEntry,
-        schemaMetadata.upgrades ?? {},
-        schemaMetadata.upgradeFns,
-      );
-    } catch {
-      return undefined;
-    }
-  }
-
-  if (!isValidModelData(model, readableData)) {
-    return undefined;
-  }
-
-  return {
-    data: readableData as ModelData<Model>,
-    model,
-  };
-}
-
-function isSupportedSchemaVersion(docSchema: DocumentSchema, schemaVersion: number): boolean {
-  const schemaMetadata = getMetadata(docSchema);
-  const minSupportedVersion = schemaMetadata.minSupportedVersion ?? schemaMetadata.version;
-  return schemaVersion >= minSupportedVersion && schemaVersion <= schemaMetadata.version;
-}
-
-function getModelByName(docSchema: DocumentSchema, modelName: string): Model | undefined {
-  for (const candidate of Object.values(docSchema)) {
-    if (candidate != null && typeof candidate === "object" && hasMetadata(candidate)) {
-      const metadata = getMetadata(candidate);
-      if ("name" in metadata && metadata.name === modelName) {
-        return candidate;
-      }
-    }
-  }
-  return undefined;
-}
-
-function isValidModelData(model: Model, data: unknown): boolean {
-  const safeParse = model.zodSchema.safeParse;
-  if (typeof safeParse !== "function") {
-    return true;
-  }
-
-  return safeParse.call(model.zodSchema, data).success;
+function getEnvelopeSchemaVersion(envelope: object): unknown {
+  return "version" in envelope ? envelope.version : undefined;
 }


### PR DESCRIPTION
There were three different places we applied read lenses: models, presence and activity. This unifies all three to use a single pathway through `readCustomPayload`.