### PR TITLE
Fix reopen with stale status and data load

### DIFF
--- a/.changeset/fix-stale-data-load-status.md
+++ b/.changeset/fix-stale-data-load-status.md
@@ -1,0 +1,6 @@
+---
+"@palantir/pack.state.core": patch
+"@palantir/pack.state.foundry": patch
+---
+
+Fix stale data-load status blocking document reopen. `waitForDataLoad` resolved off `dataStatus.load === LOADED`, which on reopen of a previously-loaded document could still read `LOADED` from the prior open — resolving against a torn-down subscription and leaving callers acting on stale state. The reset to `UNLOADED` on subscription close now lives in the base class (`closeDataSubscription`) and runs unconditionally on every close path, so subclasses can no longer skip it and a reopen re-runs the load. `waitForDataLoad` also now rejects (instead of hanging forever) when no data subscription is registered or when an in-flight load is canceled.

--- a/packages/state/core/src/__tests__/DocumentStatusTracking.test.ts
+++ b/packages/state/core/src/__tests__/DocumentStatusTracking.test.ts
@@ -226,4 +226,51 @@ describe("Document Status Tracking", () => {
     expect(immediateStatus!.metadata.load).toBe(DocumentLoadStatus.UNLOADED);
     expect(immediateStatus!.data.load).toBe(DocumentLoadStatus.UNLOADED);
   });
+
+  it("should reset data status to UNLOADED when the last data subscription closes", async () => {
+    const mockApp = createTestApp();
+    const service = internalCreateInMemoryDocumentService(mockApp, { autoCreateDocuments: true });
+    const docRef = createDocRef(mockApp, DOCUMENT_ID, testSchema);
+
+    const unsubscribe = service.onStateChange(docRef, () => {});
+    await service.waitForDataLoad(docRef);
+    expect(service.getDocumentStatus(docRef).data.load).toBe(DocumentLoadStatus.LOADED);
+
+    // Closing the last data subscription must reset status so a later reopen
+    // re-runs the load; a stale LOADED would let waitForDataLoad resolve before
+    // the write path is re-established.
+    unsubscribe();
+    const status = service.getDocumentStatus(docRef);
+    expect(status.data.load).toBe(DocumentLoadStatus.UNLOADED);
+    expect(status.data.live).toBe(DocumentLiveStatus.DISCONNECTED);
+  });
+
+  it("should reload after a close/reopen cycle", async () => {
+    const mockApp = createTestApp();
+    const service = internalCreateInMemoryDocumentService(mockApp, { autoCreateDocuments: true });
+    const docRef = createDocRef(mockApp, DOCUMENT_ID, testSchema);
+
+    const unsubscribe1 = service.onStateChange(docRef, () => {});
+    await service.waitForDataLoad(docRef);
+    unsubscribe1();
+    expect(service.getDocumentStatus(docRef).data.load).toBe(DocumentLoadStatus.UNLOADED);
+
+    // Reopen must trigger a fresh load, not short-circuit on stale status.
+    const unsubscribe2 = service.onStateChange(docRef, () => {});
+    await expect(service.waitForDataLoad(docRef)).resolves.toBeUndefined();
+    expect(service.getDocumentStatus(docRef).data.load).toBe(DocumentLoadStatus.LOADED);
+
+    unsubscribe2();
+  });
+
+  it("should reject waitForDataLoad when no data subscription is registered", async () => {
+    const mockApp = createTestApp();
+    const service = internalCreateInMemoryDocumentService(mockApp, { autoCreateDocuments: true });
+    const docRef = createDocRef(mockApp, DOCUMENT_ID, testSchema);
+
+    // No subscription means no load will ever start; must fail fast, not hang.
+    await expect(service.waitForDataLoad(docRef)).rejects.toThrow(
+      /no data subscription is registered/,
+    );
+  });
 });

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -756,11 +756,24 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
         );
 
       if (!hasDataSubs) {
-        currentDoc.hasDataSubscriptions = false;
-        this.onDataSubscriptionClosed(currentDoc, internalDocRef);
+        this.closeDataSubscription(currentDoc, internalDocRef);
       }
     };
   };
+
+  private closeDataSubscription(currentDoc: TDoc, docRef: DocumentRef): void {
+    currentDoc.hasDataSubscriptions = false;
+    this.onDataSubscriptionClosed(currentDoc, docRef);
+    if (
+      currentDoc.dataStatus.load !== DocumentLoadStatus.UNLOADED
+      || currentDoc.dataStatus.live !== DocumentLiveStatus.DISCONNECTED
+    ) {
+      this.updateDataStatus(currentDoc, docRef, {
+        live: DocumentLiveStatus.DISCONNECTED,
+        load: DocumentLoadStatus.UNLOADED,
+      });
+    }
+  }
 
   protected getDocumentRef(docId: DocumentId): DocumentRef | null {
     const internalDoc = this.documents.get(docId);
@@ -1059,8 +1072,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
         );
 
       if (!hasDataSubs) {
-        currentDoc.hasDataSubscriptions = false;
-        this.onDataSubscriptionClosed(currentDoc, internalDocRef);
+        this.closeDataSubscription(currentDoc, internalDocRef);
       }
     };
   };
