### PR TITLE
Bump platform sdk and wire application id endpoint

### DIFF
--- a/.changeset/resolve-document-application.md
+++ b/.changeset/resolve-document-application.md
@@ -20,3 +20,7 @@ when none is configured. Unsupported on the in-memory and demo services.
 `createDocumentEditDescription` no longer sends the deprecated `eventData.version` or top-level
 `eventType` fields (both are now optional in the SDK/API and superseded by `eventData.schemaVersion`
 and `eventData.eventType`).
+
+`searchDocuments` accepts an optional `ontologyRid` in its options, forwarded to the search
+request to scope results to a specific ontology. Not defaulted — omitted when unset, in which
+case the document type name is searched across all ontologies.

--- a/.changeset/resolve-document-application.md
+++ b/.changeset/resolve-document-application.md
@@ -1,0 +1,22 @@
+---
+"@palantir/pack.state.core": minor
+"@palantir/pack.state.foundry": minor
+"@palantir/pack.state.foundry-event": minor
+"@palantir/pack.state.demo": minor
+---
+
+Bump `@osdk/foundry.pack` to `^2.68.0`, surface `owningApplicationId` on document types, and add document-to-application resolution.
+
+The SDK adds `owningApplicationId` to the wire `DocumentType`, populated from the type's
+metadata. `DocumentType` (state.core) now carries `owningApplicationId?: string` and
+`FoundryDocumentService` maps it through, so it rides along on every
+`loadDocumentTypeByName` / `getDocumentType` call.
+
+Adds `resolveDocumentApplication(docRef)` to `DocumentService` (and `app.state`), backed by
+the new `GET /v2/pack/documents/{documentId}/resolveApplication` endpoint. Given a document,
+it resolves the owning application id from the document's type metadata, returning `undefined`
+when none is configured. Unsupported on the in-memory and demo services.
+
+`createDocumentEditDescription` no longer sends the deprecated `eventData.version` or top-level
+`eventType` fields (both are now optional in the SDK/API and superseded by `eventData.schemaVersion`
+and `eventData.eventType`).

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -164,6 +164,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
       documentName?: string;
       pageSize?: number;
       pageToken?: string;
+      ontologyRid?: string;
     },
   ) => Promise<SearchDocumentsResult>;
 

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -190,6 +190,10 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     ontologyRid?: string,
   ) => Promise<number | undefined>;
 
+  abstract readonly resolveDocumentApplication: (
+    docRef: DocumentRef,
+  ) => Promise<string | undefined>;
+
   readonly getDocumentSchemaOperationalVersion = (
     docRef: DocumentRef,
   ): number => {

--- a/packages/state/core/src/service/InMemoryDocumentService.ts
+++ b/packages/state/core/src/service/InMemoryDocumentService.ts
@@ -200,6 +200,16 @@ class InMemoryDocumentService extends BaseYjsDocumentService {
     );
   };
 
+  readonly resolveDocumentApplication = (
+    _docRef: DocumentRef,
+  ): Promise<string | undefined> => {
+    return Promise.reject(
+      new Error(
+        "resolveDocumentApplication is not supported by the in-memory document service",
+      ),
+    );
+  };
+
   // Lifecycle method implementations
   protected onMetadataSubscriptionOpened(
     internalDoc: InternalYjsDoc,

--- a/packages/state/core/src/service/InMemoryDocumentService.ts
+++ b/packages/state/core/src/service/InMemoryDocumentService.ts
@@ -117,6 +117,7 @@ class InMemoryDocumentService extends BaseYjsDocumentService {
       documentName?: string;
       pageSize?: number;
       pageToken?: string;
+      ontologyRid?: string;
     },
   ): Promise<SearchDocumentsResult> => {
     const results: Array<DocumentMetadata & { readonly id: DocumentId }> = [];

--- a/packages/state/core/src/types/DocumentService.ts
+++ b/packages/state/core/src/types/DocumentService.ts
@@ -148,6 +148,7 @@ export interface DocumentService {
       documentName?: string;
       pageSize?: number;
       pageToken?: string;
+      ontologyRid?: string;
     },
   ) => Promise<SearchDocumentsResult>;
 

