### PR TITLE
Deploy owningApplicationId

### DIFF
--- a/.changeset/deploy-owning-application-id.md
+++ b/.changeset/deploy-owning-application-id.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.document-schema.type-gen": minor
+---
+
+Include `owningApplicationId` when deploying a first-party document type via `ir deploy --first-party`. When set in `pack-config.json`, the value now flows through the IR chain payload into the `createFirstParty` request body, matching the existing `ir asset` behavior.

--- a/packages/document-schema/type-gen/src/commands/ir/irDeployHandler.ts
+++ b/packages/document-schema/type-gen/src/commands/ir/irDeployHandler.ts
@@ -48,7 +48,7 @@ export async function irDeployHandler(options: DeployOptions): Promise<void> {
     const irPath = resolve(options.ir);
     consola.info(`Reading schema from: ${irPath}`);
 
-    const { ir, latestVersion } = resolveIrInput(
+    const { ir, latestVersion, owningApplicationId } = resolveIrInput(
       JSON.parse(readFileSync(irPath, "utf8")) as unknown,
       irPath,
     );
@@ -56,7 +56,14 @@ export async function irDeployHandler(options: DeployOptions): Promise<void> {
     const fileSystemType = options.fileSystemType ?? "ARTIFACTS";
 
     if (options.firstParty) {
-      await deployFirstParty(options, ir.name, schema, latestVersion, fileSystemType);
+      await deployFirstParty(
+        options,
+        ir.name,
+        schema,
+        latestVersion,
+        fileSystemType,
+        owningApplicationId,
+      );
     } else {
       await deployThirdParty(options, ir.name, schema, fileSystemType);
     }
@@ -105,6 +112,7 @@ async function deployFirstParty(
   schema: DocumentTypeSchema,
   version: number,
   fileSystemType: FileSystemType,
+  owningApplicationId: string | undefined,
 ): Promise<void> {
   if (options.ontologyRid == null) {
     throw new CommanderError(
@@ -135,6 +143,7 @@ async function deployFirstParty(
       schema,
       version,
       fileSystemType,
+      ...(owningApplicationId != null ? { owningApplicationId } : {}),
     },
   };
 


### PR DESCRIPTION
Passthrough owningApplicationId for first-party deploys when present.