### PR TITLE
Record validation and error propagation

### DIFF
--- a/.changeset/record-schema-validation.md
+++ b/.changeset/record-schema-validation.md
@@ -1,0 +1,7 @@
+---
+"@palantir/pack.document-schema.model-types": minor
+"@palantir/pack.state.core": minor
+"@palantir/pack.state.react": minor
+---
+
+Record snapshots are now validated against their model's zod schema at read time, so corrupted document state can be observed and handled gracefully instead of crashing consumers. Invalid records are withheld from `onChange` delivery and surfaced through the new `RecordRef.onInvalid` / `onRecordInvalid` subscriptions, a new `"invalid"` status (with a `RecordValidationError`) on `useRecord`, `getInvalidRecords` on the state module/document service (returning the known invalid records observed so far, re-validated and pruned on each call), and an `invalidRecordCount` on the data channel of `DocumentStatus`. `RecordRef.getSnapshot` now rejects with `RecordInvalidError` when the record exists but fails validation. Records repaired by a later update automatically resume `onChange` delivery. Exceptions thrown during snapshot computation (e.g. an upgrade lens applied to corrupt data) are contained and reported as invalid records rather than escaping into notification fan-out; `updateRecord` rejects with `RecordInvalidError` for unreadable records, while `deleteRecord` remains usable on them so delete-and-recreate repair works.

--- a/packages/document-schema/model-types/src/index.ts
+++ b/packages/document-schema/model-types/src/index.ts
@@ -80,6 +80,8 @@ export { RecordCollectionRefBrand } from "./types/RecordCollectionRef.js";
 export type { RecordCollectionRef } from "./types/RecordCollectionRef.js";
 export { RecordRefBrand } from "./types/RecordRef.js";
 export type { RecordId, RecordRef } from "./types/RecordRef.js";