--- a/packages/state/core/src/types/DocumentService.ts
+++ b/packages/state/core/src/types/DocumentService.ts
@@ -112,6 +112,7 @@ export interface DocumentType {
   readonly name: string;
   readonly operationalVersion?: number;
   readonly fileSystemType?: FileSystemType;
+  readonly owningApplicationId?: string;
 }
 
 /**
@@ -199,6 +200,14 @@ export interface DocumentService {
     documentTypeName: string,
     ontologyRid?: string,
   ) => Promise<number | undefined>;
+
+  /**
+   * Resolves a document to the application that owns its document type. Returns the owning
+   * application id from the type's metadata, or undefined if none is configured.
+   */
+  readonly resolveDocumentApplication: (
+    docRef: DocumentRef,
+  ) => Promise<string | undefined>;
 
   readonly createDocRef: <const T extends DocumentSchema>(
     id: DocumentId,

--- a/packages/state/core/src/types/StateModule.ts
+++ b/packages/state/core/src/types/StateModule.ts
@@ -115,6 +115,10 @@ export interface StateModule {
     ontologyRid?: string,
   ) => Promise<number | undefined>;
 
+  readonly resolveDocumentApplication: (
+    docRef: DocumentRef,
+  ) => Promise<string | undefined>;
+
   readonly getDocumentSnapshot: <T extends DocumentSchema>(
     docRef: DocumentRef<T>,
   ) => Promise<DocumentState<T>>;
@@ -302,6 +306,12 @@ export class StateModuleImpl implements StateModule {
     ontologyRid?: string,
   ): Promise<number | undefined> {
     return this.documentService.getDocumentTypeOperationalVersion(documentTypeName, ontologyRid);
+  }
+
+  async resolveDocumentApplication(
+    docRef: DocumentRef,
+  ): Promise<string | undefined> {
+    return this.documentService.resolveDocumentApplication(docRef);
   }
 
   async getDocumentSnapshot<T extends DocumentSchema>(

--- a/packages/state/core/src/types/StateModule.ts
+++ b/packages/state/core/src/types/StateModule.ts
@@ -89,6 +89,7 @@ export interface StateModule {
       documentName?: string;
       pageSize?: number;
       pageToken?: string;
+      ontologyRid?: string;
     },
   ) => Promise<SearchDocumentsResult>;
 
@@ -270,6 +271,7 @@ export class StateModuleImpl implements StateModule {
       documentName?: string;
       pageSize?: number;
       pageToken?: string;
+      ontologyRid?: string;
     },
   ): Promise<SearchDocumentsResult> {
     return this.documentService.searchDocuments(documentTypeName, schema, options);

--- a/packages/state/demo/src/DemoDocumentService.ts
+++ b/packages/state/demo/src/DemoDocumentService.ts
@@ -275,6 +275,7 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
       documentName?: string;
       pageSize?: number;
       pageToken?: string;
+      ontologyRid?: string;
     },
   ): Promise<SearchDocumentsResult> => {
     await this.metadataStore.whenReady();

--- a/packages/state/demo/src/DemoDocumentService.ts
+++ b/packages/state/demo/src/DemoDocumentService.ts
@@ -348,6 +348,16 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
     );
   };
 
+  readonly resolveDocumentApplication = (
+    _docRef: DocumentRef,
+  ): Promise<string | undefined> => {
+    return Promise.reject(
+      new Error(
+        "resolveDocumentApplication is not supported by the demo document service",
+      ),
+    );
+  };
+
   protected onMetadataSubscriptionOpened(
     internalDoc: DemoInternalDoc,
     docRef: DocumentRef,

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -632,11 +632,7 @@ function createDocumentEditDescription(editDescription: EditDescription): Docume
       data: editDescription.data,
       eventType,
       schemaVersion: editDescription.schemaVersion ?? 1,
-      // TODO: remove `version` once the platform no longer reads it (SDK keeps it required).
-      version: editDescription.schemaVersion ?? 1,
     },
-    // TODO: remove duplicate after updating platform sdk
-    eventType,
   };
 }
 

--- a/packages/state/foundry-event/src/__tests__/editDescription.test.ts
+++ b/packages/state/foundry-event/src/__tests__/editDescription.test.ts
@@ -51,9 +51,8 @@ function createDocumentEditDescription(
     eventData: {
       data: editDescription.data,
       eventType,
-      version: editDescription.schemaVersion ?? 1,
+      schemaVersion: editDescription.schemaVersion ?? 1,
     },
-    eventType,
   };
 }
 
@@ -135,9 +134,8 @@ describe("EditDescription helpers", () => {
             name: "Alice",
           },
           eventType: "User",
-          version: 1,
+          schemaVersion: 1,
         },
-        eventType: "User",
       });
     });
 
