### PR TITLE
Rework release scripts

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,8 +14,8 @@ Releases are cut by bumping versions and letting the Release GitHub Actions work
 
 There are two equivalent ways to prepare a release; both are gated identically:
 
-- `./scripts/createReleasePr.sh` — run on `main` or a `release/*` branch. Creates a `changeset-release/<branch>` "Version Packages" PR; merge it to publish.
-- `./scripts/createReleaseCommit.sh` — run on a topic branch forked from `main` or a `release/*` branch. Bumps versions and commits them; open a PR yourself and merge to publish. (Add an empty changeset with `pnpm exec changeset add --empty` so CI checks pass.)
+- `./scripts/createReleasePr.sh` — run on `main` or a `release/*` branch. Creates a `changeset-release/<branch>` "Version Packages" PR; merge it to publish. It reads the base directly from the branch you are on, so nothing needs to be specified.
+- `./scripts/createReleaseCommit.sh [main|release]` — run on a topic branch forked from `main` or a `release/*` branch. Bumps versions and commits them; open a PR yourself and merge to publish. (Add an empty changeset with `pnpm exec changeset add --empty` so CI checks pass.) It auto-detects the base branch, but pass `main` or `release` explicitly when your branch was forked from a commit shared by both (see [Branching model enforcement](#branching-model-enforcement)).
 
 ### Cutting a minor/major release (from `main`)
 
@@ -40,7 +40,9 @@ To keep release lines coherent under uni-versioning, we only cut **minor/major**
 
 This is enforced authoritatively in CI, in `ciPublish.ts`, **before** anything is published: it compares each package's version against what is already on npm, derives the release-level bump, and refuses to publish (exits non-empty) if the bump is not allowed for the current branch. Because this runs on the protected destination branch after merge, it cannot be bypassed by how the release commit or PR was prepared.
 
-`./scripts/createReleaseCommit.sh` also runs the same check locally (via `mutateReleasePlan`) for early feedback, detecting whether your topic branch was forked from `main` or a `release/*` branch. Set `VERSION_COMMIT_BRANCH_TYPE` (`main` or `release branch`) to override the detected base.
+`./scripts/createReleaseCommit.sh` also runs the same check locally (via `mutateReleasePlan`) for early feedback. Because it runs on an arbitrarily-named topic branch, it infers the base by comparing merge-base distances to `origin/main` and each `origin/release/*`. When HEAD sits on a commit that is on **both** — e.g. the first patch on a freshly-cut `release/*` branch, which is indistinguishable from the first minor on `main` after cutting it — detection is ambiguous and the tool stops and asks you to specify. Pass `main`/`release` to the script, or set `VERSION_COMMIT_BRANCH_TYPE` (`main` or `release branch`), to resolve it.
+
+> `createReleasePr.sh` is never ambiguous: it derives the base from the branch you run it on (`main` or `release/*`), not from topology, so only the commit flow takes an explicit base.
 
 ## Uni-versioning
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,35 +8,39 @@ b. has not been published to NPM at the version in its current `package.json` ve
 
 In `packages/monorepo/release` is code that is adapted from changesets/action that will let you create the PR branch for releasing. There is a utility script at `./scripts/createReleasePr.sh` that ensures you are compiled and does some sanity checks prior to creating the release PR.
 
-## Prerelease Mode
+## Releasing
 
-We keep the `main` branch on Changesets "prerelease mode". This means that from main, we only publish releases with `-beta.x` in their version strings. To create a new set of prerelease versions:
+Releases are cut by bumping versions and letting the Release GitHub Actions workflow publish on merge. The branching model is enforced automatically (see [Branching model enforcement](#branching-model-enforcement)): **`main` cuts minor/major releases, `release/*` branches cut patches.**
 
-1. On `main`, run `./scripts/createReleasePr.sh`
-3. Merge the PR
+There are two equivalent ways to prepare a release; both are gated identically:
 
-Example: https://github.com/palantir/pack/pull/25
+- `./scripts/createReleasePr.sh` — run on `main` or a `release/*` branch. Creates a `changeset-release/<branch>` "Version Packages" PR; merge it to publish.
+- `./scripts/createReleaseCommit.sh` — run on a topic branch forked from `main` or a `release/*` branch. Bumps versions and commits them; open a PR yourself and merge to publish. (Add an empty changeset with `pnpm exec changeset add --empty` so CI checks pass.)
 
-## Releasing 
+### Cutting a minor/major release (from `main`)
 
-We publish releases from `release/` branches. On these branches, after the first release, only the patch number can be incremented. When cutting a `release/` branch, we also increment all versions on `main` to keep them ahead of the versions being published from the 
+1. Ensure the relevant changesets are on `main`.
+2. Prepare the release with either script above, then merge the PR. All publishable packages are versioned together (see [Uni-versioning](#uni-versioning)) and published to the `latest` tag.
 
-0. On `main`, run `./scripts/simulateMinorBump.sh`
-    1. Create a PR with these changes, and merge it
-    2. This will move all packages on main to their next beta versions
-1. Create a `release/YY-MM-DD` branch from the commit _prior_ to the above PR
-2. (Optional) On the `release/` branch, create RC releases:
-    1. Switch the `pre` tag to `rc` in `.changeset/pre.json`
-    2. run `./scripts/createReleasePr.sh`
-    3. Merge the PR
-3. On the `release/` branch, create the minor and major releases:
-    1. Disable the `pre` mode using `pnpm exec changeset pre exit`
-    2. run `./scripts/createReleasePr.sh`
-    3. Merge the PR
-4. Create patch releases for versions on this branch:
-    1. Create PRs against the `release/` branch, including changesets with _patch only_ changes
-    2. On the `release/` branch, run `./scripts/createReleasePr.sh`
-    3. Merge the PR
+### Starting a patch line (`release/*` branch)
+
+1. Create a `release/X.Y` branch from the `main` commit you want to stabilize.
+2. Because `main` only ever publishes new minors and a `release/*` branch only publishes patches within its line, their versions never collide — there is no longer any need to pre-bump `main` when cutting a branch.
+
+### Cutting a patch release (from a `release/*` branch)
+
+1. Open PRs against `release/X.Y` containing **patch-only** changesets.
+2. Prepare the release with either script above, then merge. A `minor`/`major` changeset on a release branch is rejected by the gate.
+
+> **Note:** `./scripts/simulateMinorBump.sh` belonged to the old prerelease/beta flow (it requires `.changeset/pre.json` and produces `-beta` versions) and is obsolete under uni-versioning.
+
+## Branching model enforcement
+
+To keep release lines coherent under uni-versioning, we only cut **minor/major** releases from `main` and **patch** releases from `release/*` branches.
+
+This is enforced authoritatively in CI, in `ciPublish.ts`, **before** anything is published: it compares each package's version against what is already on npm, derives the release-level bump, and refuses to publish (exits non-empty) if the bump is not allowed for the current branch. Because this runs on the protected destination branch after merge, it cannot be bypassed by how the release commit or PR was prepared.
+
+`./scripts/createReleaseCommit.sh` also runs the same check locally (via `mutateReleasePlan`) for early feedback, detecting whether your topic branch was forked from `main` or a `release/*` branch. Set `VERSION_COMMIT_BRANCH_TYPE` (`main` or `release branch`) to override the detected base.
 
 ## Uni-versioning
 

--- a/packages/monorepo/release/src/ciPublish.test.ts
+++ b/packages/monorepo/release/src/ciPublish.test.ts
@@ -15,7 +15,13 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { determineTag, findGreatestVersion } from "./ciPublish.js";
+import {
+  checkBumpAllowedOnBranch,
+  determineReleaseBump,
+  determineTag,
+  findGreatestVersion,
+  highestVersionBelow,
+} from "./ciPublish.js";
 
 describe("findGreatestVersion", () => {
   it("should find the highest semver version from release branch names", () => {
@@ -69,5 +75,79 @@ describe("determineTag", () => {
     const result = determineTag(currentBranch, greatestVersion, defaultTag);
 
     expect(result).toBe("latest-2.0.x");
+  });
+});
+
+describe("highestVersionBelow", () => {
+  it("returns the highest published version strictly below local", () => {
+    const published = new Set(["0.23.3", "0.23.4", "0.24.0"]);
+    expect(highestVersionBelow("0.24.0", published)).toBe("0.23.4");
+  });
+
+  it("ignores versions greater than or equal to local", () => {
+    const published = new Set(["0.23.4", "0.24.0", "0.25.0"]);
+    expect(highestVersionBelow("0.23.5", published)).toBe("0.23.4");
+  });
+
+  it("returns null when nothing is below local (new package or first in line)", () => {
+    expect(highestVersionBelow("0.1.0", new Set())).toBeNull();
+    expect(highestVersionBelow("0.23.0", new Set(["0.23.0", "0.24.0"]))).toBeNull();
+  });
+
+  it("orders prerelease versions correctly", () => {
+    const published = new Set(["0.23.5", "0.24.0-rc.0"]);
+    expect(highestVersionBelow("0.24.0-rc.1", published)).toBe("0.24.0-rc.0");
+    expect(highestVersionBelow("0.24.0", published)).toBe("0.24.0-rc.0");
+  });
+});
+
+describe("determineReleaseBump", () => {
+  it("treats a missing previous version as an initial release", () => {
+    expect(determineReleaseBump(null, "0.1.0")).toBe("initial");
+  });
+
+  it("derives major/minor/patch from the version core", () => {
+    expect(determineReleaseBump("0.23.5", "1.0.0")).toBe("major");
+    expect(determineReleaseBump("0.23.5", "0.24.0")).toBe("minor");
+    expect(determineReleaseBump("0.23.5", "0.23.6")).toBe("patch");
+  });
+
+  it("treats RC transitions by their core change", () => {
+    expect(determineReleaseBump("0.23.5", "0.24.0-rc.0")).toBe("minor");
+    expect(determineReleaseBump("0.23.5", "0.23.6-rc.0")).toBe("patch");
+  });
+
+  it("reports prerelease when only the prerelease identifier changes", () => {
+    expect(determineReleaseBump("0.24.0-rc.0", "0.24.0-rc.1")).toBe("prerelease");
+    expect(determineReleaseBump("0.24.0-rc.0", "0.24.0")).toBe("prerelease");
+  });
+});
+
+describe("checkBumpAllowedOnBranch", () => {
+  it("main rejects patch releases", () => {
+    expect(checkBumpAllowedOnBranch("main", "patch").ok).toBe(false);
+  });
+
+  it("main allows minor, major, initial, and prerelease", () => {
+    expect(checkBumpAllowedOnBranch("main", "minor").ok).toBe(true);
+    expect(checkBumpAllowedOnBranch("main", "major").ok).toBe(true);
+    expect(checkBumpAllowedOnBranch("main", "initial").ok).toBe(true);
+    expect(checkBumpAllowedOnBranch("main", "prerelease").ok).toBe(true);
+  });
+
+  it("release branches reject minor and major releases", () => {
+    expect(checkBumpAllowedOnBranch("release/0.23", "minor").ok).toBe(false);
+    expect(checkBumpAllowedOnBranch("release/0.23", "major").ok).toBe(false);
+  });
+
+  it("release branches allow patch, initial, and prerelease", () => {
+    expect(checkBumpAllowedOnBranch("release/0.23", "patch").ok).toBe(true);
+    expect(checkBumpAllowedOnBranch("release/0.23", "initial").ok).toBe(true);
+    expect(checkBumpAllowedOnBranch("release/0.23", "prerelease").ok).toBe(true);
+  });
+
+  it("does not gate branches that are neither main nor release/*", () => {
+    expect(checkBumpAllowedOnBranch("some-topic-branch", "patch").ok).toBe(true);
+    expect(checkBumpAllowedOnBranch("some-topic-branch", "minor").ok).toBe(true);
   });
 });

--- a/packages/monorepo/release/src/ciPublish.ts
+++ b/packages/monorepo/release/src/ciPublish.ts
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
+import { getPackages } from "@manypkg/get-packages";
 import consola from "consola";
 import { execa } from "execa";
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { join } from "path";
 import semver from "semver";
+import { packageVersionsOrEmptySet } from "./publishPackages.js";
 
 async function ciPublish(): Promise<void> {
   let tag = "latest";
   const repoRoot = process.cwd();
   const preJsonPath = join(repoRoot, ".changeset", "pre.json");
+  const currentBranch = await getCurrentBranch();
 
   if (existsSync(preJsonPath)) {
     try {
@@ -41,10 +44,15 @@ async function ciPublish(): Promise<void> {
     }
   } else {
     const remoteBranches = await getRemoteBranches();
-    const currentBranch = await getCurrentBranch();
     const greatestVersion = findGreatestVersion(remoteBranches);
     tag = determineTag(currentBranch, greatestVersion, tag);
   }
+
+  // Enforce the branching model (main = minor/major, release/* = patch) against the
+  // concrete versions about to be published. This is the authoritative gate: it runs
+  // on the protected destination branch and cannot be bypassed by how the release
+  // commit/PR was prepared.
+  await assertReleaseAllowedOnBranch(repoRoot, currentBranch);
 
   consola.info(`Publishing with tag: ${tag}`);
 
@@ -94,6 +102,165 @@ async function getCurrentBranch(): Promise<string> {
     "HEAD",
   ], { cwd: repoRoot });
   return stdout;
+}
+
+export type ReleaseBump = "initial" | "major" | "minor" | "patch" | "prerelease";
+
+// Higher rank = more significant. Used to reduce a set of per-package bumps down to a
+// single release-level bump (safe under fixed uni-versioning, where all published
+// packages move together).
+const BUMP_RANK: Record<ReleaseBump, number> = {
+  major: 4,
+  minor: 3,
+  patch: 2,
+  prerelease: 1,
+  initial: 0,
+};
+
+/**
+ * Returns the highest published version strictly below `local`, or null if there is
+ * none. Using "highest below local" (rather than the `latest` dist-tag) keeps the
+ * comparison correct per release line even when main is ahead of a release branch.
+ */
+export function highestVersionBelow(
+  local: string,
+  published: Set<string>,
+): string | null {
+  let highest: string | null = null;
+  for (const candidate of published) {
+    if (!semver.valid(candidate) || semver.gte(candidate, local)) {
+      continue;
+    }
+    if (highest == null || semver.gt(candidate, highest)) {
+      highest = candidate;
+    }
+  }
+  return highest;
+}
+
+/**
+ * Derives the bump type from the numeric major.minor.patch core, so RC/beta prerelease
+ * versions are handled naturally (e.g. `0.23.5 -> 0.24.0-rc.0` is a minor). A null
+ * `prev` (package not yet published) is an `initial` release. Equal cores (only the
+ * prerelease identifier differs) are reported as `prerelease`.
+ */
+export function determineReleaseBump(
+  prev: string | null,
+  local: string,
+): ReleaseBump {
+  if (prev == null) {
+    return "initial";
+  }
+  const prevParsed = semver.parse(prev);
+  const localParsed = semver.parse(local);
+  if (!prevParsed || !localParsed) {
+    throw new Error(`Unable to parse versions for bump: ${prev} -> ${local}`);
+  }
+  if (localParsed.major > prevParsed.major) {
+    return "major";
+  }
+  if (
+    localParsed.major === prevParsed.major
+    && localParsed.minor > prevParsed.minor
+  ) {
+    return "minor";
+  }
+  if (
+    localParsed.major === prevParsed.major
+    && localParsed.minor === prevParsed.minor
+    && localParsed.patch > prevParsed.patch
+  ) {
+    return "patch";
+  }
+  return "prerelease";
+}
+
+/**
+ * Enforces the branching model: main only cuts minor/major releases, release/* only
+ * cuts patch releases. `initial` (brand-new package) and `prerelease` (core unchanged)
+ * do not move the constrained core and are allowed anywhere. Branches that are neither
+ * main nor release/* are not gated.
+ */
+export function checkBumpAllowedOnBranch(
+  branch: string,
+  bump: ReleaseBump,
+): { ok: true } | { ok: false; reason: string } {
+  if (bump === "initial" || bump === "prerelease") {
+    return { ok: true };
+  }
+
+  if (branch === "main") {
+    if (bump === "patch") {
+      return {
+        ok: false,
+        reason: "Refusing to publish a patch release from main. Our branching model only "
+          + "cuts minor/major releases from main; patches must come from a release/* branch.",
+      };
+    }
+    return { ok: true };
+  }
+
+  if (branch.startsWith("release/")) {
+    if (bump === "minor" || bump === "major") {
+      return {
+        ok: false,
+        reason: `Refusing to publish a ${bump} release from a release branch (${branch}). `
+          + "Our branching model only cuts patch releases from release/* branches; "
+          + "minor/major releases must come from main.",
+      };
+    }
+    return { ok: true };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Computes the release-level bump for the packages that will actually be published
+ * (public, and whose local version is not already on npm), or null if none will
+ * publish.
+ */
+export async function computeReleaseBump(
+  cwd: string,
+): Promise<ReleaseBump | null> {
+  const { packages } = await getPackages(cwd);
+  const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
+
+  let releaseBump: ReleaseBump | null = null;
+  for (const pkg of publicPackages) {
+    const { name, version } = pkg.packageJson;
+    const published = await packageVersionsOrEmptySet(name);
+    if (published.has(version)) {
+      // Already on npm; `pnpm publish` will skip it, so it isn't part of this release.
+      continue;
+    }
+    const bump = determineReleaseBump(
+      highestVersionBelow(version, published),
+      version,
+    );
+    if (releaseBump == null || BUMP_RANK[bump] > BUMP_RANK[releaseBump]) {
+      releaseBump = bump;
+    }
+  }
+  return releaseBump;
+}
+
+async function assertReleaseAllowedOnBranch(
+  cwd: string,
+  branch: string,
+): Promise<void> {
+  const releaseBump = await computeReleaseBump(cwd);
+  if (releaseBump == null) {
+    consola.info("No unpublished packages found; skipping branch/bump gate.");
+    return;
+  }
+
+  consola.info(`Release bump for branch "${branch}": ${releaseBump}`);
+  const result = checkBumpAllowedOnBranch(branch, releaseBump);
+  if (!result.ok) {
+    consola.error(result.reason);
+    process.exit(1);
+  }
 }
 
 export function findGreatestVersion(releaseBranches: string[]): string | null {

--- a/packages/monorepo/release/src/gitUtils.ts
+++ b/packages/monorepo/release/src/gitUtils.ts
@@ -112,3 +112,68 @@ export const checkIfClean = async (): Promise<boolean> => {
   const { stdout } = await getExecOutput("git", ["status", "--porcelain"]);
   return !stdout.length;
 };
+
+/**
+ * Detects whether the current (topic) branch was forked from `main` or a `release/*`
+ * branch, by comparing merge-base distances against `origin/main` and each
+ * `origin/release/*`. The closest base (fewest commits since the merge-base) wins.
+ *
+ * Used to apply the correct branching-model rules for the version-commit flow, where
+ * the checked-out branch has an arbitrary name. Best-effort and defaults to "main" if
+ * detection is inconclusive (the authoritative gate runs later in CI before publish).
+ */
+export const detectBaseBranchType = async (): Promise<
+  "main" | "release branch"
+> => {
+  // Best-effort refresh of the refs we compare against; tolerate being offline.
+  await exec(
+    "git",
+    [
+      "fetch",
+      "--quiet",
+      "origin",
+      "refs/heads/main:refs/remotes/origin/main",
+      "refs/heads/release/*:refs/remotes/origin/release/*",
+    ],
+    { ignoreReturnCode: true },
+  );
+
+  const { stdout: refsOut } = await getExecOutput(
+    "git",
+    [
+      "for-each-ref",
+      "--format=%(refname:short)",
+      "refs/remotes/origin/main",
+      "refs/remotes/origin/release/*",
+    ],
+    { ignoreReturnCode: true, silent: true },
+  );
+  const refs = refsOut.split("\n").map(line => line.trim()).filter(Boolean);
+
+  let bestDistance = Infinity;
+  let baseType: "main" | "release branch" = "main";
+  for (const ref of refs) {
+    const mergeBase = await getExecOutput("git", ["merge-base", "HEAD", ref], {
+      ignoreReturnCode: true,
+      silent: true,
+    });
+    if (mergeBase.exitCode !== 0) {
+      continue;
+    }
+    const distance = await getExecOutput(
+      "git",
+      ["rev-list", "--count", `${mergeBase.stdout.trim()}..HEAD`],
+      { ignoreReturnCode: true, silent: true },
+    );
+    if (distance.exitCode !== 0) {
+      continue;
+    }
+    const commits = Number.parseInt(distance.stdout.trim(), 10);
+    if (Number.isNaN(commits) || commits >= bestDistance) {
+      continue;
+    }
+    bestDistance = commits;
+    baseType = ref.includes("/release/") ? "release branch" : "main";
+  }
+  return baseType;
+};

--- a/packages/monorepo/release/src/gitUtils.ts
+++ b/packages/monorepo/release/src/gitUtils.ts
@@ -118,12 +118,15 @@ export const checkIfClean = async (): Promise<boolean> => {
  * branch, by comparing merge-base distances against `origin/main` and each
  * `origin/release/*`. The closest base (fewest commits since the merge-base) wins.
  *
- * Used to apply the correct branching-model rules for the version-commit flow, where
- * the checked-out branch has an arbitrary name. Best-effort and defaults to "main" if
- * detection is inconclusive (the authoritative gate runs later in CI before publish).
+ * Returns "ambiguous" when the closest `main` and `release/*` candidates tie — e.g. HEAD
+ * was forked from a commit that is the tip of both `main` and a freshly-cut `release/*`
+ * branch (the first patch on a new release line). Topology cannot disambiguate that from
+ * the first minor on `main` after cutting the branch, so callers must fall back to an
+ * explicit choice. Also "ambiguous" if no candidate refs resolve. Best-effort: refs that
+ * cannot be resolved are skipped.
  */
 export const detectBaseBranchType = async (): Promise<
-  "main" | "release branch"
+  "main" | "release branch" | "ambiguous"
 > => {
   // Best-effort refresh of the refs we compare against; tolerate being offline.
   await exec(
@@ -150,8 +153,8 @@ export const detectBaseBranchType = async (): Promise<
   );
   const refs = refsOut.split("\n").map(line => line.trim()).filter(Boolean);
 
-  let bestDistance = Infinity;
-  let baseType: "main" | "release branch" = "main";
+  let minMainDistance = Infinity;
+  let minReleaseDistance = Infinity;
   for (const ref of refs) {
     const mergeBase = await getExecOutput("git", ["merge-base", "HEAD", ref], {
       ignoreReturnCode: true,
@@ -169,11 +172,23 @@ export const detectBaseBranchType = async (): Promise<
       continue;
     }
     const commits = Number.parseInt(distance.stdout.trim(), 10);
-    if (Number.isNaN(commits) || commits >= bestDistance) {
+    if (Number.isNaN(commits)) {
       continue;
     }
-    bestDistance = commits;
-    baseType = ref.includes("/release/") ? "release branch" : "main";
+    if (ref.includes("/release/")) {
+      minReleaseDistance = Math.min(minReleaseDistance, commits);
+    } else {
+      minMainDistance = Math.min(minMainDistance, commits);
+    }
   }
-  return baseType;
+
+  if (minReleaseDistance < minMainDistance) {
+    return "release branch";
+  }
+  if (minMainDistance < minReleaseDistance) {
+    return "main";
+  }
+  // Tie (HEAD sits on a commit shared by main and a release branch) or nothing
+  // resolved: topology cannot decide, so require the caller to choose explicitly.
+  return "ambiguous";
 };

--- a/packages/monorepo/release/src/publishPackages.ts
+++ b/packages/monorepo/release/src/publishPackages.ts
@@ -14,105 +14,13 @@
  * limitations under the License.
  */
 
-import type { AccessType, Config } from "@changesets/types";
-import type { Package } from "@manypkg/get-packages";
-import { getPackages } from "@manypkg/get-packages";
-import chalk from "chalk";
-import { consola } from "consola";
-import { execa } from "execa";
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
-import type { Octokit } from "octokit";
-import pFilter from "p-filter";
-import pMap from "p-map";
 import { PackageNotFoundError } from "package-json";
 import packageVersionsOrThrow from "pkg-versions";
 
-// Honestly I don't know that we need this file since `pnpm publish -r` is a thing
-
-export type PublishedResult = {
-  name: string;
-  newVersion: string;
-  published: boolean;
-};
-
-export async function publishPackages(
-  cwd: string,
-  { tag, gitTag = true }: { tag?: string; gitTag?: boolean },
-  config: Config,
-  octokit: Octokit,
-): Promise<PublishedResult[]> {
-  const releaseTag = tag && tag.length > 0 ? tag : "latest";
-  const { packages, tool } = await getPackages(cwd);
-
-  const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
-  const unpublishedPackagesInfo = await getUnpublishedPackages(publicPackages);
-
-  const r = await pMap(
-    unpublishedPackagesInfo,
-    async pkg => await publishSinglePackage(pkg, config.access, releaseTag),
-    { concurrency: 4 },
-  );
-
-  // need to produce the output to save for future run of create tag/release
-  await fs.writeFile(
-    path.join(cwd, "pnpm-publish-summary.json"),
-    JSON.stringify(
-      {
-        publishedPackages: r.filter(x => x.published).map(x => ({
-          name: x.name,
-          version: x.newVersion,
-        })),
-      },
-      null,
-      2,
-    ),
-  );
-
-  return r;
-}
-
-async function execPnpmPublish(
-  { cwd, tag, access }: { cwd: string; tag: string; access: AccessType },
-) {
-  const result = await execa("pnpm", [
-    "publish",
-    "--json",
-    "--tag",
-    "--dry-run",
-    tag,
-    "--no-git-checks",
-  ], { cwd });
-
-  if (result.exitCode !== 0) {
-    consola.error(
-      `Failed to publish ${chalk.cyan(cwd)} with error: ${result.stderr}`,
-    );
-    return false;
-  }
-
-  consola.success(`Published ${chalk.cyan(cwd)} with tag ${chalk.green(tag)}`);
-
-  return true;
-}
-
-async function publishSinglePackage(
-  pkg: Package,
-  access: AccessType,
-  tag: string,
-): Promise<PublishedResult> {
-  const { name, version, publishConfig } = pkg.packageJson;
-  consola.info(
-    `Publishing ${chalk.cyan(`"${name}"`)} at ${chalk.green(`"${version}"`)}`,
-  );
-
-  return {
-    name,
-    newVersion: version,
-    published: await execPnpmPublish({ cwd: pkg.dir, tag, access }),
-  };
-}
-
+/**
+ * Returns the set of versions published to npm for `name`, or an empty set if the
+ * package has never been published.
+ */
 export async function packageVersionsOrEmptySet(
   name: string,
 ): Promise<Set<string>> {
@@ -124,22 +32,4 @@ export async function packageVersionsOrEmptySet(
     }
     throw e;
   }
-}
-
-async function getUnpublishedPackages(packages: Array<Package>) {
-  return pFilter(packages, async pkg => {
-    const { name, version } = pkg.packageJson;
-    const versions = await packageVersionsOrEmptySet(name);
-    if (versions.has(version)) {
-      consola.info(
-        `${name} is being published because our local version (${version}) has not been published on npm`,
-      );
-      return true;
-    } else {
-      consola.warn(
-        `${name} is not being published because version ${version} is already published on npm`,
-      );
-      return false;
-    }
-  });
 }

--- a/packages/monorepo/release/src/runVersionCommit.ts
+++ b/packages/monorepo/release/src/runVersionCommit.ts
@@ -25,6 +25,7 @@ import { getPackages } from "@manypkg/get-packages";
 import { consola } from "consola";
 import { FailedWithUserMessage } from "./FailedWithUserMessage.js";
 import * as gitUtils from "./gitUtils.js";
+import { mutateReleasePlan } from "./mutateReleasePlan.js";
 import { packageVersionsOrEmptySet } from "./publishPackages.js";
 import { getChangedPackages } from "./util/getChangedPackages.js";
 import { getVersionsByDirectory } from "./util/getVersionsByDirectory.js";
@@ -99,9 +100,16 @@ export async function runVersionCommit({
     preState,
   );
 
-  // Use the branch from environment or default to "main"
-  // const branchType = process.env.VERSION_COMMIT_BRANCH_TYPE ?? "main";
-  // mutateReleasePlan(cwd, releasePlan, branchType);
+  // Soft, early enforcement of the branching model. The authoritative gate runs in CI
+  // before publish (see ciPublish.ts); this catches violations locally and points at
+  // the offending changeset. The base-branch type is detected from git so it is correct
+  // regardless of entry point; VERSION_COMMIT_BRANCH_TYPE can override the detection.
+  const branchTypeOverride = process.env.VERSION_COMMIT_BRANCH_TYPE;
+  const branchType: "main" | "release branch" =
+    branchTypeOverride === "release branch" || branchTypeOverride === "main"
+      ? branchTypeOverride
+      : await gitUtils.detectBaseBranchType();
+  mutateReleasePlan(cwd, releasePlan, branchType);
 
   for (const release of releasePlan.releases) {
     const versions = await packageVersionsOrEmptySet(release.name);

--- a/packages/monorepo/release/src/runVersionCommit.ts
+++ b/packages/monorepo/release/src/runVersionCommit.ts
@@ -105,10 +105,23 @@ export async function runVersionCommit({
   // the offending changeset. The base-branch type is detected from git so it is correct
   // regardless of entry point; VERSION_COMMIT_BRANCH_TYPE can override the detection.
   const branchTypeOverride = process.env.VERSION_COMMIT_BRANCH_TYPE;
-  const branchType: "main" | "release branch" =
-    branchTypeOverride === "release branch" || branchTypeOverride === "main"
-      ? branchTypeOverride
-      : await gitUtils.detectBaseBranchType();
+  let branchType: "main" | "release branch";
+  if (branchTypeOverride === "release branch" || branchTypeOverride === "main") {
+    branchType = branchTypeOverride;
+  } else {
+    const detected = await gitUtils.detectBaseBranchType();
+    if (detected === "ambiguous") {
+      throw new FailedWithUserMessage(
+        "Could not determine whether this release targets main or a release branch: "
+          + "HEAD descends from a commit that is on both (e.g. the first patch on a "
+          + "freshly-cut release branch). Re-run specifying the base, for example:\n"
+          + "  ./scripts/createReleaseCommit.sh release\n"
+          + "  ./scripts/createReleaseCommit.sh main\n"
+          + `or set VERSION_COMMIT_BRANCH_TYPE to "main" or "release branch".`,
+      );
+    }
+    branchType = detected;
+  }
   mutateReleasePlan(cwd, releasePlan, branchType);
 
   for (const release of releasePlan.releases) {

--- a/scripts/createReleaseCommit.sh
+++ b/scripts/createReleaseCommit.sh
@@ -5,13 +5,24 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cd "${SCRIPT_DIR}/../"
 
+# Optional base selector: `main` or `release`. The tool enforces the branching model
+# (main = minor/major, release/* = patch) and normally auto-detects the base, but when
+# HEAD sits on a commit shared by main and a release branch (e.g. the first patch on a
+# freshly-cut release branch) detection is ambiguous and must be told explicitly.
+case "${1:-}" in
+  main) export VERSION_COMMIT_BRANCH_TYPE="main" ;;
+  release) export VERSION_COMMIT_BRANCH_TYPE="release branch" ;;
+  "") : ;; # no arg: honor any pre-set VERSION_COMMIT_BRANCH_TYPE, else auto-detect
+  *)
+    echo "Usage: $0 [main|release]"
+    exit 1
+    ;;
+esac
+
 # Build the release tool
 pnpm exec turbo transpile --filter "./packages/monorepo/release"
 
 # Run version bump and create commit on current branch with version digest.
-# The tool enforces the branching model (main = minor/major, release/* = patch),
-# auto-detecting whether this branch was forked from main or a release/* branch. Set
-# VERSION_COMMIT_BRANCH_TYPE ("main" | "release branch") to override the detection.
 node ./packages/monorepo/release/build/esm/index.js \
   --mode version-commit
 

--- a/scripts/createReleaseCommit.sh
+++ b/scripts/createReleaseCommit.sh
@@ -8,7 +8,10 @@ cd "${SCRIPT_DIR}/../"
 # Build the release tool
 pnpm exec turbo transpile --filter "./packages/monorepo/release"
 
-# Run version bump and create commit on current branch with version digest
+# Run version bump and create commit on current branch with version digest.
+# The tool enforces the branching model (main = minor/major, release/* = patch),
+# auto-detecting whether this branch was forked from main or a release/* branch. Set
+# VERSION_COMMIT_BRANCH_TYPE ("main" | "release branch") to override the detection.
 node ./packages/monorepo/release/build/esm/index.js \
   --mode version-commit
 


### PR DESCRIPTION
Changes to RELEASING.md document the process we should follow (minor releases on `main`, patch releases on `release/**`), and the changes to the scripts try to encode/validate this logic is being followed when cutting releases.