### PR TITLE
Publish stable versions under `latest` even when pre.json is present (closes #60)

### DIFF
--- a/packages/monorepo/release/src/ciPublish.test.ts
+++ b/packages/monorepo/release/src/ciPublish.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { determineTag, findGreatestVersion } from "./ciPublish.js";
+import { determineTag, findGreatestVersion, hasPrereleaseVersion } from "./ciPublish.js";
 
 describe("findGreatestVersion", () => {
   it("should find the highest semver version from release branch names", () => {
@@ -69,5 +69,24 @@ describe("determineTag", () => {
     const result = determineTag(currentBranch, greatestVersion, defaultTag);
 
     expect(result).toBe("latest-2.0.x");
+  });
+});
+
+describe("hasPrereleaseVersion", () => {
+  it("should return false when all versions are stable releases", () => {
+    expect(hasPrereleaseVersion(["1.0.0", "2.3.4", "0.1.0"])).toBe(false);
+  });
+
+  it("should return true when any version is a semver prerelease", () => {
+    expect(hasPrereleaseVersion(["1.0.0", "2.0.0-beta.0"])).toBe(true);
+  });
+
+  it("should return true for prerelease identifiers other than beta", () => {
+    expect(hasPrereleaseVersion(["1.0.0-alpha.1"])).toBe(true);
+    expect(hasPrereleaseVersion(["1.0.0-rc.2"])).toBe(true);
+  });
+
+  it("should return false for an empty list", () => {
+    expect(hasPrereleaseVersion([])).toBe(false);
   });
 });

--- a/packages/monorepo/release/src/ciPublish.ts
+++ b/packages/monorepo/release/src/ciPublish.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { getPackages } from "@manypkg/get-packages";
 import consola from "consola";
 import { execa } from "execa";
 import { existsSync } from "fs";
@@ -26,7 +27,15 @@ async function ciPublish(): Promise<void> {
   const repoRoot = process.cwd();
   const preJsonPath = join(repoRoot, ".changeset", "pre.json");
 
-  if (existsSync(preJsonPath)) {
+  // `.changeset/pre.json` merely records that the repo is in changeset "pre"
+  // mode; it is not deleted when pre mode is exited to cut a stable release.
+  // A release maintainer may exit pre mode, version + commit a stable release,
+  // then re-enter pre mode, leaving `pre.json` present alongside stable
+  // versions. Only use the prerelease dist-tag when the versions actually being
+  // published are semver prereleases, otherwise fall back to the branch-based
+  // tag so stable releases land on "latest". See issue #60.
+  const versions = await getPublishableVersions(repoRoot);
+  if (existsSync(preJsonPath) && hasPrereleaseVersion(versions)) {
     try {
       const preJson = JSON.parse(await readFile(preJsonPath, "utf-8"));
       if (preJson.mode === "pre") {
@@ -66,6 +75,19 @@ async function ciPublish(): Promise<void> {
     consola.error(`Error during publish: ${error}`);
     process.exit(1);
   }
+}
+
+async function getPublishableVersions(repoRoot: string): Promise<string[]> {
+  const { packages } = await getPackages(repoRoot);
+  // Private packages are never published (pnpm skips them), so their versions
+  // must not influence the dist-tag decision.
+  return packages
+    .filter(pkg => !pkg.packageJson.private)
+    .map(pkg => pkg.packageJson.version);
+}
+
+export function hasPrereleaseVersion(versions: string[]): boolean {
+  return versions.some(version => semver.prerelease(version) != null);
 }
 
 async function getRemoteBranches(): Promise<string[]> {


### PR DESCRIPTION
## Problem

Closes #60.

`ciPublish` picks the npm dist-tag based purely on whether `.changeset/pre.json` exists:

https://github.com/palantir/pack/blob/main/packages/monorepo/release/src/ciPublish.ts#L29-L47

But changesets does **not** delete `pre.json` when pre mode is exited — it only flips its `mode`. The release flow described in the issue is:

1. exit pre mode
2. run the release commit script (produces **stable** versions)
3. re-enter pre mode

After step 3, `pre.json` is present again while the committed `package.json` versions are stable releases. So when `main` publishes, `ciPublish` reads `pre.json`, sees `mode === "pre"`, and publishes everything under the prerelease tag (e.g. `beta`) instead of `latest`.

## Fix

Decide the tag from the **versions actually being published**, not merely from the presence of `pre.json`. The prerelease dist-tag is only honored when at least one publishable (non-private) package has a semver prerelease version (e.g. `1.2.3-beta.0`). Otherwise we fall back to the existing branch-based `determineTag` logic, so stable releases land on `latest`.

- New `getPublishableVersions()` reads package versions via the same `@manypkg/get-packages` helper used elsewhere in this package, filtering out private packages (which pnpm never publishes).
- New pure, exported `hasPrereleaseVersion()` — unit-tested.

## Tests

Added unit tests for `hasPrereleaseVersion` (stable-only, mixed, non-beta identifiers, empty). `pnpm test`, `pnpm typecheck`, and `pnpm lint` all pass in `packages/monorepo/release`.

> Note: this only touches `packages/monorepo/release`. There is a **pre-existing**, unrelated typecheck failure on `main` in `packages/document-schema/type-gen` (`@osdk/foundry.pack` no longer exports `DocumentTypeAsset`) that is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)