@@ -150,7 +148,7 @@ describe("EditDescription helpers", () => {
 
       const result = createDocumentEditDescription(editDescription);
 
-      expect(result.eventData.version).toBe(3);
+      expect(result.eventData.schemaVersion).toBe(3);
     });
 
     it("should extract correct model name from metadata", () => {
@@ -169,7 +167,6 @@ describe("EditDescription helpers", () => {
 
       const result = createDocumentEditDescription(editDescription);
 
-      expect(result.eventType).toBe("AnotherModel");
       expect(result.eventData.data).toEqual({ id: "123" });
       expect(result.eventData.eventType).toBe("AnotherModel");
     });

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -297,6 +297,20 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     return response.operationalVersion;
   };
 
+  readonly resolveDocumentApplication = async (
+    docRef: DocumentRef,
+  ): Promise<string | undefined> => {
+    const response = await Documents.resolveApplication(
+      this.app.config.osdkClient,
+      docRef.id,
+      {
+        preview: this.config.usePreviewApi ?? DEFAULT_USE_PREVIEW_API,
+      },
+    );
+
+    return response.owningApplicationId;
+  };
+
   protected onMetadataSubscriptionOpened(
     internalDoc: FoundryInternalDoc,
     docRef: DocumentRef,
@@ -741,5 +755,6 @@ function getLocalDocumentType(wireDocumentType: WireDocumentType): DocumentType 
     name: wireDocumentType.name,
     operationalVersion: wireDocumentType.operationalVersion,
     fileSystemType: wireDocumentType.fileSystemType as FileSystemType | undefined,
+    owningApplicationId: wireDocumentType.owningApplicationId,
   };
 }

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -182,6 +182,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
       documentName?: string;
       pageSize?: number;
       pageToken?: string;
+      ontologyRid?: string;
     },
   ): Promise<SearchDocumentsResult> => {
     const request: SearchDocumentsRequest = {
@@ -190,6 +191,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         query: options?.documentName != null ? { documentName: options.documentName } : undefined,
         pageSize: options?.pageSize,
         pageToken: options?.pageToken,
+        ontologyRid: options?.ontologyRid,
       },
     };
 

--- a/packages/state/foundry/src/__tests__/FoundryDocumentTypeLoad.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryDocumentTypeLoad.test.ts
@@ -15,8 +15,9 @@
  */
 
 import type { DocumentType as WireDocumentType } from "@osdk/foundry.pack";
-import { DocumentTypes } from "@osdk/foundry.pack";
+import { Documents, DocumentTypes } from "@osdk/foundry.pack";
 import type { PackAppInternal } from "@palantir/pack.core";
+import type { DocumentRef } from "@palantir/pack.document-schema.model-types";
 import type { FoundryEventService } from "@palantir/pack.state.foundry-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
@@ -29,6 +30,9 @@ vi.mock("@osdk/foundry.pack", () => ({
     get: vi.fn(),
     loadByName: vi.fn(),
     getOperationalVersion: vi.fn(),
+  },
+  Documents: {
+    resolveApplication: vi.fn(),
   },
 }));
 
@@ -58,6 +62,7 @@ const WIRE_DOCUMENT_TYPE: WireDocumentType = {
   name: "com.palantir.pack.test.doctype",
   operationalVersion: 3,
   fileSystemType: "COMPASS",
+  owningApplicationId: "ri.workspace..application.test-app",
 };
 
 describe("FoundryDocumentService document type loading", () => {
@@ -73,6 +78,7 @@ describe("FoundryDocumentService document type loading", () => {
     vi.mocked(DocumentTypes.get).mockReset();
     vi.mocked(DocumentTypes.loadByName).mockReset();
     vi.mocked(DocumentTypes.getOperationalVersion).mockReset();
+    vi.mocked(Documents.resolveApplication).mockReset();
   });
 
   describe("loadDocumentTypeByName", () => {
@@ -97,6 +103,7 @@ describe("FoundryDocumentService document type loading", () => {
         name: "com.palantir.pack.test.doctype",
         operationalVersion: 3,
         fileSystemType: "COMPASS",
+        owningApplicationId: "ri.workspace..application.test-app",
       });
     });
 
@@ -132,6 +139,7 @@ describe("FoundryDocumentService document type loading", () => {
         name: "com.palantir.pack.test.doctype",
         operationalVersion: 3,
         fileSystemType: "COMPASS",
+        owningApplicationId: "ri.workspace..application.test-app",
       });
     });
 
@@ -148,6 +156,7 @@ describe("FoundryDocumentService document type loading", () => {
         name: "minimal",
         operationalVersion: undefined,
         fileSystemType: undefined,
+        owningApplicationId: undefined,
       });
     });
   });