+export { RecordInvalidError } from "./types/RecordValidation.js";
+export type { RecordValidationError, RecordValidationIssue } from "./types/RecordValidation.js";
 export type { Unsubscribe } from "./types/Unsubscribe.js";
 export type {
   FieldDef,

--- a/packages/document-schema/model-types/src/types/RecordRef.ts
+++ b/packages/document-schema/model-types/src/types/RecordRef.ts
@@ -17,6 +17,7 @@
 import type { Flavored } from "@palantir/pack.core";
 import type { DocumentRef } from "./DocumentRef.js";
 import type { Model, ModelData } from "./Model.js";
+import type { RecordValidationError } from "./RecordValidation.js";
 import type { Unsubscribe } from "./Unsubscribe.js";
 
 export type RecordId = Flavored<"RecordId">;
@@ -75,6 +76,33 @@ export interface RecordRef<M extends Model = Model> {
    * ```
    */
   onChange(callback: (snapshot: ModelData<M>, recordRef: RecordRef<M>) => void): Unsubscribe;
+
+  /**
+   * Subscribe to schema-validation failures for the record.
+   *
+   * If the record's stored data cannot be validated against the model's
+   * schema (for example, after a partial write left the document in a
+   * corrupted state), `onChange` subscribers are NOT called with the invalid
+   * data; instead, callbacks registered here receive a
+   * {@link RecordValidationError} describing the failure. If the record is
+   * later repaired by a subsequent update, `onChange` resumes firing.
+   *
+   * If the record is already invalid at subscription time, the callback is
+   * invoked immediately.
+   *
+   * @param callback The callback to invoke when the record fails validation.
+   * @returns An unsubscribe function.
+   *
+   * @example
+   * ```ts
+   * recordRef.onInvalid((error, recordRef) => {
+   *   console.warn("Record failed validation:", error.issues);
+   * });
+   * ```
+   */
+  onInvalid(
+    callback: (error: RecordValidationError, recordRef: RecordRef<M>) => void,
+  ): Unsubscribe;
 
   /**
    * Subscribe to deletion of the record.

--- a/packages/document-schema/model-types/src/types/RecordValidation.ts
+++ b/packages/document-schema/model-types/src/types/RecordValidation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/document-schema/model-types/src/types/RecordValidation.ts
+++ b/packages/document-schema/model-types/src/types/RecordValidation.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RecordId } from "./RecordRef.js";
+
+/**
+ * A single schema-validation failure within a record snapshot.
+ */
+export interface RecordValidationIssue {
+  /** Path of the failing field within the record (empty for record-level issues). */
+  readonly path: ReadonlyArray<string | number>;
+  /** Human-readable description of the failure. */
+  readonly message: string;
+}
+
+/**
+ * Describes why a record's stored data failed schema validation against its
+ * model.
+ *
+ * Delivered to {@link RecordRef.onInvalid} subscribers and queryable per
+ * document via `getInvalidRecords`. A record can become invalid when the
+ * document's persisted state does not match what the model's schema promises
+ * (for example, after a partial write left the document corrupted).
+ */
+export interface RecordValidationError {
+  /** Name of the model the record was expected to conform to. */
+  readonly modelName: string;
+  /** Id of the failing record. */
+  readonly recordId: RecordId;
+  /** Individual field-level failures. */
+  readonly issues: readonly RecordValidationIssue[];
+  /** Summary message suitable for logging. */
+  readonly message: string;
+}
+
+/**
+ * Error used to reject promise-based snapshot reads (e.g.
+ * {@link RecordRef.getSnapshot}) when the record exists but its data fails
+ * schema validation.
+ */
+export class RecordInvalidError extends Error {
+  readonly validation: RecordValidationError;
+
+  constructor(validation: RecordValidationError) {
+    super(validation.message);
+    this.name = "RecordInvalidError";
+    this.validation = validation;
+  }
+}

--- a/packages/state/core/src/__tests__/RecordValidation.test.ts
+++ b/packages/state/core/src/__tests__/RecordValidation.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/state/core/src/__tests__/RecordValidation.test.ts
+++ b/packages/state/core/src/__tests__/RecordValidation.test.ts
@@ -466,6 +466,42 @@ describe("Record schema validation", () => {
     expect(userInvalidCount).toBe(0);
     unsubscribe();
   });
+
+  it("notifies a new onInvalid subscriber without re-notifying existing ones", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-multi-invalid-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    let countA = 0;
+    let countB = 0;
+    const unsubscribeA = stateModule.onRecordInvalid(recordRef, () => {
+      countA++;
+    });
+
+    corruptRecord(documentId, userId);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(countA).toBe(1);
+
+    // B joins an already-invalid record: B is notified, A is not re-notified.
+    const unsubscribeB = stateModule.onRecordInvalid(recordRef, () => {
+      countB++;
+    });
+    expect(countB).toBe(1);
+    expect(countA).toBe(1);
+
+    // After A unsubscribes, a repair clears tracking and neither A nor B fire again.
+    unsubscribeA();
+    await stateModule.setRecord(recordRef, VALID_USER);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(countA).toBe(1);
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(0);
+
+    unsubscribeB();
+  });
 });
 describe("Record schema validation with a throwing upgrade lens", () => {
   let app: PackAppInternal;

--- a/packages/state/core/src/__tests__/RecordValidation.test.ts
+++ b/packages/state/core/src/__tests__/RecordValidation.test.ts
@@ -1,0 +1,688 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { PackAppInternal } from "@palantir/pack.core";
+import type {
+  DocumentId,
+  DocumentSchema,
+  Model,
+  RecordId,
+  RecordValidationError,
+  UpgradeFns,
+  UpgradeRegistry,
+} from "@palantir/pack.document-schema.model-types";
+import { Metadata, RecordInvalidError } from "@palantir/pack.document-schema.model-types";
+import { beforeEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { z } from "zod";
+import { DOCUMENT_SERVICE_MODULE_KEY } from "../DocumentServiceModule.js";
+import type { BaseYjsDocumentService } from "../service/BaseYjsDocumentService.js";
+import { createDocRef } from "../types/DocumentRefImpl.js";
+import { getStateModule } from "../types/StateModule.js";
+import { createTestApp } from "./testUtils.js";
+
+interface User {
+  id: string;
+  name: string;
+  age: number;
+}
+
+const createSchemaWithUser = () => {
+  const userSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    age: z.number().int().positive(),
+  });
+
+  const UserModel: Model<User, typeof userSchema> = {
+    __type: {} as User,
+    zodSchema: userSchema,
+    [Metadata]: {
+      name: "User",
+    },
+  };
+
+  return {
+    User: UserModel,
+    [Metadata]: {
+      version: 1,
+    },
+  } as const satisfies DocumentSchema;
+};
+
+const VALID_USER: User = {
+  id: "user_1",
+  name: "Jane Doe",
+  age: 30,
+};
+
+describe("Record schema validation", () => {
+  let app: PackAppInternal;
+
+  beforeEach(() => {
+    app = createTestApp();
+  });
+
+  /**
+   * Reproduces the corruption scenario: a record exists in the Y.Doc but its
+   * content does not match the model schema (e.g. an empty object after a
+   * partial/failed write).
+   */
+  function corruptRecord(documentId: DocumentId, recordId: RecordId): void {
+    const docService = app.getModule(DOCUMENT_SERVICE_MODULE_KEY);
+    const yDoc = (docService as BaseYjsDocumentService).getYDocForTesting(documentId);
+    if (!yDoc) {
+      throw new Error("Y.Doc not found for document ID: " + documentId);
+    }
+    yDoc.transact(() => {
+      yDoc.getMap("User").set(recordId as string, new Y.Map());
+    }, "remote");
+  }
+
+  it("delivers valid snapshots to onChange and does not call onInvalid", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-valid-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    let changedCount = 0;
+    let invalidCount = 0;
+
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, () => {
+      changedCount++;
+    });
+    const unsubscribeInvalid = stateModule.onRecordInvalid(recordRef, () => {
+      invalidCount++;
+    });
+
+    await stateModule.setRecord(recordRef, VALID_USER);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(changedCount).toBeGreaterThan(0);
+    expect(invalidCount).toBe(0);
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(0);
+
+    unsubscribeChanged();
+    unsubscribeInvalid();
+  });
+
+  it("withholds invalid snapshots from onChange and notifies onInvalid", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-invalid-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    const changedSnapshots: unknown[] = [];
+    let lastError: RecordValidationError | undefined;
+
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, snapshot => {
+      changedSnapshots.push(snapshot);
+    });
+    const unsubscribeInvalid = stateModule.onRecordInvalid(recordRef, error => {
+      lastError = error;
+    });
+
+    corruptRecord(documentId, userId);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(changedSnapshots).toHaveLength(0);
+    expect(lastError).toBeDefined();
+    expect(lastError?.modelName).toBe("User");
+    expect(lastError?.recordId).toBe(userId);
+    expect(lastError?.issues.length).toBeGreaterThan(0);
+
+    const invalidRecords = stateModule.getInvalidRecords(docRef);
+    expect(invalidRecords).toHaveLength(1);
+    expect(invalidRecords[0]).toMatchObject({ modelName: "User", recordId: userId });
+
+    unsubscribeChanged();
+    unsubscribeInvalid();
+  });
+
+  it("contains schemas whose synchronous safeParse throws", async () => {
+    const asyncUserSchema = z.object({
+      id: z.string(),
+      name: z.string(),
+      age: z.number().int().positive(),
+    }).refine(() => Promise.resolve(true));
+    const AsyncUserModel: Model<User, typeof asyncUserSchema> = {
+      __type: {} as User,
+      zodSchema: asyncUserSchema,
+      [Metadata]: { name: "User" },
+    };
+    const schema = {
+      User: AsyncUserModel,
+      [Metadata]: { version: 1 },
+    } as const satisfies DocumentSchema;
+
+    const documentId = "validation-async-schema-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+    const recordRef = stateModule.createRecordRef(docRef, "user_1" as RecordId, schema.User);
+
+    let changedCount = 0;
+    let validationError: RecordValidationError | undefined;
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, () => {
+      changedCount++;
+    });
+    const unsubscribeInvalid = stateModule.onRecordInvalid(recordRef, error => {
+      validationError = error;
+    });
+
+    await expect(stateModule.setRecord(recordRef, VALID_USER)).resolves.toBeUndefined();
+
+    expect(changedCount).toBe(0);
+    expect(validationError?.issues[0]?.message).toContain("schema validation threw");
+    await expect(recordRef.getSnapshot()).rejects.toBeInstanceOf(RecordInvalidError);
+
+    unsubscribeChanged();
+    unsubscribeInvalid();
+  });
+
+  it("notifies onInvalid immediately when subscribing to an already-invalid record", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-late-sub-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    // Load the document via a subscription, then corrupt the record.
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, () => {});
+    corruptRecord(documentId, userId);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    let lastError: RecordValidationError | undefined;
+    const unsubscribeInvalid = stateModule.onRecordInvalid(recordRef, error => {
+      lastError = error;
+    });
+
+    expect(lastError).toBeDefined();
+    expect(lastError?.recordId).toBe(userId);
+
+    unsubscribeChanged();
+    unsubscribeInvalid();
+  });
+
+  it("rejects getSnapshot with RecordInvalidError for invalid records", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-snapshot-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    // Load the document via a subscription, then corrupt the record.
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, () => {});
+    corruptRecord(documentId, userId);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    await expect(recordRef.getSnapshot()).rejects.toBeInstanceOf(RecordInvalidError);
+    await expect(recordRef.getSnapshot()).rejects.toMatchObject({
+      validation: {
+        modelName: "User",
+        recordId: userId,
+      },
+    });
+
+    unsubscribeChanged();
+  });
+
+  it("resumes onChange delivery and clears tracking when the record is repaired", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-repair-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    const changedSnapshots: unknown[] = [];
+    let invalidCount = 0;
+
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, snapshot => {
+      changedSnapshots.push(snapshot);
+    });
+    const unsubscribeInvalid = stateModule.onRecordInvalid(recordRef, () => {
+      invalidCount++;
+    });
+
+    corruptRecord(documentId, userId);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(changedSnapshots).toHaveLength(0);
+    expect(invalidCount).toBeGreaterThan(0);
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(1);
+
+    // Repair the record with valid data.
+    await stateModule.setRecord(recordRef, VALID_USER);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(changedSnapshots.length).toBeGreaterThan(0);
+    expect(changedSnapshots[changedSnapshots.length - 1]).toMatchObject(VALID_USER);
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(0);
+
+    unsubscribeChanged();
+    unsubscribeInvalid();
+  });
+
+  it("reports invalidRecordCount on the data channel status", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-status-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, () => {});
+
+    corruptRecord(documentId, userId);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(stateModule.getDocumentStatus(docRef).data.invalidRecordCount).toBe(1);
+
+    await stateModule.setRecord(recordRef, VALID_USER);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(stateModule.getDocumentStatus(docRef).data.invalidRecordCount).toBeUndefined();
+
+    unsubscribeChanged();
+  });
+
+  it("self-heals stale tracking when queried after a subscription-free repair", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-self-heal-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    // Track the corruption while a subscription exists...
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, () => {});
+    corruptRecord(documentId, userId);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(1);
+
+    // ...then drop all subscriptions and repair without any listener installed.
+    unsubscribeChanged();
+    await stateModule.setRecord(recordRef, VALID_USER);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // The pull API re-validates and prunes the stale entry.
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(0);
+    expect(stateModule.getDocumentStatus(docRef).data.invalidRecordCount).toBeUndefined();
+  });
+
+  it("clears a cached failure when subscribing after a subscription-free repair", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-resubscribe-repair-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    const unsubscribeInitial = stateModule.onRecordChanged(recordRef, () => {});
+    corruptRecord(documentId, userId);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(1);
+
+    unsubscribeInitial();
+    await stateModule.setRecord(recordRef, VALID_USER);
+
+    let repairedSnapshot: User | undefined;
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, snapshot => {
+      repairedSnapshot = snapshot;
+    });
+
+    expect(repairedSnapshot).toEqual(VALID_USER);
+    expect(stateModule.getDocumentStatus(docRef).data.invalidRecordCount).toBeUndefined();
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(0);
+
+    let invalidCount = 0;
+    const unsubscribeInvalid = stateModule.onRecordInvalid(recordRef, () => {
+      invalidCount++;
+    });
+
+    expect(invalidCount).toBe(0);
+
+    unsubscribeChanged();
+    unsubscribeInvalid();
+  });
+
+  it("clears tracking when an invalid record is deleted without subscribers", async () => {
+    const schema = createSchemaWithUser();
+    const documentId = "validation-delete-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_1" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, () => {});
+    corruptRecord(documentId, userId);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(1);
+    unsubscribeChanged();
+
+    await stateModule.deleteRecord(recordRef);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(0);
+  });
+
+  it("tracks records with the same id under different models independently", async () => {
+    const userSchema = z.object({
+      id: z.string(),
+      name: z.string(),
+      age: z.number().int().positive(),
+    });
+    const postSchema = z.object({
+      id: z.string(),
+      title: z.string(),
+    });
+    interface Post {
+      id: string;
+      title: string;
+    }
+    const UserModel: Model<User, typeof userSchema> = {
+      __type: {} as User,
+      zodSchema: userSchema,
+      [Metadata]: { name: "User" },
+    };
+    const PostModel: Model<Post, typeof postSchema> = {
+      __type: {} as Post,
+      zodSchema: postSchema,
+      [Metadata]: { name: "Post" },
+    };
+    const schema = {
+      User: UserModel,
+      Post: PostModel,
+      [Metadata]: { version: 1 },
+    } as const satisfies DocumentSchema;
+
+    const documentId = "validation-same-id-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const sharedId = "1" as RecordId;
+    const userRef = stateModule.createRecordRef(docRef, sharedId, schema.User);
+    const postRef = stateModule.createRecordRef(docRef, sharedId, schema.Post);
+
+    // Load the doc and corrupt only User "1". Uses the promise read path to
+    // avoid the (pre-existing) cross-model restriction in recordSubscriptions.
+    await expect(userRef.getSnapshot()).rejects.toThrow();
+    corruptRecord(documentId, sharedId);
+    await expect(userRef.getSnapshot()).rejects.toBeInstanceOf(RecordInvalidError);
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(1);
+
+    // A valid write + read of Post "1" must not clear User "1"'s entry.
+    await stateModule.setRecord(postRef, { id: "1", title: "hello" });
+    await expect(postRef.getSnapshot()).resolves.toMatchObject({ title: "hello" });
+
+    const invalid = stateModule.getInvalidRecords(docRef);
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0]).toMatchObject({ modelName: "User", recordId: sharedId });
+
+    // An invalid Post read must not notify User subscribers sharing its ID.
+    await stateModule.setRecord(userRef, { ...VALID_USER, id: "1" });
+    await expect(userRef.getSnapshot()).resolves.toMatchObject({ id: "1" });
+    let userInvalidCount = 0;
+    const unsubscribe = stateModule.onRecordInvalid(userRef, () => {
+      userInvalidCount++;
+    });
+
+    const docService = app.getModule(DOCUMENT_SERVICE_MODULE_KEY);
+    const yDoc = (docService as BaseYjsDocumentService).getYDocForTesting(documentId);
+    if (!yDoc) throw new Error("Y.Doc not found");
+    yDoc.transact(() => {
+      yDoc.getMap("Post").set(sharedId as string, new Y.Map());
+    }, "remote");
+
+    await expect(postRef.getSnapshot()).rejects.toBeInstanceOf(RecordInvalidError);
+    expect(userInvalidCount).toBe(0);
+    unsubscribe();
+  });
+});
+describe("Record schema validation with a throwing upgrade lens", () => {
+  let app: PackAppInternal;
+
+  beforeEach(() => {
+    app = createTestApp();
+  });
+
+  interface UserV2 {
+    id: string;
+    name: string;
+    displayName: string;
+  }
+
+  /**
+   * v2 schema where displayName is derived from name. The upgrade fn assumes
+   * name is a string; corrupt data with a non-string name makes the lens
+   * throw during snapshot computation.
+   */
+  const createLensedSchema = () => {
+    const userSchema = z.object({
+      id: z.string(),
+      name: z.string(),
+      displayName: z.string(),
+    });
+
+    const UserModel: Model<UserV2, typeof userSchema> = {
+      __type: {} as UserV2,
+      zodSchema: userSchema,
+      [Metadata]: { name: "User" },
+    };
+
+    const registry: UpgradeRegistry = {
+      allFields: {
+        id: { type: { kind: "primitive" } },
+        name: { type: { kind: "primitive" } },
+        displayName: { type: { kind: "primitive" } },
+      },
+      modelName: "User",
+      steps: [
+        {
+          addedInVersion: 2,
+          fields: {
+            displayName: {
+              derivedFrom: ["name"],
+            },
+          },
+        },
+      ],
+    };
+
+    const upgradeFns: UpgradeFns = {
+      User: {
+        v2: {
+          displayName: ({ name }: { readonly name: string }) => name.toUpperCase(),
+        },
+      },
+    };
+
+    return {
+      User: UserModel,
+      [Metadata]: {
+        minSupportedVersion: 1,
+        upgradeFns,
+        upgrades: { User: registry },
+        version: 2,
+      },
+    } as const satisfies DocumentSchema;
+  };
+
+  /** Writes raw field values for a record directly into the Y.Doc. */
+  function writeRawRecord(
+    documentId: DocumentId,
+    recordId: RecordId,
+    fields: Record<string, unknown>,
+  ): void {
+    const docService = app.getModule(DOCUMENT_SERVICE_MODULE_KEY);
+    const yDoc = (docService as BaseYjsDocumentService).getYDocForTesting(documentId);
+    if (!yDoc) {
+      throw new Error("Y.Doc not found for document ID: " + documentId);
+    }
+    yDoc.transact(() => {
+      const record = new Y.Map();
+      for (const [key, value] of Object.entries(fields)) {
+        record.set(key, value);
+      }
+      yDoc.getMap("User").set(recordId as string, record);
+    }, "remote");
+  }
+
+  it("contains a throwing lens as an invalid record instead of an escaping exception", async () => {
+    const schema = createLensedSchema();
+    const documentId = "lens-throw-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_a" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    const changedSnapshots: unknown[] = [];
+    let lastError: RecordValidationError | undefined;
+
+    const unsubscribeChanged = stateModule.onRecordChanged(recordRef, snapshot => {
+      changedSnapshots.push(snapshot);
+    });
+    const unsubscribeInvalid = stateModule.onRecordInvalid(recordRef, error => {
+      lastError = error;
+    });
+
+    // name present but non-string: the lens fires and throws inside toUpperCase.
+    writeRawRecord(documentId, userId, { id: "user_a", name: 123 });
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(changedSnapshots).toHaveLength(0);
+    expect(lastError).toBeDefined();
+    expect(lastError?.modelName).toBe("User");
+    expect(lastError?.issues[0]?.message).toContain("snapshot computation threw");
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(1);
+
+    await expect(recordRef.getSnapshot()).rejects.toBeInstanceOf(RecordInvalidError);
+
+    unsubscribeChanged();
+    unsubscribeInvalid();
+  });
+
+  it("still notifies sibling records changed in the same transaction", async () => {
+    const schema = createLensedSchema();
+    const documentId = "lens-throw-sibling-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const corruptId = "user_a" as RecordId;
+    const healthyId = "user_b" as RecordId;
+    const corruptRef = stateModule.createRecordRef(docRef, corruptId, schema.User);
+    const healthyRef = stateModule.createRecordRef(docRef, healthyId, schema.User);
+
+    let corruptInvalid = false;
+    const healthySnapshots: unknown[] = [];
+
+    const unsubscribes = [
+      stateModule.onRecordInvalid(corruptRef, () => {
+        corruptInvalid = true;
+      }),
+      stateModule.onRecordChanged(corruptRef, () => {}),
+      stateModule.onRecordChanged(healthyRef, snapshot => {
+        healthySnapshots.push(snapshot);
+      }),
+    ];
+
+    // One transaction touching both records: the corrupt one first, so an
+    // escaping exception would have starved the healthy one's notification.
+    const docService = app.getModule(DOCUMENT_SERVICE_MODULE_KEY);
+    const yDoc = (docService as BaseYjsDocumentService).getYDocForTesting(documentId);
+    if (!yDoc) throw new Error("Y.Doc not found");
+    yDoc.transact(() => {
+      const corrupt = new Y.Map();
+      corrupt.set("id", "user_a");
+      corrupt.set("name", 123);
+      yDoc.getMap("User").set(corruptId as string, corrupt);
+
+      const healthy = new Y.Map();
+      healthy.set("id", "user_b");
+      healthy.set("name", "bee");
+      yDoc.getMap("User").set(healthyId as string, healthy);
+    }, "remote");
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(corruptInvalid).toBe(true);
+    expect(healthySnapshots).toHaveLength(1);
+    // v1 data lensed on read: displayName derived from name.
+    expect(healthySnapshots[0]).toMatchObject({
+      id: "user_b",
+      name: "bee",
+      displayName: "BEE",
+    });
+
+    for (const unsubscribe of unsubscribes) unsubscribe();
+  });
+
+  it("rejects updateRecord on an unreadable record with RecordInvalidError", async () => {
+    const schema = createLensedSchema();
+    const documentId = "lens-throw-update-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_a" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    const unsubscribe = stateModule.onRecordChanged(recordRef, () => {});
+    writeRawRecord(documentId, userId, { id: "user_a", name: 123 });
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    await expect(stateModule.updateRecord(recordRef, { name: "fixed" }))
+      .rejects.toBeInstanceOf(RecordInvalidError);
+
+    unsubscribe();
+  });
+
+  it("keeps unreadable records deletable so delete-and-recreate repair works", async () => {
+    const schema = createLensedSchema();
+    const documentId = "lens-throw-delete-doc" as DocumentId;
+    const docRef = createDocRef(app, documentId, schema);
+    const stateModule = getStateModule(app);
+
+    const userId = "user_a" as RecordId;
+    const recordRef = stateModule.createRecordRef(docRef, userId, schema.User);
+
+    const unsubscribe = stateModule.onRecordChanged(recordRef, () => {});
+    writeRawRecord(documentId, userId, { id: "user_a", name: 123 });
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(1);
+
+    await expect(stateModule.deleteRecord(recordRef)).resolves.toBeUndefined();
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(stateModule.getInvalidRecords(docRef)).toHaveLength(0);
+
+    unsubscribe();
+  });
+});

--- a/packages/state/core/src/index.ts
+++ b/packages/state/core/src/index.ts
@@ -52,6 +52,7 @@ export type {
   DocumentStatusChangeCallback,
   DocumentSyncStatus,
   DocumentType,
+  RecordInvalidCallback,
   SearchDocumentsResult,
   UpdateDocumentMetadata,
 } from "./types/DocumentService.js";

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -34,7 +34,9 @@ import {
   type PresencePublishOptions,
   type RecordCollectionRef,
   type RecordId,
+  RecordInvalidError,
   type RecordRef,
+  type RecordValidationError,
   type UpgradeFns,
   type UpgradeRegistryMap,
 } from "@palantir/pack.document-schema.model-types";
@@ -54,6 +56,7 @@ import type {
   RecordChangeCallback,
   RecordCollectionChangeCallback,
   RecordDeleteCallback,
+  RecordInvalidCallback,
   SearchDocumentsResult,
   UpdateDocumentMetadata,
 } from "../types/DocumentService.js";
@@ -67,6 +70,30 @@ import {
 } from "./DocumentUpdateSchemaVersion.js";
 import * as YjsSchemaMapper from "./YjsSchemaMapper.js";
 
+/**
+ * Minimal structural view of a zod schema's safeParse. Some models carry a
+ * non-functional placeholder zodSchema (e.g. custom payload models), so the
+ * presence of a callable safeParse is checked at runtime.
+ */
+type SafeParseLike = (data: unknown) => {
+  readonly success: boolean;
+  readonly error?: {
+    readonly issues?: ReadonlyArray<{
+      readonly path: ReadonlyArray<PropertyKey>;
+      readonly message: string;
+    }>;
+  };
+};
+
+/**
+ * Identity key for invalid-record tracking. Records are identified by
+ * model + id: the same id may exist in different collections of a document,
+ * so id alone is not a safe key. JSON encoding avoids delimiter collisions.
+ */
+function invalidRecordKey(recordRef: RecordRef): string {
+  return JSON.stringify([getMetadata(recordRef.model).name, recordRef.id as string]);
+}
+
 export interface RecordCollectionSubscriptions<M extends Model = Model> {
   added?: Set<RecordCollectionChangeCallback<M>>;
   changed?: Set<RecordCollectionChangeCallback<M>>;
@@ -77,6 +104,7 @@ export interface RecordSubscribers<M extends Model = Model> {
   readonly ref: RecordRef<M>;
   changed?: Set<RecordChangeCallback<M>>;
   deleted?: Set<RecordDeleteCallback<M>>;
+  invalid?: Set<RecordInvalidCallback<M>>;
 }
 
 export interface InternalYjsDoc {
@@ -116,6 +144,7 @@ export interface InternalYjsDoc {
   readonly statusSubscribers: Set<DocumentStatusChangeCallback>;
 
   readonly yjsCollectionHandlers: Map<string, () => void>;
+  readonly invalidRecords: Map<string, RecordValidationError>;
 
   readonly upgrades?: UpgradeRegistryMap;
   /**
@@ -347,6 +376,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
       docStateSubscribers: new Set(),
       metadataSubscribers: new Set(),
       recordSubscriptions: new Map(),
+      invalidRecords: new Map(),
       yDoc: this.initializeYDoc(schema),
       yDocUpdateHandler: undefined,
       yjsCollectionHandlers: new Map(),
@@ -372,9 +402,12 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
 
   // Status helper methods
   private buildStatus(internalDoc: TDoc): DocumentStatus {
+    const invalidRecordCount = internalDoc.invalidRecords.size;
     return {
       metadata: internalDoc.metadataStatus,
-      data: internalDoc.dataStatus,
+      data: invalidRecordCount > 0
+        ? { ...internalDoc.dataStatus, invalidRecordCount }
+        : internalDoc.dataStatus,
       presence: internalDoc.presenceStatus,
       activity: internalDoc.activityStatus,
     };
@@ -530,15 +563,25 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     recordRef: RecordRef<M>,
   ): Promise<ModelData<M>> => {
     const { internalDoc } = this.getCreateInternalDoc(recordRef.docRef);
-    const snapshot = this.getRecordSnapshotInternal(internalDoc, recordRef);
+    const { snapshot, thrown } = this.getRecordSnapshotChecked(internalDoc, recordRef);
 
     // This is a promise interface for async loading for external API implementations to trigger a load first
     // For this base implementation, we always return from the local Y.Doc
 
+    if (thrown != null) {
+      this.markRecordInvalid(internalDoc, recordRef, thrown);
+      return Promise.reject(new RecordInvalidError(thrown));
+    }
     if (snapshot == null) {
       // TODO: well known error types
       return Promise.reject(new Error(`Record not found: ${recordRef.id}`));
     }
+    const validationError = this.validateRecordSnapshot(recordRef, snapshot);
+    if (validationError != null) {
+      this.markRecordInvalid(internalDoc, recordRef, validationError);
+      return Promise.reject(new RecordInvalidError(validationError));
+    }
+    this.clearRecordInvalid(internalDoc, recordRef);
     return Promise.resolve(snapshot);
   };
 
@@ -553,6 +596,154 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
       internalDoc.upgrades,
       internalDoc.upgradeFns,
     ) as ModelData<M>;
+  }
+
+  /**
+   * Compute a record snapshot, containing any exception thrown by the read
+   * path (schema mapping / upgrade lens) instead of letting it escape into
+   * notification fan-out or Yjs observer callbacks. A throw is synthesized
+   * into a RecordValidationError so a corrupt record that breaks its upgrade
+   * lens is handled identically to one that fails validation: that one
+   * record becomes invalid, and sibling records in the same transaction are
+   * unaffected.
+   */
+  private getRecordSnapshotChecked<M extends Model>(
+    internalDoc: TDoc,
+    recordRef: RecordRef<M>,
+  ): { readonly snapshot?: ModelData<M>; readonly thrown?: RecordValidationError } {
+    try {
+      return { snapshot: this.getRecordSnapshotInternal(internalDoc, recordRef) };
+    } catch (e) {
+      const modelName = getMetadata(recordRef.model).name;
+      const cause = e instanceof Error ? e.message : String(e);
+      return {
+        thrown: {
+          modelName,
+          recordId: recordRef.id,
+          issues: [{ path: [], message: `snapshot computation threw: ${cause}` }],
+          message: `Record ${recordRef.id} of model ${modelName} could not be read `
+            + `(a failing upgrade lens on corrupt data can cause this): ${cause}`,
+        },
+      };
+    }
+  }
+
+  /**
+   * Validate a record snapshot against its model's zod schema, if a
+   * functional one is present. Models without a usable schema (e.g. custom
+   * payload placeholders) are treated as always valid.
+   *
+   * @returns undefined if valid (or has no usable schema), otherwise the error.
+   */
+  private validateRecordSnapshot<M extends Model>(
+    recordRef: RecordRef<M>,
+    snapshot: unknown,
+  ): RecordValidationError | undefined {
+    const zodSchema = recordRef.model.zodSchema as { readonly safeParse?: SafeParseLike };
+    const safeParse = zodSchema?.safeParse;
+    if (safeParse == null) {
+      return undefined;
+    }
+
+    const modelName = getMetadata(recordRef.model).name;
+    let result: ReturnType<SafeParseLike>;
+    try {
+      result = safeParse.call(recordRef.model.zodSchema, snapshot);
+    } catch (e) {
+      const cause = e instanceof Error ? e.message : String(e);
+      return {
+        modelName,
+        recordId: recordRef.id,
+        issues: [{ path: [], message: `schema validation threw: ${cause}` }],
+        message: `Record ${recordRef.id} of model ${modelName} could not be validated: ${cause}`,
+      };
+    }
+    if (result.success) {
+      return undefined;
+    }
+
+    const issues = (result.error?.issues ?? []).map(issue => ({
+      path: issue.path.map(part => (typeof part === "number" ? part : String(part))),
+      message: issue.message,
+    }));
+    const issueSummary = issues
+      .map(issue =>
+        issue.path.length > 0 ? `${issue.path.join(".")}: ${issue.message}` : issue.message
+      )
+      .join("; ");
+    return {
+      modelName,
+      recordId: recordRef.id,
+      issues,
+      message: `Record ${recordRef.id} does not match schema for model ${modelName}`
+        + (issueSummary.length > 0 ? ` (${issueSummary})` : ""),
+    };
+  }
+
+  /**
+   * Track a validation failure: store it on the doc, notify onInvalid
+   * subscribers, log, and (on the valid->invalid transition) notify status
+   * subscribers so doc-level UI can react.
+   */
+  private markRecordInvalid<M extends Model>(
+    internalDoc: TDoc,
+    recordRef: RecordRef<M>,
+    error: RecordValidationError,
+  ): void {
+    const key = invalidRecordKey(recordRef);
+    const wasInvalid = internalDoc.invalidRecords.has(key);
+    internalDoc.invalidRecords.set(key, error);
+
+    if (!wasInvalid) {
+      this.logger.error(
+        "Record failed schema validation; withholding snapshot from onChange subscribers",
+        {
+          docId: recordRef.docRef.id,
+          recordId: recordRef.id,
+          model: error.modelName,
+          issues: error.issues,
+        },
+      );
+    }
+
+    const recordSubs = internalDoc.recordSubscriptions.get(recordRef.id);
+    if (
+      recordSubs != null
+      && getMetadata(recordSubs.ref.model).name === getMetadata(recordRef.model).name
+    ) {
+      for (const callback of recordSubs.invalid ?? []) {
+        try {
+          callback(error, recordRef);
+        } catch (e) {
+          console.error("Record onInvalid callback threw unhandled error", e, {
+            model: error.modelName,
+            id: recordRef.id,
+          });
+        }
+      }
+    }
+
+    if (!wasInvalid) {
+      this.notifyStatusSubscribers(internalDoc, recordRef.docRef);
+    }
+  }
+
+  /**
+   * Clear a previously tracked validation failure (record repaired or
+   * deleted). Notifies status subscribers on the invalid->valid transition.
+   */
+  private clearRecordInvalid(
+    internalDoc: TDoc,
+    recordRef: RecordRef,
+  ): void {
+    if (!internalDoc.invalidRecords.delete(invalidRecordKey(recordRef))) {
+      return;
+    }
+    this.logger.info("Record passes schema validation again", {
+      docId: recordRef.docRef.id,
+      recordId: recordRef.id,
+    });
+    this.notifyStatusSubscribers(internalDoc, recordRef.docRef);
   }
 
   readonly setRecord = <R extends Model>(
@@ -606,7 +797,14 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     );
 
     const storageName = getMetadata(recordRef.model).name;
-    const currentState = this.getRecordSnapshotInternal(internalDoc, recordRef);
+    const { snapshot: currentState, thrown } = this.getRecordSnapshotChecked(
+      internalDoc,
+      recordRef,
+    );
+    if (thrown != null) {
+      this.markRecordInvalid(internalDoc, recordRef, thrown);
+      return Promise.reject(new RecordInvalidError(thrown));
+    }
     const documentUpdateSchemaVersion = getPartialModelDataSchemaVersion(
       internalDoc.schema,
       storageName,
@@ -835,22 +1033,27 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     invariant(internalDoc != null, "Document not found for record notifications");
 
     const recordSubs = internalDoc.recordSubscriptions.get(recordRef.id);
-    if (recordSubs == null) {
-      return;
+    if (recordSubs != null) {
+      // Verify model consistency
+      invariant(
+        getMetadata(recordSubs.ref.model).name === getMetadata(recordRef.model).name,
+        `Model mismatch when notifying record subscribers for ${recordRef.id}: expected ${
+          getMetadata(recordSubs.ref.model).name
+        }, got ${getMetadata(recordRef.model).name}`,
+      );
     }
-
-    // Verify model consistency
-    invariant(
-      getMetadata(recordSubs.ref.model).name === getMetadata(recordRef.model).name,
-      `Model mismatch when notifying record subscribers for ${recordRef.id}: expected ${
-        getMetadata(recordSubs.ref.model).name
-      }, got ${getMetadata(recordRef.model).name}`,
-    );
 
     switch (changeType) {
       case "changed": {
-        const snapshot = this.getRecordSnapshotInternal(internalDoc, recordRef);
-        for (const callback of recordSubs.changed ?? []) {
+        const { snapshot, thrown } = this.getRecordSnapshotChecked(internalDoc, recordRef);
+        const validationError = thrown
+          ?? (snapshot != null ? this.validateRecordSnapshot(recordRef, snapshot) : undefined);
+        if (validationError != null) {
+          this.markRecordInvalid(internalDoc, recordRef, validationError);
+          break;
+        }
+        this.clearRecordInvalid(internalDoc, recordRef);
+        for (const callback of recordSubs?.changed ?? []) {
           try {
             callback(snapshot, recordRef);
           } catch (e) {
@@ -863,7 +1066,8 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
         break;
       }
       case "deleted": {
-        for (const callback of recordSubs.deleted ?? []) {
+        this.clearRecordInvalid(internalDoc, recordRef);
+        for (const callback of recordSubs?.deleted ?? []) {
           try {
             callback(recordRef);
           } catch (e) {
@@ -929,16 +1133,28 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
 
     const existed = recordsCollection.has(record.id as string);
     if (existed) {
-      const documentUpdateSchemaVersion = getModelDataSchemaVersion(
-        internalDoc.schema,
-        storageName,
-        this.getRecordSnapshotInternal(internalDoc, record),
-      );
+      let documentUpdateSchemaVersion: number | undefined;
+      try {
+        documentUpdateSchemaVersion = getModelDataSchemaVersion(
+          internalDoc.schema,
+          storageName,
+          this.getRecordSnapshotInternal(internalDoc, record),
+        );
+      } catch {
+        // A corrupt record whose upgrade lens throws must still be deletable
+        // (delete-and-recreate is the repair path). Fall back to tagging no
+        // explicit schema version on the deletion transaction.
+        documentUpdateSchemaVersion = undefined;
+      }
       internalDoc.yDoc.transact(transaction => {
-        addDocumentUpdateSchemaVersionToTransaction(transaction, documentUpdateSchemaVersion);
+        if (documentUpdateSchemaVersion != null) {
+          addDocumentUpdateSchemaVersionToTransaction(transaction, documentUpdateSchemaVersion);
+        }
         recordsCollection.delete(record.id as string);
       });
     }
+
+    this.clearRecordInvalid(internalDoc, record);
 
     return Promise.resolve();
   };
@@ -1033,12 +1249,17 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
       this.setupCollectionListener(internalDoc, collectionRef);
     }
 
-    const snapshot = this.getRecordSnapshotInternal(
-      internalDoc,
-      record,
-    );
-    if (snapshot != null) {
-      callback(snapshot, record);
+    const { snapshot, thrown } = this.getRecordSnapshotChecked(internalDoc, record);
+    if (thrown != null) {
+      this.markRecordInvalid(internalDoc, record, thrown);
+    } else if (snapshot != null) {
+      const validationError = this.validateRecordSnapshot(record, snapshot);
+      if (validationError == null) {
+        this.clearRecordInvalid(internalDoc, record);
+        callback(snapshot, record);
+      } else {
+        this.markRecordInvalid(internalDoc, record, validationError);
+      }
     }
 
     return () => {
@@ -1110,6 +1331,95 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
         this.onDataSubscriptionClosed(currentDoc, internalDocRef);
       }
     };
+  };
+
+  readonly onRecordInvalid = <M extends Model>(
+    record: RecordRef<M>,
+    callback: RecordInvalidCallback<M>,
+  ): Unsubscribe => {
+    const { internalDoc, internalDocRef } = this.getCreateInternalDoc(record.docRef);
+    const isFirstDataSubscription = !internalDoc.hasDataSubscriptions;
+    const storageName = getMetadata(record.model).name;
+    const collectionRef = this.getCreateRecordCollectionRef(record.docRef, record.model);
+    const needsCollectionListener = !internalDoc.yjsCollectionHandlers.has(storageName);
+
+    const recordSubs = this.getCreateRecordSubscriptions(internalDoc, record);
+    (recordSubs.invalid ??= new Set()).add(callback);
+    internalDoc.hasDataSubscriptions = true;
+
+    // Trigger remote load if this is the first data subscription and not yet loaded
+    if (isFirstDataSubscription && internalDoc.dataStatus.load === DocumentLoadStatus.UNLOADED) {
+      this.onDataSubscriptionOpened(internalDoc, internalDocRef);
+    }
+
+    if (needsCollectionListener) {
+      this.getCreateCollectionSubscriptions(internalDoc, collectionRef);
+      this.setupCollectionListener(internalDoc, collectionRef);
+    }
+
+    const { snapshot, thrown } = this.getRecordSnapshotChecked(internalDoc, record);
+    const validationError = thrown
+      ?? (snapshot != null ? this.validateRecordSnapshot(record, snapshot) : undefined);
+    if (validationError != null) {
+      this.markRecordInvalid(internalDoc, record, validationError);
+    } else {
+      this.clearRecordInvalid(internalDoc, record);
+    }
+
+    return () => {
+      recordSubs.invalid?.delete(callback);
+      const currentDoc = this.documents.get(record.docRef.id);
+      if (!currentDoc) return;
+
+      if (isRecordSubscriptionsEmpty(recordSubs)) {
+        currentDoc.recordSubscriptions.delete(record.id);
+      }
+
+      this.cleanupCollectionListenerIfUnused(currentDoc, record.docRef.id, storageName);
+
+      const hasDataSubs = currentDoc.docStateSubscribers.size > 0
+        || currentDoc.recordSubscriptions.size > 0
+        || Array.from(currentDoc.collectionSubscriptions.values()).some(subs =>
+          subs.added?.size || subs.changed?.size || subs.deleted?.size
+        );
+
+      if (!hasDataSubs) {
+        currentDoc.hasDataSubscriptions = false;
+        this.onDataSubscriptionClosed(currentDoc, internalDocRef);
+      }
+    };
+  };
+
+  /**
+   * Get the KNOWN invalid records of a document: records whose stored data
+   * failed schema validation when last read or notified. This is not a full
+   * document scan, so corruption in records that have never been read or
+   * observed is not included. Tracked entries are re-validated on each call
+   * and pruned if the record has since been repaired or deleted, so results
+   * do not go stale for documents without active subscriptions.
+   */
+  readonly getInvalidRecords = (
+    docRef: DocumentRef,
+  ): ReadonlyArray<RecordValidationError> => {
+    const internalDoc = this.documents.get(docRef.id);
+    if (internalDoc == null) {
+      return [];
+    }
+    for (const error of [...internalDoc.invalidRecords.values()]) {
+      const model: Model | undefined = internalDoc.schema[error.modelName];
+      if (model == null) {
+        continue;
+      }
+      const recordRef = this.getCreateRecordRef(docRef, error.recordId, model);
+      const { snapshot, thrown } = this.getRecordSnapshotChecked(internalDoc, recordRef);
+      if (thrown != null) {
+        continue; // still unreadable; keep the tracked entry
+      }
+      if (snapshot == null || this.validateRecordSnapshot(recordRef, snapshot) == null) {
+        this.clearRecordInvalid(internalDoc, recordRef);
+      }
+    }
+    return [...internalDoc.invalidRecords.values()];
   };
 
   private getCreateCollectionSubscriptions<M extends Model>(
@@ -1472,5 +1782,6 @@ function isRecordSubscriptionsEmpty<M extends Model>(
   return (
     !subs.changed?.size
     && !subs.deleted?.size
+    && !subs.invalid?.size
   );
 }

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -689,6 +689,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     internalDoc: TDoc,
     recordRef: RecordRef<M>,
     error: RecordValidationError,
+    callbackToNotify?: RecordInvalidCallback<M>,
   ): void {
     const key = invalidRecordKey(recordRef);
     const wasInvalid = internalDoc.invalidRecords.has(key);
@@ -711,7 +712,8 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
       recordSubs != null
       && getMetadata(recordSubs.ref.model).name === getMetadata(recordRef.model).name
     ) {
-      for (const callback of recordSubs.invalid ?? []) {
+      const callbacks = callbackToNotify != null ? [callbackToNotify] : recordSubs.invalid ?? [];
+      for (const callback of callbacks) {
         try {
           callback(error, recordRef);
         } catch (e) {
@@ -1361,7 +1363,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
     const validationError = thrown
       ?? (snapshot != null ? this.validateRecordSnapshot(record, snapshot) : undefined);
     if (validationError != null) {
-      this.markRecordInvalid(internalDoc, record, validationError);
+      this.markRecordInvalid(internalDoc, record, validationError, callback);
     } else {
       this.clearRecordInvalid(internalDoc, record);
     }

--- a/packages/state/core/src/types/DocumentService.ts
+++ b/packages/state/core/src/types/DocumentService.ts
@@ -33,6 +33,7 @@ import type {
   RecordCollectionRef,
   RecordId,
   RecordRef,
+  RecordValidationError,
 } from "@palantir/pack.document-schema.model-types";
 import type { CreateDocumentMetadata, FileSystemType } from "./CreateDocumentMetadata.js";
 
@@ -54,6 +55,7 @@ export type DocumentLiveStatus = typeof DocumentLiveStatus[keyof typeof Document
 
 export type DocumentSyncStatus = {
   readonly error?: ChannelError;
+  readonly invalidRecordCount?: number;
   /**
    * When true, indicates this is a demo/test service not connected to real Foundry.
    * UI can use this to display a badge or indicator that data is local-only.
@@ -93,6 +95,11 @@ export type RecordChangeCallback<M extends Model = Model> = (
 ) => void;
 
 export type RecordDeleteCallback<M extends Model = Model> = (
+  record: RecordRef<M>,
+) => void;
+
+export type RecordInvalidCallback<M extends Model = Model> = (
+  error: RecordValidationError,
   record: RecordRef<M>,
 ) => void;
 
@@ -331,6 +338,15 @@ export interface DocumentService {
     record: RecordRef<M>,
     callback: RecordDeleteCallback<M>,
   ) => Unsubscribe;
+
+  readonly onRecordInvalid: <M extends Model>(
+    record: RecordRef<M>,
+    callback: RecordInvalidCallback<M>,
+  ) => Unsubscribe;
+
+  readonly getInvalidRecords: (
+    docRef: DocumentRef,
+  ) => ReadonlyArray<RecordValidationError>;
 
   // Status methods
   readonly getDocumentStatus: <T extends DocumentSchema>(

--- a/packages/state/core/src/types/RecordRefImpl.ts
+++ b/packages/state/core/src/types/RecordRefImpl.ts
@@ -20,6 +20,7 @@ import type {
   ModelData,
   RecordId,
   RecordRef,
+  RecordValidationError,
   Unsubscribe,
 } from "@palantir/pack.document-schema.model-types";
 import { RecordRefBrand } from "@palantir/pack.document-schema.model-types";
@@ -37,6 +38,7 @@ const INVALID_RECORD_REF: RecordRef = Object.freeze(
     getSnapshot: () => Promise.reject(new Error("Invalid record reference")),
     onChange: () => () => {},
     onDeleted: () => () => {},
+    onInvalid: () => () => {},
   } as const,
 );
 
@@ -115,6 +117,12 @@ class RecordRefImpl<M extends Model> implements RecordRef<M> {
 
   onDeleted(callback: (recordRef: RecordRef<M>) => void): Unsubscribe {
     return this.#documentService.onRecordDeleted(this, callback);
+  }
+
+  onInvalid(
+    callback: (error: RecordValidationError, recordRef: RecordRef<M>) => void,
+  ): Unsubscribe {
+    return this.#documentService.onRecordInvalid(this, callback);
   }
 
   delete(): Promise<void> {

--- a/packages/state/core/src/types/StateModule.ts
+++ b/packages/state/core/src/types/StateModule.ts
@@ -32,6 +32,7 @@ import type {
   RecordCollectionRef,
   RecordId,
   RecordRef,
+  RecordValidationError,
 } from "@palantir/pack.document-schema.model-types";
 import { getMetadata } from "@palantir/pack.document-schema.model-types";
 import { DOCUMENT_SERVICE_MODULE_KEY } from "../DocumentServiceModule.js";
@@ -42,6 +43,7 @@ import type {
   RecordChangeCallback,
   RecordCollectionChangeCallback,
   RecordDeleteCallback,
+  RecordInvalidCallback,
   SearchDocumentsResult,
   UpdateDocumentMetadata,
 } from "./DocumentService.js";
@@ -202,6 +204,15 @@ export interface StateModule {
     record: RecordRef<M>,
     callback: RecordDeleteCallback<M>,
   ) => Unsubscribe;
+
+  readonly onRecordInvalid: <M extends Model>(
+    record: RecordRef<M>,
+    callback: RecordInvalidCallback<M>,
+  ) => Unsubscribe;
+
+  readonly getInvalidRecords: (
+    docRef: DocumentRef,
+  ) => ReadonlyArray<RecordValidationError>;
 
   readonly deleteRecord: <M extends Model>(
     record: RecordRef<M>,
@@ -443,6 +454,19 @@ export class StateModuleImpl implements StateModule {
     callback: RecordDeleteCallback<M>,
   ): Unsubscribe {
     return this.documentService.onRecordDeleted(record, callback);
+  }
+
+  onRecordInvalid<M extends Model>(
+    record: RecordRef<M>,
+    callback: RecordInvalidCallback<M>,
+  ): Unsubscribe {
+    return this.documentService.onRecordInvalid(record, callback);
+  }
+
+  getInvalidRecords(
+    docRef: DocumentRef,
+  ): ReadonlyArray<RecordValidationError> {
+    return this.documentService.getInvalidRecords(docRef);
   }
 
   onCollectionItemsAdded<M extends Model>(

--- a/packages/state/react/src/__tests__/useRecord.test.tsx
+++ b/packages/state/react/src/__tests__/useRecord.test.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  Model,
+  ModelData,
+  RecordId,
+  RecordRef,
+  RecordValidationError,
+} from "@palantir/pack.document-schema.model-types";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useRecord } from "../hooks/useRecord.js";
+
+interface User {
+  id: string;
+  name: string;
+}
+
+type UserModel = Model<User>;
+
+function createMockRecordRef(): {
+  readonly recordRef: RecordRef<UserModel>;
+  readonly emitChange: (snapshot: ModelData<UserModel>) => void;
+  readonly emitDeleted: () => void;
+  readonly emitInvalid: (error: RecordValidationError) => void;
+  readonly unsubscribeChange: ReturnType<typeof vi.fn>;
+  readonly unsubscribeDeleted: ReturnType<typeof vi.fn>;
+  readonly unsubscribeInvalid: ReturnType<typeof vi.fn>;
+} {
+  let changeCallback:
+    | ((snapshot: ModelData<UserModel>, recordRef: RecordRef<UserModel>) => void)
+    | undefined;
+  let deletedCallback: ((recordRef: RecordRef<UserModel>) => void) | undefined;
+  let invalidCallback:
+    | ((error: RecordValidationError, recordRef: RecordRef<UserModel>) => void)
+    | undefined;
+
+  const unsubscribeChange = vi.fn();
+  const unsubscribeDeleted = vi.fn();
+  const unsubscribeInvalid = vi.fn();
+
+  const recordRef = {
+    id: "rec-1" as RecordId,
+    model: {} as UserModel,
+    onChange: (callback: typeof changeCallback) => {
+      changeCallback = callback;
+      return unsubscribeChange;
+    },
+    onDeleted: (callback: typeof deletedCallback) => {
+      deletedCallback = callback;
+      return unsubscribeDeleted;
+    },
+    onInvalid: (callback: typeof invalidCallback) => {
+      invalidCallback = callback;
+      return unsubscribeInvalid;
+    },
+  } as unknown as RecordRef<UserModel>;
+
+  return {
+    recordRef,
+    emitChange: snapshot => act(() => changeCallback?.(snapshot, recordRef)),
+    emitDeleted: () => act(() => deletedCallback?.(recordRef)),
+    emitInvalid: error => act(() => invalidCallback?.(error, recordRef)),
+    unsubscribeChange,
+    unsubscribeDeleted,
+    unsubscribeInvalid,
+  };
+}
+
+const VALIDATION_ERROR: RecordValidationError = {
+  modelName: "User",
+  recordId: "rec-1" as RecordId,
+  issues: [{ path: ["name"], message: "Required" }],
+  message: "Record rec-1 does not match schema for model User (name: Required)",
+};
+
+describe("useRecord invalid state", () => {
+  it("starts in loading state", () => {
+    const { recordRef } = createMockRecordRef();
+    const { result } = renderHook(() => useRecord(recordRef));
+    expect(result.current).toEqual({ status: "loading", data: undefined });
+  });
+
+  it("transitions to invalid with the validation error", () => {
+    const { recordRef, emitInvalid } = createMockRecordRef();
+    const { result } = renderHook(() => useRecord(recordRef));
+
+    emitInvalid(VALIDATION_ERROR);
+
+    expect(result.current.status).toBe("invalid");
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBe(VALIDATION_ERROR);
+  });
+
+  it("recovers from invalid to loaded when a valid change arrives", () => {
+    const { recordRef, emitChange, emitInvalid } = createMockRecordRef();
+    const { result } = renderHook(() => useRecord(recordRef));
+
+    emitInvalid(VALIDATION_ERROR);
+    expect(result.current.status).toBe("invalid");
+
+    const repaired: User = { id: "rec-1", name: "Jane" };
+    emitChange(repaired);
+
+    expect(result.current.status).toBe("loaded");
+    expect(result.current.data).toEqual(repaired);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("transitions from invalid to deleted when the record is deleted", () => {
+    const { recordRef, emitDeleted, emitInvalid } = createMockRecordRef();
+    const { result } = renderHook(() => useRecord(recordRef));
+
+    emitInvalid(VALIDATION_ERROR);
+    emitDeleted();
+
+    expect(result.current).toEqual({ status: "deleted", data: undefined });
+  });
+
+  it("unsubscribes all three subscriptions on unmount", () => {
+    const { recordRef, unsubscribeChange, unsubscribeDeleted, unsubscribeInvalid } =
+      createMockRecordRef();
+    const { unmount } = renderHook(() => useRecord(recordRef));
+
+    unmount();
+
+    expect(unsubscribeChange).toHaveBeenCalledTimes(1);
+    expect(unsubscribeDeleted).toHaveBeenCalledTimes(1);
+    expect(unsubscribeInvalid).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/state/react/src/hooks/useRecord.ts
+++ b/packages/state/react/src/hooks/useRecord.ts
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-import type { Model, ModelData, RecordRef } from "@palantir/pack.document-schema.model-types";
+import type {
+  Model,
+  ModelData,
+  RecordRef,
+  RecordValidationError,
+} from "@palantir/pack.document-schema.model-types";
 import { useEffect, useState } from "react";
 
 type UseRecordResult<M extends Model> =
-  | { status: "loading"; data: undefined }
-  | { status: "loaded"; data: ModelData<M> }
-  | { status: "deleted"; data: undefined };
+  | { status: "loading"; data: undefined; error?: undefined }
+  | { status: "loaded"; data: ModelData<M>; error?: undefined }
+  | { status: "deleted"; data: undefined; error?: undefined }
+  | { status: "invalid"; data: undefined; error: RecordValidationError };
 
 /**
  * Subscribes to an individual record and subscribes to its changes.
@@ -43,6 +49,12 @@ type UseRecordResult<M extends Model> =
  *     return <div>Record not found</div>;
  *   }
  *
+ *   if (record.status === "invalid") {
+ *     // The record exists but its data failed schema validation
+ *     // (e.g. after a corrupted/partial write). record.error has details.
+ *     return <div>Record cannot be displayed</div>;
+ *   }
+ *
  *   return <div>Hello, {record.data.myFieldName}</div>;
  * }
  * ```
@@ -63,9 +75,14 @@ export function useRecord<M extends Model>(
       setResult({ status: "deleted", data: undefined });
     });
 
+    const unsubscribeToOnInvalid = ref.onInvalid(error => {
+      setResult({ status: "invalid", data: undefined, error });
+    });
+
     return () => {
       unsubscribeToOnChange();
       unsubscribeToOnDeleted();
+      unsubscribeToOnInvalid();
     };
   }, [ref]);
 


### PR DESCRIPTION
 Validates record snapshots against their model’s Zod schema before exposing them to consumers. Corrupted records are withheld from onChange, surfaced through dedicated validation APIs, and automatically recover when repaired.

Persisted Yjs state can become partial or corrupted and no longer match the TypeScript type promised by its model. Previously, that invalid data could reach consumers or throw during snapshot computation, potentially interrupting other record notifications.