@@ -1106,8 +1118,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
         );
 
       if (!hasDataSubs) {
-        currentDoc.hasDataSubscriptions = false;
-        this.onDataSubscriptionClosed(currentDoc, internalDocRef);
+        this.closeDataSubscription(currentDoc, internalDocRef);
       }
     };
   };
@@ -1190,8 +1201,7 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
         );
 
       if (!hasDataSubs) {
-        currentDoc.hasDataSubscriptions = false;
-        this.onDataSubscriptionClosed(currentDoc, internalDocRef);
+        this.closeDataSubscription(currentDoc, internalDocRef);
       }
     };
   }
@@ -1432,15 +1442,42 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
       return Promise.reject(new Error("Data load error", { cause: internalDoc.dataStatus.error }));
     }
 
-    // Wait for status to change to LOADED or ERROR
+    // Data loads are demand-driven: they only start when a data subscription
+    // (onStateChange / record / collection) is registered. Waiting with no
+    // subscription and no load in flight would hang forever, so fail fast.
+    if (
+      !internalDoc.hasDataSubscriptions
+      && internalDoc.dataStatus.load === DocumentLoadStatus.UNLOADED
+    ) {
+      return Promise.reject(
+        new Error(
+          "Cannot wait for data load: no data subscription is registered for this document, "
+            + "so no load will start. Subscribe (e.g. onStateChange) before waiting.",
+        ),
+      );
+    }
+
     return new Promise((resolve, reject) => {
+      let hasStartedLoading = internalDoc.dataStatus.load === DocumentLoadStatus.LOADING;
       const unsubscribe = this.onStatusChange(docRef, (_, status) => {
-        if (status.data.load === DocumentLoadStatus.LOADED) {
-          unsubscribe();
-          resolve();
-        } else if (status.data.load === DocumentLoadStatus.ERROR) {
-          unsubscribe();
-          reject(new Error("Data load error", { cause: status.data.error }));
+        switch (status.data.load) {
+          case DocumentLoadStatus.LOADING:
+            hasStartedLoading = true;
+            break;
+          case DocumentLoadStatus.LOADED:
+            unsubscribe();
+            resolve();
+            break;
+          case DocumentLoadStatus.ERROR:
+            unsubscribe();
+            reject(new Error("Data load error", { cause: status.data.error }));
+            break;
+          case DocumentLoadStatus.UNLOADED:
+            if (hasStartedLoading) {
+              unsubscribe();
+              reject(new Error("Data load canceled"));
+            }
+            break;
         }
       });
     });

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -524,19 +524,9 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     if (internalDoc.syncSession) {
       this.eventService.stopDocumentSync(internalDoc.syncSession);
       internalDoc.syncSession = undefined;
-      this.updateDataStatus(internalDoc, docRef, {
-        live: DocumentLiveStatus.DISCONNECTED,
-        load: DocumentLoadStatus.UNLOADED,
-      });
-    } else if (
-      internalDoc.dataStatus.load === DocumentLoadStatus.LOADING
-      || internalDoc.dataStatus.load === DocumentLoadStatus.ERROR
-    ) {
-      this.updateDataStatus(internalDoc, docRef, {
-        live: DocumentLiveStatus.DISCONNECTED,
-        load: DocumentLoadStatus.UNLOADED,
-      });
     }
+    // Data status reset (UNLOADED/DISCONNECTED) is owned by the base class,
+    // which applies it after this hook returns.
     if (
       internalDoc.metadataStatus.load === DocumentLoadStatus.ERROR
       && internalDoc.metadataSubscribers.size === 0


### PR DESCRIPTION
waitForDataLoad resolves off dataStatus.load === LOADED, treated by callers as "safe to read/write." On a reopen of a previously-loaded document, that status could still read LOADED from the prior open, so waitForDataLoad short-circuits and resolves against a subscription that has been torn down and not yet re-established. Callers then act on stale state.

The root cause is that the reset of data status to UNLOADED on subscription close lived in the FoundryDocumentService subclass and was conditional — a close in a state that matched none of its branches left status at LOADED. Because the reopen gate only fires when status is UNLOADED, a stale LOADED silently blocked the fresh load.

This should fix and make waitForDataLoad be reliable as a write-ready signal.