### PR TITLE
export runtime functions in sdk

### DIFF
--- a/.changeset/export-versioned-type-guards.md
+++ b/.changeset/export-versioned-type-guards.md
@@ -1,0 +1,9 @@
+---
+"@palantir/pack.document-schema.type-gen": minor
+---
+
+Export union variant type guards as values from the generated versioned SDK `index.ts`.
+
+The versioned generator emits per-variant guard functions (e.g. `isShape_v1Circle`) into `types_vN.ts`, but `index.ts` only re-exported per-version symbols via `export type { ... }`. Since guards are runtime values, the type-only re-export erased them, leaving them unreachable from the package root — unlike the legacy non-versioned generator, whose flat `export *` carried them through.
+
+`generateIndexFromChain` now emits a per-version value export (`export { isFooBar_v1, ... } from "./types_vN.js"`) alongside the existing type-only export, so consumers can narrow a union at runtime without re-deriving the discriminant check. Records-only schemas are unaffected (no guards, no value export).

--- a/demos/canvas/sdk/src/index.ts
+++ b/demos/canvas/sdk/src/index.ts
@@ -7,5 +7,8 @@ export * from "./versionedDocRef.js";
 export * from "./documentType.js";
 export { type DocumentUpgradeFns } from "./_internal/upgradeFns.js";
 export type { CanvasActivity_v1, CanvasActivity_v1ShapeAdded, CanvasActivity_v1ShapeDeleted, CanvasActivity_v1ShapeUpdated, CursorPresence_v1, NodeShape_v1, NodeShape_v1Box, NodeShape_v1Circle, SelectionPresence_v1, ShapeAddedActivity_v1, ShapeBox_v1, ShapeCircle_v1, ShapeDeletedActivity_v1, ShapeUpdatedActivity_v1 } from "./types_v1.js";
+export { isCanvasActivity_v1ShapeAdded, isCanvasActivity_v1ShapeDeleted, isCanvasActivity_v1ShapeUpdated, isNodeShape_v1Box, isNodeShape_v1Circle } from "./types_v1.js";
 export type { CanvasActivity_v2, CanvasActivity_v2ShapeAdded, CanvasActivity_v2ShapeDeleted, CanvasActivity_v2ShapeUpdated, CursorPresence_v2, NodeShape_v2, NodeShape_v2Box, NodeShape_v2Circle, SelectionPresence_v2, ShapeAddedActivity_v2, ShapeBox_v2, ShapeCircle_v2, ShapeDeletedActivity_v2, ShapeUpdatedActivity_v2 } from "./types_v2.js";
+export { isCanvasActivity_v2ShapeAdded, isCanvasActivity_v2ShapeDeleted, isCanvasActivity_v2ShapeUpdated, isNodeShape_v2Box, isNodeShape_v2Circle } from "./types_v2.js";
 export type { CanvasActivity_v3, CanvasActivity_v3ShapeAdded, CanvasActivity_v3ShapeDeleted, CanvasActivity_v3ShapeUpdated, CursorPresence_v3, FreehandStroke_v3, NodeShape_v3, NodeShape_v3Box, NodeShape_v3Circle, SelectionPresence_v3, ShapeAddedActivity_v3, ShapeBox_v3, ShapeCircle_v3, ShapeDeletedActivity_v3, ShapeUpdatedActivity_v3 } from "./types_v3.js";
+export { isCanvasActivity_v3ShapeAdded, isCanvasActivity_v3ShapeDeleted, isCanvasActivity_v3ShapeUpdated, isNodeShape_v3Box, isNodeShape_v3Circle } from "./types_v3.js";

--- a/packages/document-schema/type-gen/src/utils/schema/__tests__/generateIndexFromSchema.test.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/__tests__/generateIndexFromSchema.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateIndexFromChain } from "../generateIndexFromSchema.js";
+import { resolveSchemaChain } from "../resolveSchemaChain.js";
+import { singleVersionSchema, unionTypesSchema } from "./fixtures.js";
+
+describe("generateIndexFromChain", () => {
+  it("re-exports union variant type guards as values", () => {
+    const result = generateIndexFromChain(resolveSchemaChain(unionTypesSchema));
+
+    // Guards are exported as values (not `export type`) so consumers can narrow
+    // a union at runtime without re-deriving the discriminant check.
+    expect(result).toContain(
+      `export { isShape_v1Circle, isShape_v1Rectangle } from "./types_v1.js";`,
+    );
+    // The variant *types* remain a separate type-only export.
+    expect(result).toMatch(/export type \{[^}]*Shape_v1Circle[^}]*\} from "\.\/types_v1\.js";/);
+  });
+
+  it("emits no value guard export when the schema has no unions", () => {
+    const result = generateIndexFromChain(resolveSchemaChain(singleVersionSchema));
+
+    // No unions → no `is<Variant>` guards → no value export from types_v1.
+    expect(result).not.toMatch(/export \{ is\w+ \} from "\.\/types_v1\.js";/);
+  });
+});

--- a/packages/document-schema/type-gen/src/utils/schema/generateIndexFromSchema.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/generateIndexFromSchema.ts
@@ -42,6 +42,9 @@ import {
  * - `DocumentUpgradeFns` type (the typed shape the factory accepts)
  * - Per supported version: explicit named type exports from `types_vN.js`
  *   (not star exports, to avoid polluting autocomplete for read-only consumers)
+ * - Per supported version: the union variant type guard *functions* from
+ *   `types_vN.js` as values (e.g. `isFooBar_v1`), so consumers can narrow a
+ *   union without re-deriving the discriminant check
  */
 export function generateIndexFromChain(
   resolved: ResolvedIrChain,
@@ -67,6 +70,8 @@ export function generateIndexFromChain(
     if (version < minVersion) continue;
 
     const typeNames: string[] = [];
+    // Union variant type guard functions (values, not types).
+    const guardNames: string[] = [];
 
     for (const [modelKey, modelDef] of Object.entries(ir.models)) {
       if (modelDef.type === "record") {
@@ -74,10 +79,12 @@ export function generateIndexFromChain(
       } else if (modelDef.type === "union") {
         typeNames.push(versionedTypeName(modelKey, version));
 
-        // Union variant types
+        // Union variant types and their generated `is<Variant>` guards.
         for (const variantName of Object.keys(modelDef.union.variants)) {
           const formattedVariant = formatVariantName(variantName);
-          typeNames.push(`${versionedTypeName(modelKey, version)}${formattedVariant}`);
+          const variantTypeName = `${versionedTypeName(modelKey, version)}${formattedVariant}`;
+          typeNames.push(variantTypeName);
+          guardNames.push(`is${variantTypeName}`);
         }
       }
     }
@@ -86,6 +93,10 @@ export function generateIndexFromChain(
       output += `export type { ${typeNames.sort().join(", ")} } from "${
         typesFilePath(version)
       }";\n`;
+    }
+
+    if (guardNames.length > 0) {
+      output += `export { ${guardNames.sort().join(", ")} } from "${typesFilePath(version)}";\n`;
     }
   }
 


### PR DESCRIPTION
type guard functions were not included as part of generated sdk exports. include them as part of exports.