@@ -180,6 +189,33 @@ describe("FoundryDocumentService document type loading", () => {
         "com.palantir.pack.test.doctype",
         "ri.ontology..explicit-rid",
       );
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("resolveDocumentApplication", () => {
+    const docRef = { id: "test-doc-1" } as DocumentRef;
+
+    it("calls resolveApplication with the document id and returns the owning application id", async () => {
+      vi.mocked(Documents.resolveApplication).mockResolvedValue({
+        owningApplicationId: "ri.workspace..application.test-app",
+      });
+
+      const result = await service.resolveDocumentApplication(docRef);
+
+      expect(Documents.resolveApplication).toHaveBeenCalledWith(
+        mockOsdkClient,
+        "test-doc-1",
+        { preview: true },
+      );
+      expect(result).toBe("ri.workspace..application.test-app");
+    });
+
+    it("returns undefined when no owning application is configured", async () => {
+      vi.mocked(Documents.resolveApplication).mockResolvedValue({});
+
+      const result = await service.resolveDocumentApplication(docRef);
 
       expect(result).toBeUndefined();
     });

--- a/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundrySecurityConversion.test.ts
@@ -188,6 +188,31 @@ describe("Foundry Security Conversion", () => {
 
       expect(result.data[0]?.operationalVersion).toBe(2);
     });
+
+    it("forwards ontologyRid on the request when provided", async () => {
+      vi.mocked(Documents.search).mockResolvedValue({ data: [] });
+
+      await service.searchDocuments("SecureType", testSchema, {
+        ontologyRid: "ri.ontology..scoped-rid",
+      });
+
+      expect(Documents.search).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          requestBody: expect.objectContaining({ ontologyRid: "ri.ontology..scoped-rid" }),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("leaves ontologyRid undefined when not provided", async () => {
+      vi.mocked(Documents.search).mockResolvedValue({ data: [] });
+
+      await service.searchDocuments("SecureType", testSchema);
+
+      const request = vi.mocked(Documents.search).mock.calls[0]?.[1];
+      expect(request?.requestBody.ontologyRid).toBeUndefined();
+    });
   });
 
   describe("onMetadataSubscriptionOpened", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^2.56.0
       version: 2.56.0
     '@osdk/foundry.pack':
-      specifier: ^2.66.0
-      version: 2.66.0
+      specifier: ^2.68.0
+      version: 2.68.0
     '@osdk/oauth':
       specifier: ^1.4.0
       version: 1.4.0
@@ -579,7 +579,7 @@ importers:
         version: 2.5.2
       '@osdk/foundry.pack':
         specifier: 'catalog:'
-        version: 2.66.0
+        version: 2.68.0
       '@palantir/pack.document-schema.model-types':
         specifier: workspace:~
         version: link:../model-types
@@ -1094,7 +1094,7 @@ importers:
         version: 2.5.2
       '@osdk/foundry.pack':
         specifier: 'catalog:'
-        version: 2.66.0
+        version: 2.68.0
       '@palantir/pack.auth':
         specifier: workspace:*
         version: link:../../auth/core
@@ -1146,7 +1146,7 @@ importers:
         version: 2.5.2
       '@osdk/foundry.pack':
         specifier: 'catalog:'
-        version: 2.66.0
+        version: 2.68.0
       '@palantir/pack.auth':
         specifier: workspace:*
         version: link:../../auth/core
@@ -3905,11 +3905,11 @@ packages:
   '@osdk/foundry.core@2.56.0':
     resolution: {integrity: sha512-lm7c5IxHfmaAhSv3FB7od+YpvA1mTGP12FBEdQYQ7FqnJTLEB+GLaHLzvX+1WsSFJA/LxnasRV3ztWfjy1Qe+w==}
 
-  '@osdk/foundry.core@2.66.0':
-    resolution: {integrity: sha512-I4smqvsirv1coaWWWQIM+7lAivZuTCLczNH+8NQVLzndI4V7yjWl7dzBLEaIVgOBisG1mibifk/9o8cjCK3cVQ==}
+  '@osdk/foundry.core@2.68.0':
+    resolution: {integrity: sha512-65Qs0obdgAPDzXKL6jCWpfa0OueraA+dEYuduuPVXb+WpS6KwBas5R8gGYv1wPa/GgHuU7wIJ+P8PcL//tcQOg==}
 
-  '@osdk/foundry.filesystem@2.66.0':
-    resolution: {integrity: sha512-PALmyLrfwV1ZGdSzTz2KntsQGh8O62dJvIfJotIJ7rySYTJysAMXDYJvbRimBSWWBO7laFfzHWe33gHnevGuDA==}
+  '@osdk/foundry.filesystem@2.68.0':
+    resolution: {integrity: sha512-hmgRu1H7MaI0kdcNvawk/3U6p/oKvHeD2W25m7i8rjS8qY22KaZez+F+x7kzLhD7e9L0hN4j5RO4JgCSDSJKPg==}
 
   '@osdk/foundry.geo@2.30.0':
     resolution: {integrity: sha512-VsYE9vtDwUVxfHlQLKxfDq6YrknPoPt6Gf3Ui0ojY7STqT/FTJlyH8aG+D3zosUVKeTZNXZ3ybc51GhB8kuYSQ==}
@@ -3917,14 +3917,14 @@ packages:
   '@osdk/foundry.geo@2.56.0':
     resolution: {integrity: sha512-ZB7RzItE3JJSsP7MPBihz8Zq7a361MtdUfxA+zHQbdaqCwZqukZ1ghJm/0mc/rQmHkV7bt3/SVknGOcHhVj3/g==}
 
-  '@osdk/foundry.geo@2.66.0':
-    resolution: {integrity: sha512-QQbJ2n1hTs0WwiVHqX9hj03aoJ46mKm872AiVTDeVGLX+A786inAZtHAF4huwsAjvvcaBcZS3e2SMSrMy2wPnQ==}
+  '@osdk/foundry.geo@2.68.0':
+    resolution: {integrity: sha512-RwsDB8vnvawAAlsULCux++OdqEgIfxOvYROKlQIYjZxGg5L1yarkiGUZ48cukj/FBTd5fB6Rlht7W8qWrHjCiQ==}
 
   '@osdk/foundry.ontologies@2.30.0':
     resolution: {integrity: sha512-hmUhGJ846r8FDqkDZbt9P4tSzTcYzTatwrCVr4wN43WNRMIARvPLGnKCs9lk/nL1DOoUG6AM1v2RfvfLryQngA==}
 
-  '@osdk/foundry.pack@2.66.0':
-    resolution: {integrity: sha512-MdbKf/rOE1DEhmsbazZ/MORX+WHLTnUJgS8n2u0KZ0mA8/O+8mHLGyWQq7QYabIR3Bhkd1SgckIV4iRZrhVrKA==}
+  '@osdk/foundry.pack@2.68.0':
+    resolution: {integrity: sha512-cFH5i3oxmkOYQV5b7R87CPx4Ork4idXWINfM4ZatlPQfb/Wjws06Ke61g0Nzpregr5jpUGgOA+lC7r52xoJgPQ==}
 
   '@osdk/generator-converters@2.5.2':
     resolution: {integrity: sha512-k7sJM00w70A4g6OB0LKq1Gfmka8kiiPNAPeX/CK9sT5DfwGwfJ7wIZrXJVSkSwNlEqVr6zSKSbwwgmU/FyMqQQ==}
@@ -14754,16 +14754,16 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.core@2.66.0':
+  '@osdk/foundry.core@2.68.0':
     dependencies:
-      '@osdk/foundry.geo': 2.66.0
+      '@osdk/foundry.geo': 2.68.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.filesystem@2.66.0':
+  '@osdk/foundry.filesystem@2.68.0':
     dependencies:
-      '@osdk/foundry.core': 2.66.0
+      '@osdk/foundry.core': 2.68.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -14780,7 +14780,7 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.geo@2.66.0':
+  '@osdk/foundry.geo@2.68.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
@@ -14794,10 +14794,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.4.0
 
-  '@osdk/foundry.pack@2.66.0':
+  '@osdk/foundry.pack@2.68.0':
     dependencies:
-      '@osdk/foundry.core': 2.66.0
-      '@osdk/foundry.filesystem': 2.66.0
+      '@osdk/foundry.core': 2.68.0
+      '@osdk/foundry.filesystem': 2.68.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   "@osdk/api": ^2.5.2
   "@osdk/client": ^2.5.2
   "@osdk/foundry.admin": ^2.56.0
-  "@osdk/foundry.pack": ^2.66.0
+  "@osdk/foundry.pack": ^2.68.0
   "@osdk/oauth": ^1.4.0
   "@osdk/react": ^0.6.0
   "@osdk/shared.client2": ^1.0.0


### PR DESCRIPTION
Bumps sdk, includes application id endpoint now for getting the owning application Id from a document, used for first party applications needing to redirect to an owning app based on a document Id. Also removes redundant fields for update descriptions. Search requests now enable per ontology searches.