### PR TITLE
Write owningApplicationId to asset file

### DIFF
--- a/.changeset/asset-owning-application-id.md
+++ b/.changeset/asset-owning-application-id.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.document-schema.type-gen": minor
+---
+
+Include `owningApplicationId` in the generated document type asset. When set in `pack-config.json`, the value flows through `schema ir` into the IR chain payload and `ir asset` writes it onto the `DocumentTypeAsset`.

--- a/packages/document-schema/type-gen/src/commands/ir/__tests__/resolveIrInput.test.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/__tests__/resolveIrInput.test.ts
@@ -56,6 +56,16 @@ describe("resolveIrInput", () => {
     });
   });
 
+  it("carries owningApplicationId through from a chain payload", () => {
+    const resolved = resolveIrInput({
+      latestVersion: 1,
+      owningApplicationId: "app-123",
+      chain: [{ version: 1, ir: ir(1) }],
+    }, "chain.json");
+
+    expect(resolved.owningApplicationId).toBe("app-123");
+  });
+
   it("defaults chain minSupportedVersion to latestVersion", () => {
     const resolved = resolveIrInput({
       latestVersion: 3,

--- a/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irGenAssetHandler.ts
@@ -74,7 +74,7 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
 
     const resolved = resolveIrInput(parsed, irPath);
 
-    const { ir: irSchema, latestVersion, minSupportedVersion } = resolved;
+    const { ir: irSchema, latestVersion, minSupportedVersion, owningApplicationId } = resolved;
     const { name: documentTypeName } = irSchema;
     const wireSchema = convertIrToWireSchema(irSchema);
 
@@ -96,6 +96,7 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
       },
       fileSystemType,
       schemaVersion: latestVersion,
+      ...(owningApplicationId != null ? { owningApplicationId } : {}),
     };
 
     const outputDir = dirname(outputPath);
@@ -132,6 +133,9 @@ export function irGenAssetHandler(options: IrGenAssetOptions): void {
     consola.info(`   Schema version: ${latestVersion}`);
     consola.info(`   Compatibility range: [${minSupportedVersion}, ${latestVersion}]`);
     consola.info(`   File system type: ${fileSystemType}`);
+    if (owningApplicationId != null) {
+      consola.info(`   Owning application id: ${owningApplicationId}`);
+    }
   } catch (error) {
     if (error instanceof CommanderError) {
       throw error;

--- a/packages/document-schema/type-gen/src/commands/ir/resolveIrInput.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/resolveIrInput.ts
@@ -22,6 +22,7 @@ export interface ResolvedIrInput {
   readonly ir: IRealTimeDocumentSchema;
   readonly latestVersion: number;
   readonly minSupportedVersion: number;
+  readonly owningApplicationId?: string;
 }
 
 function isChainPayload(parsed: unknown): parsed is IrChainPayload {
@@ -54,7 +55,12 @@ function resolveFromChain(payload: IrChainPayload, irPath: string): ResolvedIrIn
       `IR chain payload at ${irPath} has no entry matching latestVersion ${latestVersion}`,
     );
   }
-  return { ir: latestEntry.ir, latestVersion, minSupportedVersion: minVersion };
+  return {
+    ir: latestEntry.ir,
+    latestVersion,
+    minSupportedVersion: minVersion,
+    owningApplicationId: payload.owningApplicationId,
+  };
 }
 
 function resolveFromSingleIr(ir: IRealTimeDocumentSchema): ResolvedIrInput {

--- a/packages/document-schema/type-gen/src/commands/schema/__tests__/readPackConfig.test.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/__tests__/readPackConfig.test.ts
@@ -47,6 +47,7 @@ describe("readPackConfig", () => {
       documentTypeName: "Canvas Document Type",
       documentTypeDescription: "Document type description for demo canvas",
       minSupportedVersion: 1,
+      owningApplicationId: undefined,
     });
   });
 
@@ -59,7 +60,33 @@ describe("readPackConfig", () => {
       documentTypeName: "Canvas Document Type",
       documentTypeDescription: "Document type description for demo canvas",
       minSupportedVersion: undefined,
+      owningApplicationId: undefined,
     });
+  });
+
+  it("reads owningApplicationId when present", async () => {
+    const configPath = await writeConfig({
+      documentTypeName: "Canvas Document Type",
+      documentTypeDescription: "Document type description for demo canvas",
+      owningApplicationId: "app-123",
+    });
+    await expect(readPackConfig(configPath)).resolves.toEqual({
+      documentTypeName: "Canvas Document Type",
+      documentTypeDescription: "Document type description for demo canvas",
+      minSupportedVersion: undefined,
+      owningApplicationId: "app-123",
+    });
+  });
+
+  it("throws when owningApplicationId is an empty string", async () => {
+    const configPath = await writeConfig({
+      documentTypeName: "Canvas Document Type",
+      documentTypeDescription: "Document type description for demo canvas",
+      owningApplicationId: "   ",
+    });
+    await expect(readPackConfig(configPath)).rejects.toThrow(
+      "'owningApplicationId' in",
+    );
   });
 
   it("throws when the config file does not exist", async () => {

--- a/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/schema/schemaIrHandler.ts
@@ -32,12 +32,14 @@ interface PackConfigLike {
   documentTypeName?: unknown;
   documentTypeDescription?: unknown;
   minSupportedVersion?: unknown;
+  owningApplicationId?: unknown;
 }
 
 interface PackConfigValues {
   readonly documentTypeName: string;
   readonly documentTypeDescription: string;
   readonly minSupportedVersion?: number;
+  readonly owningApplicationId?: string;
 }
 
 function assertNonEmptyString(value: unknown, field: string, configPath: string): string {
@@ -94,7 +96,16 @@ export async function readPackConfig(configPath: string): Promise<PackConfigValu
     minSupportedVersion = rawMin;
   }
 
-  return { documentTypeName, documentTypeDescription, minSupportedVersion };
+  let owningApplicationId: string | undefined;
+  if (config.owningApplicationId != null) {
+    owningApplicationId = assertNonEmptyString(
+      config.owningApplicationId,
+      "owningApplicationId",
+      resolvedConfigPath,
+    );
+  }
+
+  return { documentTypeName, documentTypeDescription, minSupportedVersion, owningApplicationId };
 }
 
 function parseMaxVersion(maxVersion: string | undefined): number | undefined {
@@ -132,6 +143,9 @@ function parseMaxVersion(maxVersion: string | undefined): number | undefined {
  *    (`ir gen-types`, `ir asset`) read the same value. Omitting the field is
  *    an explicit opt-out: the IR will not include `minSupportedVersion` and
  *    downstream tools default to supporting only the latest schema version.
+ *  - `owningApplicationId`: the application that owns this document type; when
+ *    set, it is embedded in the payload and surfaced as `owningApplicationId`
+ *    by `ir asset`.
  *
  * Note: this is distinct from the legacy single-version IR JSON consumed by
  * `ir zod`, which is a bare `IRealTimeDocumentSchema` (no chain, no migrations).
@@ -141,9 +155,8 @@ function parseMaxVersion(maxVersion: string | undefined): number | undefined {
 export async function schemaIrHandler(options: SchemaIrOptions): Promise<void> {
   const { input, output, config } = options;
   const maxVersion = parseMaxVersion(options.maxVersion);
-  const { documentTypeName, documentTypeDescription, minSupportedVersion } = await readPackConfig(
-    config,
-  );
+  const { documentTypeName, documentTypeDescription, minSupportedVersion, owningApplicationId } =
+    await readPackConfig(config);
 
   if (minSupportedVersion == null) {
     consola.warn(
@@ -174,6 +187,7 @@ export async function schemaIrHandler(options: SchemaIrOptions): Promise<void> {
     comment: GENERATED_JSON_COMMENT,
     latestVersion,
     ...(minSupportedVersion != null ? { minSupportedVersion } : {}),
+    ...(owningApplicationId != null ? { owningApplicationId } : {}),
     chain,
   };
   await fs.writeFile(outputPath, JSON.stringify(payload, null, 2) + "\n", "utf8");

--- a/packages/document-schema/type-gen/src/utils/schema/resolveSchemaChain.ts
+++ b/packages/document-schema/type-gen/src/utils/schema/resolveSchemaChain.ts
@@ -50,6 +50,7 @@ export interface IrChainPayload {
   comment?: string;
   latestVersion: number;
   minSupportedVersion?: number;
+  owningApplicationId?: string;
   chain: VersionedIrEntry[];
 }
 


### PR DESCRIPTION
For first party apps, pack-config can take an optional owningApplicationId that will be passed-through in the generated asset file, to set the owning application ID for that document type. This is currently primarily used for redirects to open a given document in its respective application.