### PR TITLE
Refactor and fix subscription lifecycles (activity, presence, metadata and data)

### DIFF
--- a/.changeset/fix-document-subscriptions.md
+++ b/.changeset/fix-document-subscriptions.md
@@ -1,0 +1,9 @@
+---
+"@palantir/pack.state.core": patch
+"@palantir/pack.state.demo": patch
+"@palantir/pack.state.foundry-event": patch
+"@palantir/pack.state.foundry": patch
+"@palantir/pack.state.react": patch
+---
+
+Fix document subscription ownership so activity, presence, metadata, and data channels are shared and cleaned up according to their own subscribers. Preserve client identity across data restarts, safely discard canceled asynchronous opens, and apply presence self-update filtering per subscriber.

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -205,17 +205,9 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
       ?? schemaMeta.version;
   };
 
-  /**
-   * Ensures document metadata (the source of `operationalVersion`, and thus
-   * `docRef.version`) is loaded whenever document data is loaded. Without this,
-   * a component that only subscribes to data (e.g. via useRecords) would leave
-   * docRef.version stuck on the bundled schema fallback. Idempotent: gated on
-   * load status, so it's a no-op if a metadata subscriber already triggered it.
-   */
+  /** Ensures metadata loading and any backing subscription needed by data. */
   protected ensureMetadataLoaded(internalDoc: TDoc, docRef: DocumentRef): void {
-    if (internalDoc.metadataStatus.load === DocumentLoadStatus.UNLOADED) {
-      this.onMetadataSubscriptionOpened(internalDoc, docRef);
-    }
+    this.onMetadataSubscriptionOpened(internalDoc, docRef);
   }
 
   readonly createDocRef = <const T extends DocumentSchema>(
@@ -675,8 +667,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     internalDoc.metadataSubscribers.add(callback as DocumentMetadataChangeCallback);
     internalDoc.hasMetadataSubscriptions = true;
 
-    // Trigger remote load if this is the first subscription and not yet loaded
-    if (isFirstSubscription && internalDoc.metadataStatus.load === DocumentLoadStatus.UNLOADED) {
+    if (isFirstSubscription) {
       this.onMetadataSubscriptionOpened(internalDoc, internalDocRef);
     }
 
@@ -1403,13 +1394,26 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
 
     // Wait for status to change to LOADED or ERROR
     return new Promise((resolve, reject) => {
+      let hasStartedLoading = internalDoc.metadataStatus.load === DocumentLoadStatus.LOADING;
       const unsubscribe = this.onStatusChange(docRef, (_, status) => {
-        if (status.metadata.load === DocumentLoadStatus.LOADED) {
-          unsubscribe();
-          resolve();
-        } else if (status.metadata.load === DocumentLoadStatus.ERROR) {
-          unsubscribe();
-          reject(new Error("Metadata load error", { cause: status.metadata.error }));
+        switch (status.metadata.load) {
+          case DocumentLoadStatus.LOADING:
+            hasStartedLoading = true;
+            break;
+          case DocumentLoadStatus.LOADED:
+            unsubscribe();
+            resolve();
+            break;
+          case DocumentLoadStatus.ERROR:
+            unsubscribe();
+            reject(new Error("Metadata load error", { cause: status.metadata.error }));
+            break;
+          case DocumentLoadStatus.UNLOADED:
+            if (hasStartedLoading) {
+              unsubscribe();
+              reject(new Error("Metadata load canceled"));
+            }
+            break;
         }
       });
     });

--- a/packages/state/core/src/service/InMemoryDocumentService.ts
+++ b/packages/state/core/src/service/InMemoryDocumentService.ts
@@ -216,6 +216,9 @@ class InMemoryDocumentService extends BaseYjsDocumentService {
     internalDoc: InternalYjsDoc,
     docRef: DocumentRef,
   ): void {
+    if (internalDoc.metadataStatus.load !== DocumentLoadStatus.UNLOADED) {
+      return;
+    }
     this.updateMetadataStatus(internalDoc, docRef, {
       load: DocumentLoadStatus.LOADING,
     });

--- a/packages/state/demo/src/DemoDocumentService.ts
+++ b/packages/state/demo/src/DemoDocumentService.ts
@@ -363,6 +363,9 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
     internalDoc: DemoInternalDoc,
     docRef: DocumentRef,
   ): void {
+    if (internalDoc.metadataStatus.load !== DocumentLoadStatus.UNLOADED) {
+      return;
+    }
     this.updateMetadataStatus(internalDoc, docRef, {
       load: DocumentLoadStatus.LOADING,
     });

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -106,7 +106,6 @@ export interface SyncSession {
 }
 
 interface SyncSessionInternal extends SyncSession {
-  activitySubscriptionId?: SubscriptionId;
   documentSubscriptionId?: SubscriptionId;
   lastRevisionId?: number;
   localYDocUpdateHandler?: (
@@ -115,8 +114,6 @@ interface SyncSessionInternal extends SyncSession {
     doc: y.Doc,
     transaction: y.Transaction,
   ) => void;
-  metadataSubscriptionId?: SubscriptionId;
-  presenceSubscriptionId?: SubscriptionId;
   yDoc?: y.Doc;
 }
 
@@ -125,6 +122,8 @@ interface SyncSessionInternal extends SyncSession {
  * our PACK Foundry backend's cometd service.
  */
 export interface FoundryEventService {
+  disposeDocument(documentId: DocumentId): void;
+
   publishCustomPresence(
     documentId: DocumentId,
     eventType: string,
@@ -161,6 +160,8 @@ export interface FoundryEventService {
     callback: (update: PresenceCollaborativeUpdate) => void,
     options?: PresenceSubscriptionOptions,
   ): Promise<SubscriptionId>;
+
+  unsubscribe(subscriptionId: SubscriptionId): void;
 }
 
 class FoundryEventServiceImpl implements FoundryEventService {
@@ -179,20 +180,18 @@ class FoundryEventServiceImpl implements FoundryEventService {
     });
   }
 
-  private getOrCreateSession(documentId: DocumentId, yDoc?: y.Doc): SyncSessionInternal {
+  private getOrCreateSession(documentId: DocumentId): SyncSessionInternal {
     const sessionId = this.getSessionId(documentId);
     let session = this.sessions.get(sessionId);
 
     if (!session) {
       session = {
-        activitySubscriptionId: undefined,
         clientId: crypto.randomUUID(),
         documentId,
         documentSubscriptionId: undefined,
         lastRevisionId: undefined,
         localYDocUpdateHandler: undefined,
-        presenceSubscriptionId: undefined,
-        yDoc,
+        yDoc: undefined,
       };
       this.sessions.set(sessionId, session);
     }
@@ -207,11 +206,15 @@ class FoundryEventServiceImpl implements FoundryEventService {
     onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
     getDocumentSchemaOperationalVersion?: () => number,
   ): SyncSession {
-    const session = this.getOrCreateSession(documentId, yDoc);
+    const session = this.getOrCreateSession(documentId);
 
-    if (session.documentSubscriptionId != null) {
+    if (
+      session.localYDocUpdateHandler != null
+      || session.documentSubscriptionId != null
+    ) {
       throw new Error(`Document data sync already active for document ${documentId}`);
     }
+    session.yDoc = yDoc;
 
     const localYDocUpdateHandler = (
       update: Uint8Array,
@@ -287,7 +290,6 @@ class FoundryEventServiceImpl implements FoundryEventService {
         session.documentSubscriptionId = subscriptionId;
       } else {
         this.eventService.unsubscribe(subscriptionId);
-        this.sessions.delete(this.getSessionId(documentId));
       }
     }).catch((e: unknown) => {
       if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
@@ -333,10 +335,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         clientId: session.clientId,
         clientSupportedVersionRange,
       } satisfies DocumentActivitySubscriptionRequest),
-    ).then(subscriptionId => {
-      session.activitySubscriptionId = subscriptionId;
-      return subscriptionId;
-    }).catch((e: unknown) => {
+    ).catch((e: unknown) => {
       this.logger.error("Failed to subscribe to activity updates", e, {
         docId: documentId,
       });
@@ -348,8 +347,6 @@ class FoundryEventServiceImpl implements FoundryEventService {
     documentId: DocumentId,
     callback: (event: DocumentMetadataUpdate) => void,
   ): Promise<SubscriptionId> {
-    const session = this.getOrCreateSession(documentId);
-
     const channelId = getDocumentMetadataUpdatesChannelId(documentId);
 
     return this.eventService.subscribe(
@@ -361,10 +358,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         });
         callback(event);
       },
-    ).then(subscriptionId => {
-      session.metadataSubscriptionId = subscriptionId;
-      return subscriptionId;
-    }).catch((e: unknown) => {
+    ).catch((e: unknown) => {
       this.logger.error("Failed to subscribe to metadata updates", e, {
         docId: documentId,
       });
@@ -425,10 +419,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         clientId: session.clientId,
         clientSupportedVersionRange,
       } satisfies DocumentPresenceSubscriptionRequest),
-    ).then(subscriptionId => {
-      session.presenceSubscriptionId = subscriptionId;
-      return subscriptionId;
-    }).catch((e: unknown) => {
+    ).catch((e: unknown) => {
       this.logger.error("Failed to subscribe to presence updates", e, {
         docId: documentId,
       });
@@ -494,22 +485,26 @@ class FoundryEventServiceImpl implements FoundryEventService {
       internalSession.localYDocUpdateHandler = undefined;
     }
 
-    if (internalSession.activitySubscriptionId) {
-      this.eventService.unsubscribe(internalSession.activitySubscriptionId);
-    }
-
-    if (internalSession.metadataSubscriptionId) {
-      this.eventService.unsubscribe(internalSession.metadataSubscriptionId);
-    }
-
-    if (internalSession.presenceSubscriptionId) {
-      this.eventService.unsubscribe(internalSession.presenceSubscriptionId);
-    }
-
     if (internalSession.documentSubscriptionId) {
       this.eventService.unsubscribe(internalSession.documentSubscriptionId);
-      this.sessions.delete(sessionId);
+      internalSession.documentSubscriptionId = undefined;
     }
+    internalSession.lastRevisionId = undefined;
+    internalSession.yDoc = undefined;
+  }
+
+  unsubscribe(subscriptionId: SubscriptionId): void {
+    this.eventService.unsubscribe(subscriptionId);
+  }
+
+  disposeDocument(documentId: DocumentId): void {
+    const sessionId = this.getSessionId(documentId);
+    const session = this.sessions.get(sessionId);
+    if (session == null) {
+      return;
+    }
+    this.stopDocumentSync(session);
+    this.sessions.delete(sessionId);
   }
 
   private handleDocumentUpdateMessage(

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -191,4 +191,204 @@ describe("FoundryEventService", () => {
       | undefined;
     expect(publishCall?.[1].documentUpdateSchemaVersion).toBe(1);
   });
+
+  it("keeps activity subscriptions independent from document data sync", async () => {
+    mocks.eventService.subscribe
+      .mockResolvedValueOnce("activity-sub" as SubscriptionId)
+      .mockResolvedValueOnce("document-sub" as SubscriptionId);
+
+    const service = createFoundryEventService(app);
+    const activitySubscriptionId = await service.subscribeToActivityUpdates(
+      "doc-1" as DocumentId,
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+    const session = service.startDocumentSync(
+      "doc-1" as DocumentId,
+      new Y.Doc(),
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+    await Promise.resolve();
+
+    service.stopDocumentSync(session);
+
+    expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("document-sub");
+    expect(mocks.eventService.unsubscribe).not.toHaveBeenCalledWith("activity-sub");
+
+    service.unsubscribe(activitySubscriptionId);
+    expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("activity-sub");
+  });
+
+  it("keeps presence subscriptions independent from document data sync", async () => {
+    mocks.eventService.subscribe
+      .mockResolvedValueOnce("presence-sub" as SubscriptionId)
+      .mockResolvedValueOnce("document-sub" as SubscriptionId);
+
+    const service = createFoundryEventService(app);
+    const presenceSubscriptionId = await service.subscribeToPresenceUpdates(
+      "doc-1" as DocumentId,
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+    const session = service.startDocumentSync(
+      "doc-1" as DocumentId,
+      new Y.Doc(),
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+    await Promise.resolve();
+
+    service.stopDocumentSync(session);
+
+    expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("document-sub");
+    expect(mocks.eventService.unsubscribe).not.toHaveBeenCalledWith("presence-sub");
+
+    service.unsubscribe(presenceSubscriptionId);
+    expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("presence-sub");
+  });
+
+  it("keeps metadata subscriptions independent from document data sync", async () => {
+    mocks.eventService.subscribe
+      .mockResolvedValueOnce("metadata-sub" as SubscriptionId)
+      .mockResolvedValueOnce("document-sub" as SubscriptionId);
+
+    const service = createFoundryEventService(app);
+    const metadataSubscriptionId = await service.subscribeToMetadataUpdates(
+      "doc-1" as DocumentId,
+      () => {},
+    );
+    const session = service.startDocumentSync(
+      "doc-1" as DocumentId,
+      new Y.Doc(),
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+    await Promise.resolve();
+
+    service.stopDocumentSync(session);
+
+    expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("document-sub");
+    expect(mocks.eventService.unsubscribe).not.toHaveBeenCalledWith("metadata-sub");
+
+    service.unsubscribe(metadataSubscriptionId);
+    expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("metadata-sub");
+  });
+
+  it("keeps the document client id stable when data sync restarts", async () => {
+    mocks.eventService.subscribe
+      .mockResolvedValueOnce("document-sub-1" as SubscriptionId)
+      .mockResolvedValueOnce("document-sub-2" as SubscriptionId);
+
+    const service = createFoundryEventService(app);
+    const firstSession = service.startDocumentSync(
+      "doc-1" as DocumentId,
+      new Y.Doc(),
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+    await Promise.resolve();
+    service.stopDocumentSync(firstSession);
+
+    const secondSession = service.startDocumentSync(
+      "doc-1" as DocumentId,
+      new Y.Doc(),
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+
+    expect(secondSession.clientId).toBe(firstSession.clientId);
+  });
+
+  it("does not replace the active Y.Doc when a duplicate data sync is rejected", async () => {
+    mocks.eventService.subscribe.mockResolvedValueOnce("document-sub" as SubscriptionId);
+    const service = createFoundryEventService(app);
+    const activeYDoc = new Y.Doc();
+    const rejectedYDoc = new Y.Doc();
+    const activeOff = vi.spyOn(activeYDoc, "off");
+    const rejectedOff = vi.spyOn(rejectedYDoc, "off");
+
+    const session = service.startDocumentSync(
+      "doc-1" as DocumentId,
+      activeYDoc,
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+    await Promise.resolve();
+
+    expect(() =>
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        rejectedYDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      )
+    ).toThrow("Document data sync already active");
+
+    service.stopDocumentSync(session);
+
+    expect(activeOff).toHaveBeenCalledWith("update", expect.any(Function));
+    expect(rejectedOff).not.toHaveBeenCalled();
+    expect(mocks.eventService.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects duplicate data sync while the first subscription is still opening", async () => {
+    let resolveSubscription: (subscriptionId: SubscriptionId) => void = () => {};
+    mocks.eventService.subscribe.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveSubscription = resolve;
+      }),
+    );
+    const service = createFoundryEventService(app);
+    const session = service.startDocumentSync(
+      "doc-1" as DocumentId,
+      new Y.Doc(),
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+
+    expect(() =>
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      )
+    ).toThrow("Document data sync already active");
+    expect(mocks.eventService.subscribe).toHaveBeenCalledTimes(1);
+
+    service.stopDocumentSync(session);
+    resolveSubscription("stale-document-sub" as SubscriptionId);
+    await Promise.resolve();
+
+    expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("stale-document-sub");
+  });
+
+  it("disposes a document session and its active data subscription", async () => {
+    mocks.eventService.subscribe
+      .mockResolvedValueOnce("document-sub-1" as SubscriptionId)
+      .mockResolvedValueOnce("document-sub-2" as SubscriptionId);
+
+    const service = createFoundryEventService(app);
+    const firstSession = service.startDocumentSync(
+      "doc-1" as DocumentId,
+      new Y.Doc(),
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+    await Promise.resolve();
+
+    service.disposeDocument("doc-1" as DocumentId);
+
+    expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("document-sub-1");
+
+    const secondSession = service.startDocumentSync(
+      "doc-1" as DocumentId,
+      new Y.Doc(),
+      { maxVersion: 1, minVersion: 1 },
+      () => {},
+    );
+
+    expect(secondSession.clientId).not.toBe(firstSession.clientId);
+  });
 });

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -25,6 +25,7 @@ import type {
   SearchDocumentsRequest,
 } from "@osdk/foundry.pack";
 import { Documents, DocumentTypes } from "@osdk/foundry.pack";
+import { getAuthModule } from "@palantir/pack.auth";
 import {
   assertNever,
   getOntologyRid,
@@ -61,7 +62,11 @@ import {
   DocumentLiveStatus,
   DocumentLoadStatus,
 } from "@palantir/pack.state.core";
-import type { FoundryEventService, SyncSession } from "@palantir/pack.state.foundry-event";
+import type {
+  FoundryEventService,
+  SubscriptionId,
+  SyncSession,
+} from "@palantir/pack.state.foundry-event";
 import { createFoundryEventService } from "@palantir/pack.state.foundry-event";
 import { getActivityEvent, getPresenceEvent, toChannelError } from "./eventMappers.js";
 
@@ -73,6 +78,15 @@ const EMPTY_DOCUMENT_SECURITY: DocumentSecurity = Object.freeze({
 
 interface FoundryDocumentServiceConfig {
   readonly usePreviewApi?: boolean;
+}
+
+interface ActivitySubscriber {
+  readonly callback: (event: ActivityEvent) => void;
+}
+
+interface PresenceSubscriber {
+  readonly callback: (event: PresenceEvent) => void;
+  readonly ignoreSelfUpdates: boolean;
 }
 
 export function createFoundryDocumentServiceConfig(
@@ -98,7 +112,13 @@ export function internalCreateFoundryDocumentService(
 }
 
 interface FoundryInternalDoc extends InternalYjsDoc {
-  metadataUpdateUnsubscribed?: boolean;
+  activitySubscribers?: Set<ActivitySubscriber>;
+  activitySubscriptionId?: SubscriptionId;
+  dataSubscriptionOpenToken?: object;
+  metadataSubscriptionId?: SubscriptionId;
+  metadataSubscriptionOpenToken?: object;
+  presenceSubscribers?: Set<PresenceSubscriber>;
+  presenceSubscriptionId?: SubscriptionId;
   syncSession?: SyncSession;
 }
 
@@ -248,6 +268,24 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         preview: this.config.usePreviewApi ?? DEFAULT_USE_PREVIEW_API,
       },
     );
+    const internalDoc = this.documents.get(docRef.id);
+    if (internalDoc != null) {
+      internalDoc.activitySubscribers = undefined;
+      internalDoc.presenceSubscribers = undefined;
+      internalDoc.metadataSubscriptionOpenToken = undefined;
+      for (
+        const subscriptionId of [
+          internalDoc.activitySubscriptionId,
+          internalDoc.metadataSubscriptionId,
+          internalDoc.presenceSubscriptionId,
+        ]
+      ) {
+        if (subscriptionId != null) {
+          this.eventService.unsubscribe(subscriptionId);
+        }
+      }
+    }
+    this.eventService.disposeDocument(docRef.id);
     this.documents.delete(docRef.id);
   };
 
@@ -317,11 +355,15 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     internalDoc: FoundryInternalDoc,
     docRef: DocumentRef,
   ): void {
-    if (internalDoc.metadataStatus.load !== DocumentLoadStatus.UNLOADED) {
-      throw new Error(
-        `Cannot subscribe to document metadata when status is ${internalDoc.metadataStatus.load}`,
-      );
+    if (
+      internalDoc.metadataSubscriptionOpenToken != null
+      || !this.hasMetadataDemand(internalDoc)
+    ) {
+      return;
     }
+
+    const openToken = {};
+    internalDoc.metadataSubscriptionOpenToken = openToken;
 
     this.updateMetadataStatus(internalDoc, docRef, {
       load: DocumentLoadStatus.LOADING,
@@ -331,7 +373,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
       preview: this.config.usePreviewApi ?? DEFAULT_USE_PREVIEW_API,
     })
       .then(document => {
-        if (!this.documents.has(docRef.id)) {
+        if (!this.isMetadataOpenGeneration(internalDoc, docRef, openToken)) {
           return;
         }
         const metadata = getLocalDocumentMetadata(document);
@@ -342,25 +384,13 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
           load: DocumentLoadStatus.LOADED,
         });
 
-        // The metadata channel is for document metadata edits/deletion. Name
-        // and description changes arrive as generic updates; operationalVersion
-        // only refreshes here if it changed by the time this Document is loaded again.
-        this.eventService
-          .subscribeToMetadataUpdates(docRef.id, _event => {
-            if (!internalDoc.metadataUpdateUnsubscribed) {
-              this.refetchMetadata(docRef);
-            }
-          })
-          .catch((e: unknown) => {
-            this.logger.error("Failed to subscribe to metadata updates", e, {
-              docId: docRef.id,
-            });
-          });
+        this.openMetadataUpdatesSubscription(internalDoc, docRef, openToken);
       })
       .catch((e: unknown) => {
-        if (!this.documents.has(docRef.id)) {
+        if (!this.isMetadataOpenGeneration(internalDoc, docRef, openToken)) {
           return;
         }
+        internalDoc.metadataSubscriptionOpenToken = undefined;
         this.updateMetadataStatus(internalDoc, docRef, {
           error: toUnknownChannelError(
             new Error("Failed to load document metadata", { cause: e }),
@@ -370,13 +400,64 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
       });
   }
 
+  private openMetadataUpdatesSubscription(
+    internalDoc: FoundryInternalDoc,
+    docRef: DocumentRef,
+    openToken: object,
+  ): void {
+    this.eventService
+      .subscribeToMetadataUpdates(docRef.id, _event => {
+        if (this.isMetadataOpenGeneration(internalDoc, docRef, openToken)) {
+          this.refetchMetadata(internalDoc, docRef);
+        }
+      })
+      .then(subscriptionId => {
+        if (!this.isMetadataOpenGeneration(internalDoc, docRef, openToken)) {
+          this.eventService.unsubscribe(subscriptionId);
+          return;
+        }
+        internalDoc.metadataSubscriptionId = subscriptionId;
+      })
+      .catch((e: unknown) => {
+        if (!this.isMetadataOpenGeneration(internalDoc, docRef, openToken)) {
+          return;
+        }
+        this.logger.error("Failed to subscribe to metadata updates", e, {
+          docId: docRef.id,
+        });
+      });
+  }
+
+  private hasMetadataDemand(internalDoc: FoundryInternalDoc): boolean {
+    return internalDoc.hasDataSubscriptions || internalDoc.hasMetadataSubscriptions;
+  }
+
+  /**
+   * Checks whether a metadata request's result is still safe to use. It is not safe if the
+   * request was replaced, nobody needs metadata anymore, or the document was recreated.
+   */
+  private isMetadataOpenGeneration(
+    internalDoc: FoundryInternalDoc,
+    docRef: DocumentRef,
+    openToken: object,
+  ): boolean {
+    return this.documents.get(docRef.id) === internalDoc
+      && internalDoc.metadataSubscriptionOpenToken === openToken
+      && this.hasMetadataDemand(internalDoc);
+  }
+
   protected onDataSubscriptionOpened(
     internalDoc: FoundryInternalDoc,
     docRef: DocumentRef,
   ): void {
-    if (internalDoc.syncSession != null) {
+    if (
+      internalDoc.dataSubscriptionOpenToken != null
+      || internalDoc.syncSession != null
+    ) {
       throw new Error("Document data subscription already opened");
     }
+    const openToken = {};
+    internalDoc.dataSubscriptionOpenToken = openToken;
 
     this.updateDataStatus(internalDoc, docRef, {
       load: DocumentLoadStatus.LOADING,
@@ -393,6 +474,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         const currentDoc = this.documents.get(docRef.id);
         if (
           currentDoc !== internalDoc
+          || currentDoc.dataSubscriptionOpenToken !== openToken
           || !currentDoc.hasDataSubscriptions
           || currentDoc.syncSession != null
         ) {
@@ -411,7 +493,11 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
       })
       .catch((e: unknown) => {
         const currentDoc = this.documents.get(docRef.id);
-        if (currentDoc !== internalDoc || !currentDoc.hasDataSubscriptions) {
+        if (
+          currentDoc !== internalDoc
+          || currentDoc.dataSubscriptionOpenToken !== openToken
+          || !currentDoc.hasDataSubscriptions
+        ) {
           return;
         }
         this.updateDataStatus(internalDoc, docRef, {
@@ -425,15 +511,16 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
 
   protected onMetadataSubscriptionClosed(
     internalDoc: FoundryInternalDoc,
-    _docRef: DocumentRef,
+    docRef: DocumentRef,
   ): void {
-    internalDoc.metadataUpdateUnsubscribed = true;
+    this.closeMetadataUpdatesSubscription(internalDoc, docRef);
   }
 
   protected onDataSubscriptionClosed(
     internalDoc: FoundryInternalDoc,
     docRef: DocumentRef,
   ): void {
+    internalDoc.dataSubscriptionOpenToken = undefined;
     if (internalDoc.syncSession) {
       this.eventService.stopDocumentSync(internalDoc.syncSession);
       internalDoc.syncSession = undefined;
@@ -458,62 +545,106 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         load: DocumentLoadStatus.UNLOADED,
       });
     }
+    this.closeMetadataUpdatesSubscription(internalDoc, docRef);
   }
 
-  // TODO: refcount activity subscribers like data (onStateChange). Each call opens
-  // its own backend subscription, overwriting session.activitySubscriptionId (leaking
-  // the prior subscription), and the shared activityStatus is last-writer-wins so one
-  // subscriber's unsubscribe/error clobbers the status others still rely on. Should
-  // share one backend subscription per doc and only open/close + reset status on first/last subscriber.
+  private closeMetadataUpdatesSubscription(
+    internalDoc: FoundryInternalDoc,
+    docRef: DocumentRef,
+  ): void {
+    if (this.hasMetadataDemand(internalDoc)) {
+      return;
+    }
+    internalDoc.metadataSubscriptionOpenToken = undefined;
+    if (internalDoc.metadataSubscriptionId != null) {
+      this.eventService.unsubscribe(internalDoc.metadataSubscriptionId);
+      internalDoc.metadataSubscriptionId = undefined;
+    }
+    if (internalDoc.metadataStatus.load === DocumentLoadStatus.LOADING) {
+      this.updateMetadataStatus(internalDoc, docRef, {
+        load: DocumentLoadStatus.UNLOADED,
+      });
+    }
+  }
+
   onActivity<T extends DocumentSchema>(
     docRef: DocumentRef<T>,
     callback: (docRef: DocumentRef<T>, event: ActivityEvent) => void,
   ): Unsubscribe {
-    let unsubscribed = false;
-    const unsubscribeFn = () => {
-      unsubscribed = true;
-      // Reset status so a later re-subscribe (e.g. after a version upgrade that
-      // cleared a CLIENT_VERSION_TOO_LOW error) starts clean from UNLOADED.
-      const internalDoc = this.documents.get(docRef.id);
-      if (internalDoc != null) {
-        this.updateActivityStatus(internalDoc, docRef, {
-          load: DocumentLoadStatus.UNLOADED,
-          live: DocumentLiveStatus.DISCONNECTED,
-        });
+    const { internalDoc } = this.getCreateInternalDoc(docRef);
+    const subscriber: ActivitySubscriber = {
+      callback: event => callback(docRef, event),
+    };
+    const subscribers = (internalDoc.activitySubscribers ??= new Set());
+    const isFirstSubscriber = subscribers.size === 0;
+    subscribers.add(subscriber);
+
+    if (isFirstSubscriber) {
+      this.openActivitySubscription(internalDoc, docRef);
+    }
+
+    return () => {
+      const currentDoc = this.documents.get(docRef.id);
+      if (currentDoc?.activitySubscribers == null) {
+        return;
+      }
+      currentDoc.activitySubscribers.delete(subscriber);
+      if (currentDoc.activitySubscribers.size === 0) {
+        this.closeActivitySubscription(currentDoc, docRef);
       }
     };
+  }
+
+  private openActivitySubscription(
+    internalDoc: FoundryInternalDoc,
+    docRef: DocumentRef,
+  ): void {
+    const expectedSubscribers = internalDoc.activitySubscribers;
+    this.updateActivityStatus(internalDoc, docRef, {
+      load: DocumentLoadStatus.LOADING,
+      live: DocumentLiveStatus.CONNECTING,
+    });
 
     this.eventService
       .subscribeToActivityUpdates(
         docRef.id,
         getClientSupportedVersionRange(docRef.schema),
         foundryEvent => {
-          if (unsubscribed) {
+          const currentDoc = this.documents.get(docRef.id);
+          if (
+            expectedSubscribers == null
+            || currentDoc?.activitySubscribers !== expectedSubscribers
+          ) {
             return;
           }
           if (foundryEvent.type === "error") {
-            const internalDoc = this.documents.get(docRef.id);
-            if (internalDoc == null) {
-              return;
-            }
-            this.updateActivityStatus(internalDoc, docRef, {
+            this.updateActivityStatus(currentDoc, docRef, {
               error: toChannelError(foundryEvent),
               load: DocumentLoadStatus.ERROR,
+              live: DocumentLiveStatus.ERROR,
             });
             return;
           }
           const localEvent = getActivityEvent(docRef.schema, foundryEvent);
           if (localEvent != null) {
-            callback(docRef, localEvent);
+            for (const subscriber of currentDoc.activitySubscribers) {
+              subscriber.callback(localEvent);
+            }
           }
         },
       )
-      .then(() => {
-        const internalDoc = this.documents.get(docRef.id);
-        if (unsubscribed || internalDoc == null) {
+      .then(subscriptionId => {
+        const currentDoc = this.documents.get(docRef.id);
+        if (
+          expectedSubscribers == null
+          || expectedSubscribers.size === 0
+          || currentDoc?.activitySubscribers !== expectedSubscribers
+        ) {
+          this.eventService.unsubscribe(subscriptionId);
           return;
         }
-        this.updateActivityStatus(internalDoc, docRef, {
+        currentDoc.activitySubscriptionId = subscriptionId;
+        this.updateActivityStatus(currentDoc, docRef, {
           load: DocumentLoadStatus.LOADED,
           live: DocumentLiveStatus.CONNECTED,
         });
@@ -522,28 +653,48 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         this.logger.error("Failed to subscribe to activity updates", e, {
           docId: docRef.id,
         });
-        const internalDoc = this.documents.get(docRef.id);
-        if (unsubscribed || internalDoc == null) {
+        const currentDoc = this.documents.get(docRef.id);
+        if (
+          expectedSubscribers == null
+          || currentDoc?.activitySubscribers !== expectedSubscribers
+        ) {
           return;
         }
-        this.updateActivityStatus(internalDoc, docRef, {
+        this.updateActivityStatus(currentDoc, docRef, {
           error: toUnknownChannelError(e),
           load: DocumentLoadStatus.ERROR,
+          live: DocumentLiveStatus.ERROR,
         });
       });
-
-    return unsubscribeFn;
   }
 
-  private refetchMetadata(docRef: DocumentRef): void {
-    if (!this.documents.has(docRef.id)) {
+  private closeActivitySubscription(
+    internalDoc: FoundryInternalDoc,
+    docRef: DocumentRef,
+  ): void {
+    if (internalDoc.activitySubscriptionId != null) {
+      this.eventService.unsubscribe(internalDoc.activitySubscriptionId);
+      internalDoc.activitySubscriptionId = undefined;
+    }
+    internalDoc.activitySubscribers = undefined;
+    this.updateActivityStatus(internalDoc, docRef, {
+      load: DocumentLoadStatus.UNLOADED,
+      live: DocumentLiveStatus.DISCONNECTED,
+    });
+  }
+
+  private refetchMetadata(
+    internalDoc: FoundryInternalDoc,
+    docRef: DocumentRef,
+  ): void {
+    if (this.documents.get(docRef.id) !== internalDoc) {
       return;
     }
     Documents.get(this.app.config.osdkClient, docRef.id, {
       preview: this.config.usePreviewApi ?? DEFAULT_USE_PREVIEW_API,
     })
       .then(document => {
-        if (!this.documents.has(docRef.id)) {
+        if (this.documents.get(docRef.id) !== internalDoc) {
           return;
         }
         const metadata = getLocalDocumentMetadata(document);
@@ -551,7 +702,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         this.updateMetadata(docRef.id, metadata);
       })
       .catch((e: unknown) => {
-        if (!this.documents.has(docRef.id)) {
+        if (this.documents.get(docRef.id) !== internalDoc) {
           return;
         }
         this.logger.error("Failed to refetch document metadata", e, {
@@ -560,62 +711,91 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
       });
   }
 
-  // TODO: refcount presence subscribers like data (onStateChange). Each call opens
-  // its own backend subscription, overwriting session.presenceSubscriptionId (leaking
-  // the prior subscription), and the shared presenceStatus is last-writer-wins so one
-  // subscriber's unsubscribe/error clobbers the status others still rely on. Should
-  // share one backend subscription per doc and only open/close + reset status on first/last subscriber.
   onPresence<T extends DocumentSchema>(
     docRef: DocumentRef<T>,
     callback: (docRef: DocumentRef<T>, event: PresenceEvent) => void,
     options?: PresenceSubscriptionOptions,
   ): Unsubscribe {
-    let unsubscribed = false;
-    const unsubscribeFn = () => {
-      unsubscribed = true;
-      // Reset status so a later re-subscribe (e.g. after a version upgrade that
-      // cleared a CLIENT_VERSION_TOO_LOW error) starts clean from UNLOADED.
-      const internalDoc = this.documents.get(docRef.id);
-      if (internalDoc != null) {
-        this.updatePresenceStatus(internalDoc, docRef, {
-          load: DocumentLoadStatus.UNLOADED,
-          live: DocumentLiveStatus.DISCONNECTED,
-        });
+    const { internalDoc } = this.getCreateInternalDoc(docRef);
+    const subscriber: PresenceSubscriber = {
+      callback: event => callback(docRef, event),
+      ignoreSelfUpdates: options?.ignoreSelfUpdates ?? true,
+    };
+    const subscribers = (internalDoc.presenceSubscribers ??= new Set());
+    const isFirstSubscriber = subscribers.size === 0;
+    subscribers.add(subscriber);
+
+    if (isFirstSubscriber) {
+      this.openPresenceSubscription(internalDoc, docRef);
+    }
+
+    return () => {
+      const currentDoc = this.documents.get(docRef.id);
+      if (currentDoc?.presenceSubscribers == null) {
+        return;
+      }
+      currentDoc.presenceSubscribers.delete(subscriber);
+      if (currentDoc.presenceSubscribers.size === 0) {
+        this.closePresenceSubscription(currentDoc, docRef);
       }
     };
+  }
+
+  private openPresenceSubscription(
+    internalDoc: FoundryInternalDoc,
+    docRef: DocumentRef,
+  ): void {
+    const expectedSubscribers = internalDoc.presenceSubscribers;
+    this.updatePresenceStatus(internalDoc, docRef, {
+      load: DocumentLoadStatus.LOADING,
+      live: DocumentLiveStatus.CONNECTING,
+    });
 
     this.eventService
       .subscribeToPresenceUpdates(
         docRef.id,
         getClientSupportedVersionRange(docRef.schema),
         foundryUpdate => {
-          if (unsubscribed) {
+          const currentDoc = this.documents.get(docRef.id);
+          if (
+            expectedSubscribers == null
+            || currentDoc?.presenceSubscribers !== expectedSubscribers
+          ) {
             return;
           }
           if (foundryUpdate.type === "error") {
-            const internalDoc = this.documents.get(docRef.id);
-            if (internalDoc == null) {
-              return;
-            }
-            this.updatePresenceStatus(internalDoc, docRef, {
+            this.updatePresenceStatus(currentDoc, docRef, {
               error: toChannelError(foundryUpdate),
               load: DocumentLoadStatus.ERROR,
+              live: DocumentLiveStatus.ERROR,
             });
             return;
           }
           const localEvent = getPresenceEvent(docRef.schema, foundryUpdate);
           if (localEvent != null) {
-            callback(docRef, localEvent);
+            const localUserId = getAuthModule(this.app).getCurrentUser(true)?.userId;
+            const isSelfUpdate = localUserId != null && localEvent.userId === localUserId;
+            for (const subscriber of currentDoc.presenceSubscribers) {
+              if (!isSelfUpdate || !subscriber.ignoreSelfUpdates) {
+                subscriber.callback(localEvent);
+              }
+            }
           }
         },
-        options,
+        { ignoreSelfUpdates: false },
       )
-      .then(() => {
-        const internalDoc = this.documents.get(docRef.id);
-        if (unsubscribed || internalDoc == null) {
+      .then(subscriptionId => {
+        const currentDoc = this.documents.get(docRef.id);
+        if (
+          expectedSubscribers == null
+          || expectedSubscribers.size === 0
+          || currentDoc?.presenceSubscribers !== expectedSubscribers
+        ) {
+          this.eventService.unsubscribe(subscriptionId);
           return;
         }
-        this.updatePresenceStatus(internalDoc, docRef, {
+        currentDoc.presenceSubscriptionId = subscriptionId;
+        this.updatePresenceStatus(currentDoc, docRef, {
           load: DocumentLoadStatus.LOADED,
           live: DocumentLiveStatus.CONNECTED,
         });
@@ -624,17 +804,34 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         this.logger.error("Failed to subscribe to presence updates", e, {
           docId: docRef.id,
         });
-        const internalDoc = this.documents.get(docRef.id);
-        if (unsubscribed || internalDoc == null) {
+        const currentDoc = this.documents.get(docRef.id);
+        if (
+          expectedSubscribers == null
+          || currentDoc?.presenceSubscribers !== expectedSubscribers
+        ) {
           return;
         }
-        this.updatePresenceStatus(internalDoc, docRef, {
+        this.updatePresenceStatus(currentDoc, docRef, {
           error: toUnknownChannelError(e),
           load: DocumentLoadStatus.ERROR,
+          live: DocumentLiveStatus.ERROR,
         });
       });
+  }
 
-    return unsubscribeFn;
+  private closePresenceSubscription(
+    internalDoc: FoundryInternalDoc,
+    docRef: DocumentRef,
+  ): void {
+    if (internalDoc.presenceSubscriptionId != null) {
+      this.eventService.unsubscribe(internalDoc.presenceSubscriptionId);
+      internalDoc.presenceSubscriptionId = undefined;
+    }
+    internalDoc.presenceSubscribers = undefined;
+    this.updatePresenceStatus(internalDoc, docRef, {
+      load: DocumentLoadStatus.UNLOADED,
+      live: DocumentLiveStatus.DISCONNECTED,
+    });
   }
 
   updateCustomPresence<M extends Model>(

--- a/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
@@ -17,6 +17,7 @@
 import type {
   ActivityCollaborativeUpdate,
   Document,
+  DocumentMetadataUpdate,
   PresenceCollaborativeUpdate,
 } from "@osdk/foundry.pack";
 import { Documents } from "@osdk/foundry.pack";
@@ -45,6 +46,7 @@ vi.mock("@osdk/foundry.pack", () => ({
 }));
 
 const mockAuthModule = {
+  getCurrentUser: vi.fn().mockReturnValue({ userId: "local-user" }),
   onTokenChange: vi.fn(),
   getToken: vi.fn().mockReturnValue("mock-token"),
 };
@@ -257,6 +259,83 @@ describe("Foundry Document Status Tracking", () => {
 
       await expect(service.waitForMetadataLoad(docRef)).resolves.toBeUndefined();
     });
+
+    it("should refresh and reopen metadata when a new subscriber joins", async () => {
+      mockEventService.subscribeToMetadataUpdates
+        .mockResolvedValueOnce("metadata-sub-1" as SubscriptionId)
+        .mockResolvedValueOnce("metadata-sub-2" as SubscriptionId);
+      const docRef = createDocRef(mockApp, "test-doc-metadata-reopen" as DocumentId, testSchema);
+
+      const unsubscribeFirst = service.onMetadataChange(docRef, () => {});
+      await vi.runAllTimersAsync();
+      unsubscribeFirst();
+
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("metadata-sub-1");
+
+      vi.mocked(Documents.get).mockClear();
+      const unsubscribeSecond = service.onMetadataChange(docRef, () => {});
+      await vi.runAllTimersAsync();
+
+      expect(Documents.get).toHaveBeenCalledTimes(1);
+      expect(mockEventService.subscribeToMetadataUpdates).toHaveBeenCalledTimes(2);
+
+      unsubscribeSecond();
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("metadata-sub-2");
+    });
+
+    it("should discard a metadata subscription that resolves after demand closes", async () => {
+      let resolveSubscription: (subscriptionId: SubscriptionId) => void = () => {};
+      mockEventService.subscribeToMetadataUpdates.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveSubscription = resolve;
+          }),
+      );
+      const docRef = createDocRef(mockApp, "test-doc-metadata-stale" as DocumentId, testSchema);
+
+      const unsubscribe = service.onMetadataChange(docRef, () => {});
+      await vi.runAllTimersAsync();
+      unsubscribe();
+
+      resolveSubscription("stale-metadata-sub" as SubscriptionId);
+      await vi.runAllTimersAsync();
+
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("stale-metadata-sub");
+    });
+
+    it("should discard a metadata refetch from a deleted document generation", async () => {
+      let metadataUpdateCallback: (update: DocumentMetadataUpdate) => void = () => {};
+      mockEventService.subscribeToMetadataUpdates.mockImplementation(
+        (_documentId, callback) => {
+          metadataUpdateCallback = callback;
+          return Promise.resolve("metadata-sub" as SubscriptionId);
+        },
+      );
+      const docRef = createDocRef(mockApp, "test-doc-metadata-refetch" as DocumentId, testSchema);
+      service.onMetadataChange(docRef, () => {});
+      await vi.runAllTimersAsync();
+
+      let resolveRefetch: (document: Document) => void = () => {};
+      vi.mocked(Documents.get).mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveRefetch = resolve;
+        }),
+      );
+      metadataUpdateCallback({} as DocumentMetadataUpdate);
+
+      await service.deleteDocument(docRef);
+      const recreatedDocRef = service.createDocRef(docRef.id, testSchema);
+      const names: string[] = [];
+      service.onMetadataChange(recreatedDocRef, (_ref, metadata) => {
+        names.push(metadata.name);
+      });
+      await vi.runAllTimersAsync();
+
+      resolveRefetch({ ...mockDocument, name: "Stale name" });
+      await vi.runAllTimersAsync();
+
+      expect(names).not.toContain("Stale name");
+    });
   });
 
   describe("websocket data loading", () => {
@@ -323,12 +402,27 @@ describe("Foundry Document Status Tracking", () => {
     });
 
     it("should handle fast unsubscribe before websocket data sync starts", async () => {
+      let resolveMetadata: (document: Document) => void = () => {};
+      vi.mocked(Documents.get).mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveMetadata = resolve;
+        }),
+      );
       const docRef = createDocRef(mockApp, "test-doc-13" as DocumentId, testSchema);
+      const statusUpdates: DocumentStatus[] = [];
+      unsubscribes.push(service.onStatusChange(docRef, (_, status) => {
+        statusUpdates.push(status);
+      }));
 
       const unsubscribeState = service.onStateChange(docRef, () => {});
+      const metadataWait = service.waitForMetadataLoad(docRef);
 
       unsubscribeState();
 
+      expect(statusUpdates.at(-1)?.metadata.load).toBe(DocumentLoadStatus.UNLOADED);
+      await expect(metadataWait).rejects.toThrow("Metadata load canceled");
+
+      resolveMetadata(mockDocument);
       await vi.runAllTimersAsync();
 
       expect(mockEventService.startDocumentSync).not.toHaveBeenCalled();
@@ -338,6 +432,45 @@ describe("Foundry Document Status Tracking", () => {
       await vi.runAllTimersAsync();
 
       expect(mockEventService.startDocumentSync).toHaveBeenCalled();
+    });
+
+    it("should not let a canceled metadata wait fail reopened data", async () => {
+      let resolveFirst: (document: Document) => void = () => {};
+      let resolveSecond: (document: Document) => void = () => {};
+      vi.mocked(Documents.get)
+        .mockImplementationOnce(() =>
+          new Promise(resolve => {
+            resolveFirst = resolve;
+          })
+        )
+        .mockImplementationOnce(() =>
+          new Promise(resolve => {
+            resolveSecond = resolve;
+          })
+        );
+      const docRef = createDocRef(mockApp, "test-doc-data-reopen-race" as DocumentId, testSchema);
+      const statusUpdates: DocumentStatus[] = [];
+      unsubscribes.push(service.onStatusChange(docRef, (_, status) => {
+        statusUpdates.push(status);
+      }));
+
+      const unsubscribeFirst = service.onStateChange(docRef, () => {});
+      unsubscribeFirst();
+      unsubscribes.push(service.onStateChange(docRef, () => {}));
+      await vi.runAllTimersAsync();
+
+      expect(statusUpdates.at(-1)?.data.load).toBe(DocumentLoadStatus.LOADING);
+
+      resolveSecond(mockDocument);
+      await vi.runAllTimersAsync();
+
+      expect(mockEventService.startDocumentSync).toHaveBeenCalledTimes(1);
+      expect(statusUpdates.at(-1)?.data.load).toBe(DocumentLoadStatus.LOADED);
+
+      resolveFirst(mockDocument);
+      await vi.runAllTimersAsync();
+
+      expect(mockEventService.startDocumentSync).toHaveBeenCalledTimes(1);
     });
 
     it("should reopen websocket data sync after loaded subscription closes", async () => {
@@ -357,6 +490,39 @@ describe("Foundry Document Status Tracking", () => {
       await vi.runAllTimersAsync();
 
       expect(mockEventService.startDocumentSync).toHaveBeenCalledTimes(2);
+    });
+
+    it("should close data-owned metadata updates with the last data subscriber", async () => {
+      mockEventService.subscribeToMetadataUpdates.mockResolvedValueOnce(
+        "data-metadata-sub" as SubscriptionId,
+      );
+      const docRef = createDocRef(mockApp, "test-doc-data-metadata" as DocumentId, testSchema);
+
+      const unsubscribeState = service.onStateChange(docRef, () => {});
+      await vi.runAllTimersAsync();
+      unsubscribeState();
+
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("data-metadata-sub");
+    });
+
+    it("should keep metadata updates while an explicit subscriber remains", async () => {
+      mockEventService.subscribeToMetadataUpdates.mockResolvedValueOnce(
+        "shared-metadata-sub" as SubscriptionId,
+      );
+      const docRef = createDocRef(mockApp, "test-doc-shared-metadata" as DocumentId, testSchema);
+
+      const unsubscribeMetadata = service.onMetadataChange(docRef, () => {});
+      const unsubscribeState = service.onStateChange(docRef, () => {});
+      await vi.runAllTimersAsync();
+
+      mockEventService.unsubscribe.mockClear();
+      unsubscribeState();
+
+      expect(mockEventService.stopDocumentSync).toHaveBeenCalled();
+      expect(mockEventService.unsubscribe).not.toHaveBeenCalledWith("shared-metadata-sub");
+
+      unsubscribeMetadata();
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("shared-metadata-sub");
     });
 
     it("should retry metadata load after data-open metadata failure", async () => {
@@ -406,6 +572,31 @@ describe("Foundry Document Status Tracking", () => {
       await vi.runAllTimersAsync();
 
       expect(mockEventService.startDocumentSync).not.toHaveBeenCalled();
+    });
+
+    it("should dispose every active document channel after deletion", async () => {
+      mockEventService.subscribeToMetadataUpdates.mockResolvedValueOnce(
+        "delete-metadata-sub" as SubscriptionId,
+      );
+      mockEventService.subscribeToActivityUpdates.mockResolvedValueOnce(
+        "delete-activity-sub" as SubscriptionId,
+      );
+      mockEventService.subscribeToPresenceUpdates.mockResolvedValueOnce(
+        "delete-presence-sub" as SubscriptionId,
+      );
+      const docRef = createDocRef(mockApp, "test-doc-delete-active" as DocumentId, testSchema);
+
+      service.onStateChange(docRef, () => {});
+      service.onActivity(docRef, () => {});
+      service.onPresence(docRef, () => {});
+      await vi.runAllTimersAsync();
+
+      await service.deleteDocument(docRef);
+
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("delete-metadata-sub");
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("delete-activity-sub");
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("delete-presence-sub");
+      expect(mockEventService.disposeDocument).toHaveBeenCalledWith(docRef.id);
     });
 
     it("should handle websocket subscription errors and update data status to ERROR", async () => {
@@ -572,6 +763,103 @@ describe("Foundry Document Status Tracking", () => {
       expect(statusUpdates.at(-1)?.activity.load).toBe(DocumentLoadStatus.UNLOADED);
       expect(statusUpdates.at(-1)?.activity.error).toBeUndefined();
     });
+
+    it("should share activity updates until the last subscriber leaves", async () => {
+      let activityCallback: (event: ActivityCollaborativeUpdate) => void = () => {};
+      mockEventService.subscribeToActivityUpdates.mockImplementationOnce(
+        (_documentId, _range, callback) => {
+          activityCallback = callback;
+          return Promise.resolve("activity-sub-id" as SubscriptionId);
+        },
+      );
+
+      const docRef = createDocRef(mockApp, "test-doc-activity-shared" as DocumentId, testSchema);
+      const callbackA = vi.fn();
+      const callbackB = vi.fn();
+      const unsubscribeA = service.onActivity(docRef, callbackA);
+      const unsubscribeB = service.onActivity(docRef, callbackB);
+      await vi.runAllTimersAsync();
+
+      expect(mockEventService.subscribeToActivityUpdates).toHaveBeenCalledTimes(1);
+
+      const activityUpdate = {
+        type: "activityCreated",
+        activityEvent: {
+          aggregationKey: "test-doc-activity-shared",
+          createdBy: "other-user",
+          createdTime: "2025-01-01T00:00:00Z",
+          eventData: { type: "documentCreate", name: "Test Document" },
+          eventId: "activity-event-1",
+          isRead: false,
+        },
+      } as unknown as ActivityCollaborativeUpdate;
+      activityCallback(activityUpdate);
+
+      expect(callbackA).toHaveBeenCalledTimes(1);
+      expect(callbackB).toHaveBeenCalledTimes(1);
+
+      unsubscribeA();
+      expect(mockEventService.unsubscribe).not.toHaveBeenCalled();
+
+      activityCallback(activityUpdate);
+      expect(callbackA).toHaveBeenCalledTimes(1);
+      expect(callbackB).toHaveBeenCalledTimes(2);
+
+      unsubscribeB();
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("activity-sub-id");
+    });
+
+    it("should discard an activity subscription from an obsolete subscriber generation", async () => {
+      let resolveFirst: (subscriptionId: SubscriptionId) => void = () => {};
+      let resolveSecond: (subscriptionId: SubscriptionId) => void = () => {};
+      const activityCallbacks: Array<(event: ActivityCollaborativeUpdate) => void> = [];
+      mockEventService.subscribeToActivityUpdates
+        .mockImplementationOnce((_documentId, _range, callback) => {
+          activityCallbacks.push(callback);
+          return new Promise(resolve => {
+            resolveFirst = resolve;
+          });
+        })
+        .mockImplementationOnce((_documentId, _range, callback) => {
+          activityCallbacks.push(callback);
+          return new Promise(resolve => {
+            resolveSecond = resolve;
+          });
+        });
+
+      const docRef = createDocRef(mockApp, "test-doc-activity-stale" as DocumentId, testSchema);
+      const callback = vi.fn();
+      const unsubscribeFirst = service.onActivity(docRef, callback);
+      unsubscribeFirst();
+      const unsubscribeSecond = service.onActivity(docRef, callback);
+
+      resolveFirst("old-activity-sub-id" as SubscriptionId);
+      await vi.runAllTimersAsync();
+
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("old-activity-sub-id");
+
+      const activityUpdate = {
+        type: "activityCreated",
+        activityEvent: {
+          aggregationKey: "test-doc-activity-stale",
+          createdBy: "other-user",
+          createdTime: "2025-01-01T00:00:00Z",
+          eventData: { type: "documentCreate", name: "Test Document" },
+          eventId: "activity-event-1",
+          isRead: false,
+        },
+      } as unknown as ActivityCollaborativeUpdate;
+      activityCallbacks[0]?.(activityUpdate);
+      expect(callback).not.toHaveBeenCalled();
+
+      resolveSecond("new-activity-sub-id" as SubscriptionId);
+      await vi.runAllTimersAsync();
+      activityCallbacks[1]?.(activityUpdate);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      unsubscribeSecond();
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("new-activity-sub-id");
+    });
   });
 
   describe("presence channel status", () => {
@@ -642,6 +930,87 @@ describe("Foundry Document Status Tracking", () => {
 
       expect(statusUpdates.at(-1)?.presence.load).toBe(DocumentLoadStatus.UNLOADED);
       expect(statusUpdates.at(-1)?.presence.error).toBeUndefined();
+    });
+
+    it("should share presence updates with per-subscriber self filtering", async () => {
+      let presenceCallback: (update: PresenceCollaborativeUpdate) => void = () => {};
+      mockEventService.subscribeToPresenceUpdates.mockImplementationOnce(
+        (_documentId, _range, callback, options) => {
+          presenceCallback = callback;
+          expect(options?.ignoreSelfUpdates).toBe(false);
+          return Promise.resolve("presence-sub-id" as SubscriptionId);
+        },
+      );
+
+      const docRef = createDocRef(mockApp, "test-doc-presence-shared" as DocumentId, testSchema);
+      const callbackA = vi.fn();
+      const callbackB = vi.fn();
+      const unsubscribeA = service.onPresence(docRef, callbackA);
+      const unsubscribeB = service.onPresence(docRef, callbackB, { ignoreSelfUpdates: false });
+      await vi.runAllTimersAsync();
+
+      expect(mockEventService.subscribeToPresenceUpdates).toHaveBeenCalledTimes(1);
+
+      presenceCallback({
+        type: "presenceChangeEvent",
+        userId: "local-user",
+        status: "PRESENT",
+      } as unknown as PresenceCollaborativeUpdate);
+
+      expect(callbackA).not.toHaveBeenCalled();
+      expect(callbackB).toHaveBeenCalledTimes(1);
+
+      unsubscribeA();
+      expect(mockEventService.unsubscribe).not.toHaveBeenCalled();
+
+      unsubscribeB();
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("presence-sub-id");
+    });
+
+    it("should discard a presence subscription from an obsolete subscriber generation", async () => {
+      let resolveFirst: (subscriptionId: SubscriptionId) => void = () => {};
+      let resolveSecond: (subscriptionId: SubscriptionId) => void = () => {};
+      const presenceCallbacks: Array<(update: PresenceCollaborativeUpdate) => void> = [];
+      mockEventService.subscribeToPresenceUpdates
+        .mockImplementationOnce((_documentId, _range, callback) => {
+          presenceCallbacks.push(callback);
+          return new Promise(resolve => {
+            resolveFirst = resolve;
+          });
+        })
+        .mockImplementationOnce((_documentId, _range, callback) => {
+          presenceCallbacks.push(callback);
+          return new Promise(resolve => {
+            resolveSecond = resolve;
+          });
+        });
+
+      const docRef = createDocRef(mockApp, "test-doc-presence-stale" as DocumentId, testSchema);
+      const callback = vi.fn();
+      const unsubscribeFirst = service.onPresence(docRef, callback);
+      unsubscribeFirst();
+      const unsubscribeSecond = service.onPresence(docRef, callback);
+
+      resolveFirst("old-presence-sub-id" as SubscriptionId);
+      await vi.runAllTimersAsync();
+
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("old-presence-sub-id");
+
+      const presenceUpdate = {
+        type: "presenceChangeEvent",
+        userId: "other-user",
+        status: "PRESENT",
+      } as unknown as PresenceCollaborativeUpdate;
+      presenceCallbacks[0]?.(presenceUpdate);
+      expect(callback).not.toHaveBeenCalled();
+
+      resolveSecond("new-presence-sub-id" as SubscriptionId);
+      await vi.runAllTimersAsync();
+      presenceCallbacks[1]?.(presenceUpdate);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      unsubscribeSecond();
+      expect(mockEventService.unsubscribe).toHaveBeenCalledWith("new-presence-sub-id");
     });
   });
 

--- a/packages/state/react/src/__tests__/useOnDocPresenceEvents.test.tsx
+++ b/packages/state/react/src/__tests__/useOnDocPresenceEvents.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  DocumentId,
+  DocumentRef,
+  DocumentSchema,
+} from "@palantir/pack.document-schema.model-types";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useOnDocPresenceEvents } from "../hooks/useOnDocPresenceEvents.js";
+
+describe("useOnDocPresenceEvents", () => {
+  it("resubscribes when ignoreSelfUpdates changes", () => {
+    const unsubscribeFirst = vi.fn();
+    const unsubscribeSecond = vi.fn();
+    const onPresence = vi.fn()
+      .mockReturnValueOnce(unsubscribeFirst)
+      .mockReturnValueOnce(unsubscribeSecond);
+    const docRef = {
+      id: "doc-1" as DocumentId,
+      onPresence,
+    } as unknown as DocumentRef<DocumentSchema>;
+
+    const { rerender, unmount } = renderHook(
+      ({ ignoreSelfUpdates }) => {
+        useOnDocPresenceEvents(docRef, () => {}, { ignoreSelfUpdates });
+      },
+      { initialProps: { ignoreSelfUpdates: true } },
+    );
+
+    expect(onPresence).toHaveBeenCalledTimes(1);
+    expect(onPresence.mock.calls[0]?.[1]).toEqual({ ignoreSelfUpdates: true });
+
+    rerender({ ignoreSelfUpdates: false });
+
+    expect(unsubscribeFirst).toHaveBeenCalledOnce();
+    expect(onPresence).toHaveBeenCalledTimes(2);
+    expect(onPresence.mock.calls[1]?.[1]).toEqual({ ignoreSelfUpdates: false });
+
+    unmount();
+    expect(unsubscribeSecond).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/state/react/src/hooks/useOnDocPresenceEvents.ts
+++ b/packages/state/react/src/hooks/useOnDocPresenceEvents.ts
@@ -93,8 +93,7 @@ export function useOnDocPresenceEvents(
 ): void {
   const callback = useRef<(typeof onPresence)>(onPresence);
   callback.current = onPresence;
-  const subOptions = useRef<PresenceSubscriptionOptions>(options);
-  subOptions.current = options;
+  const ignoreSelfUpdates = options.ignoreSelfUpdates ?? true;
 
   useEffect(() => {
     if (!isValidDocRef(docRef)) {
@@ -103,10 +102,10 @@ export function useOnDocPresenceEvents(
 
     const unsubscribe = docRef.onPresence((_inDocRef, event) => {
       callback.current(event);
-    }, subOptions.current);
+    }, { ignoreSelfUpdates });
 
     return () => {
       unsubscribe();
     };
-  }, [docRef]);
+  }, [docRef, ignoreSelfUpdates]);
 }


### PR DESCRIPTION
**Summary**
This PR fixes document subscription ownership so each channel has one logical backend subscription per document while supporting multiple local subscribers. The shared physical CometD connection remains unchanged.

Previously, activity and presence opened a new backend subscription for every local subscriber, unlike data subscriptions, which only opened one subscription for all subscribers. Subscription IDs were overwritten, causing leaks, incorrect shared status, and one subscriber’s cleanup affecting others. Stopping data sync also closed unrelated channels, even when activity, presence, or metadata subscribers remained.

**Main changes**
- Activity and presence now fan out one backend subscription to multiple local subscribers and close only after the last subscriber leaves.
- Presence applies ignoreSelfUpdates per subscriber, including when the React option changes.
- Data teardown now stops only data sync. Full document deletion explicitly disposes every channel.
- Metadata remains active while data or explicit metadata subscribers need it, and refreshes before restarted data sync continues.
- Async subscription results are ignored and cleaned up after cancellation or document recreation.
- Metadata cancellation settles pending waiters instead of leaving status stuck at LOADING.
- Data restarts preserve the document client ID.
- Duplicate data starts are rejected without replacing the active Y.Doc.