### PR TITLE
Delete `ReturnedSchema` and `Schema` type aliases (closes #180)

### DIFF
--- a/.changeset/delete-returnedschema-schema-aliases.md
+++ b/.changeset/delete-returnedschema-schema-aliases.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.schema": minor
+---
+
+Remove the deprecated `ReturnedSchema` and `Schema` type aliases from `@palantir/pack.schema`. Both were thin aliases over `ModelDefs` (`ReturnedSchema = ModelDefs`, `Schema<T> = T`) and were marked for removal. Use `ModelDefs` directly instead.

--- a/packages/document-schema/type-gen/src/commands/steps/stepsGenTypesHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/steps/stepsGenTypesHandler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ReturnedSchema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 import { CommanderError } from "commander";
 import { consola } from "consola";
 import * as fs from "fs";
@@ -62,7 +62,7 @@ export function stepsGenTypesHandler(options: TypesGenOptions): void {
 
   const { recordDefinitions, unionDefinitions } = convertStepsToSchema(steps);
 
-  const schema: ReturnedSchema = {
+  const schema: ModelDefs = {
     ...Object.fromEntries(recordDefinitions.map(def => [def.name, def])),
     ...Object.fromEntries(unionDefinitions.map(def => [def.name, def])),
   };

--- a/packages/document-schema/type-gen/src/utils/schema/convertSchemaToSteps.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/convertSchemaToSteps.ts
@@ -85,7 +85,7 @@ function convertUnionToYaml(unionDef: P.UnionDef): UnionDefinition {
   return result;
 }
 
-export function convertSchemaToSteps(schema: P.ReturnedSchema): MigrationStep[] {
+export function convertSchemaToSteps(schema: P.ModelDefs): MigrationStep[] {
   // Reject aliased schemas: the YAML step format cannot represent exportKey !== declaredName
   for (const [exportKey, def] of Object.entries(schema)) {
     if (exportKey !== def.name) {

--- a/packages/document-schema/type-gen/src/utils/schema/generateTypesFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateTypesFromSchema.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ReturnedSchema, Schema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 import { TypeKind as SchemaTypeKind } from "@palantir/pack.schema";
 import { formatVariantName } from "../formatVariantName.js";
 import { GENERATED_FILE_HEADER } from "../generatedFileHeader.js";
@@ -179,8 +179,8 @@ function detectUsedRefTypes(schema: RuntimeSchema): Set<string> {
   return refTypes;
 }
 
-export function generateTypesFromSchema<T extends ReturnedSchema>(
-  schema: Schema<T>,
+export function generateTypesFromSchema<T extends ModelDefs>(
+  schema: T,
 ): string {
   const runtimeSchema = schema as unknown as RuntimeSchema;
 

--- a/packages/document-schema/type-gen/src/utils/schema/generateZodFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateZodFromSchema.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ReturnedSchema, Schema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 import { generateZodSchemasFromIr } from "../ir/generateZodSchemasFromIr.js";
 import { convertSchemaToIr, type SchemaMetadata } from "../steps/convertStepsToIr.js";
 
@@ -24,8 +24,8 @@ import { convertSchemaToIr, type SchemaMetadata } from "../steps/convertStepsToI
  * @param metadata - Optional schema metadata overrides
  * @returns Generated TypeScript code with Zod schemas
  */
-export async function generateZodFromSchema<T extends ReturnedSchema>(
-  schema: Schema<T>,
+export async function generateZodFromSchema<T extends ModelDefs>(
+  schema: T,
   metadata?: SchemaMetadata,
 ): Promise<string> {
   const irSchema = convertSchemaToIr(

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/__snapshots__/stepSchemas/customDiscriminant.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/__snapshots__/stepSchemas/customDiscriminant.ts
@@ -1,5 +1,5 @@
 
-import { Schema } from "@palantir/pack.schema";
+import { ModelDefs } from "@palantir/pack.schema";
 
 const schema = (
 {
@@ -47,6 +47,6 @@ const schema = (
     }
   }
 }
-) satisfies Schema<any>;
+) satisfies ModelDefs;
 
 export default schema;

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/__snapshots__/stepSchemas/simpleSteps.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/__snapshots__/stepSchemas/simpleSteps.ts
@@ -1,5 +1,5 @@
 
-import { Schema } from "@palantir/pack.schema";
+import { ModelDefs } from "@palantir/pack.schema";
 
 const schema = (
 {
@@ -84,6 +84,6 @@ const schema = (
     }
   }
 }
-) satisfies Schema<any>;
+) satisfies ModelDefs;
 
 export default schema;

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/convertStepsToSchema.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ReturnedSchema, Schema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 import fs from "fs";
 import path from "path";
 import { describe, expect, it } from "vitest";
@@ -41,7 +41,7 @@ describe("convertStepsToSchema", () => {
       const raw: unknown = YAML.parse(fileContent);
       const parsedSteps = parseMigrationSteps(raw);
       const { recordDefinitions, unionDefinitions } = convertStepsToSchema(parsedSteps);
-      const schema: Schema<ReturnedSchema> = {};
+      const schema: ModelDefs = {};
 
       // Add record definitions using their record names as keys
       recordDefinitions.forEach(record => {
@@ -61,13 +61,13 @@ describe("convertStepsToSchema", () => {
   });
 });
 
-function printSchemaFile(schema: Schema<ReturnedSchema>) {
+function printSchemaFile(schema: ModelDefs) {
   return `
-import { Schema } from "@palantir/pack.schema";
+import { ModelDefs } from "@palantir/pack.schema";
 
 const schema = (
 ${JSON.stringify(schema, null, 2)}
-) satisfies Schema<any>;
+) satisfies ModelDefs;
 
 export default schema;
 `;

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/arrayFields.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/arrayFields.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 
 const arrayFields = {
   "Container": {
@@ -19,6 +19,6 @@ const arrayFields = {
       },
     },
   },
-} satisfies Schema<any>;
+} satisfies ModelDefs;
 
 export default arrayFields;

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/customDiscriminant.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/customDiscriminant.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 
 const customDiscriminant = {
   "Animal": {
@@ -44,6 +44,6 @@ const customDiscriminant = {
       },
     },
   },
-} satisfies Schema<any>;
+} satisfies ModelDefs;
 
 export default customDiscriminant;

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/generateTypeScriptInterfaces.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/generateTypeScriptInterfaces.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 
 const generateTypeScriptInterfaces = {
   "Node": {
@@ -75,6 +75,6 @@ const generateTypeScriptInterfaces = {
       },
     },
   },
-} satisfies Schema<any>;
+} satisfies ModelDefs;
 
 export default generateTypeScriptInterfaces;

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/refTypes.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/refTypes.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 
 const refTypes = {
   "Document": {
@@ -41,6 +41,6 @@ const refTypes = {
       },
     },
   },
-} satisfies Schema<any>;
+} satisfies ModelDefs;
 
 export default refTypes;

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/simpleRecord.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/fixtures/stepSchemas/simpleRecord.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 
 const simpleRecord = {
   "Person": {
@@ -20,6 +20,6 @@ const simpleRecord = {
       },
     },
   },
-} satisfies Schema<any>;
+} satisfies ModelDefs;
 
 export default simpleRecord;

--- a/packages/document-schema/type-gen/src/utils/steps/__tests__/generateTypes.test.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/__tests__/generateTypes.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ReturnedSchema, Schema } from "@palantir/pack.schema";
+import type { ModelDefs } from "@palantir/pack.schema";
 import fs from "fs";
 import path from "path";
 import { describe, expect, it } from "vitest";
@@ -43,7 +43,7 @@ describe("generateTypes", () => {
 
     it(`should handle ${testName}`, async () => {
       const inputSchema = await import(path.join(fixturesInputDir, testFile)) as {
-        default: Schema<ReturnedSchema>;
+        default: ModelDefs;
       };
       const result = generateTypesFromSchema(inputSchema.default);
 

--- a/packages/document-schema/type-gen/src/utils/steps/convertStepsToIr.ts
+++ b/packages/document-schema/type-gen/src/utils/steps/convertStepsToIr.ts
@@ -79,7 +79,7 @@ export function convertStepsToIr(
  * everything falls back to `metadata.version` (default 1).
  */
 export function convertSchemaToIr(
-  inputSchema: P.Schema<P.ReturnedSchema>,
+  inputSchema: P.ModelDefs,
   metadata?: SchemaMetadata,
   provenance?: SchemaProvenance,
 ): IRealTimeDocumentSchema {

--- a/packages/schema/src/defineMigration.ts
+++ b/packages/schema/src/defineMigration.ts
@@ -21,12 +21,6 @@ import { ModelDefType } from "./defs.js";
 import type { Ref, Type } from "./primitives.js";
 import { isRecordDef, isUnionDef } from "./utils.js";
 
-/** Soon to be deprecated - Use `ModelDefs` instead. */
-export type ReturnedSchema = ModelDefs;
-
-/** Soon to be deprecated - use `ModelDefs` instead. */
-export type Schema<T extends ModelDefs> = T;
-
 export type SchemaBuilder<T extends ModelDefs> = {
   [k in keyof T]: T[k] extends UnionDef<infer R> ? UnionBuilder<R>
     : T[k] extends RecordDef<infer R> ? RecordBuilder<R>


### PR DESCRIPTION
## What

Closes #180. `@palantir/pack.schema` exported two type aliases that the issue asked to remove, both replaced by `ModelDefs`:

```ts
/** Soon to be deprecated - Use `ModelDefs` instead. */
export type ReturnedSchema = ModelDefs;

/** Soon to be deprecated - use `ModelDefs` instead. */
export type Schema<T extends ModelDefs> = T;
```

This PR deletes them and migrates every usage to `ModelDefs` directly.

## Changes

- **`packages/schema`** — removed the `ReturnedSchema` / `Schema` aliases from `defineMigration.ts`.
- **`packages/document-schema/type-gen`** — migrated all consumers:
  - `convertSchemaToSteps.ts`, `convertStepsToIr.ts` (`P.ReturnedSchema` / `P.Schema<P.ReturnedSchema>` → `P.ModelDefs`)
  - `generateTypesFromSchema.ts`, `generateZodFromSchema.ts` (`<T extends ReturnedSchema>` + `schema: Schema<T>` → `<T extends ModelDefs>` + `schema: T`)
  - `stepsGenTypesHandler.ts`
  - test files + fixtures (`satisfies Schema<any>` → `satisfies ModelDefs`, which now strictly validates the fixtures as real schemas)
  - regenerated the two affected snapshots

The local, unrelated `ReturnedSchema` type in `validateSchemaModule.ts` (`= Record<string, SchemaDef>`) is intentionally left untouched.

## Notes

These were type-only aliases, so there is **no runtime behaviour change**. The change is breaking only at the type level (two removed exports from `@palantir/pack.schema`), hence a `minor` changeset for that 0.x package.

## Testing

- `vitest run src/utils/steps src/utils/schema` — 94 passed (13 files)
- `pnpm typecheck` (schema + type-gen) — clean
- `eslint` — clean
- `dprint check` — clean