### PR TITLE
Guard meta tag reads against non-DOM scopes

### DIFF
--- a/.changeset/page-env-non-dom-guard.md
+++ b/.changeset/page-env-non-dom-guard.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.app": patch
+---
+
+Guard meta tag reads against non-DOM scopes. `getPageEnv` called `document.querySelectorAll` unconditionally, so it threw `ReferenceError: document is not defined` in a Worker, SharedWorker, or Node scope — the only DOM dependency left on PACK's worker path. `getMetaTagContent` now returns `null` when `document` is undefined, so callers fall back to their explicit `options` and get the normal "missing configuration" errors instead of a `ReferenceError`. Browser behavior is unchanged.

--- a/packages/app/src/__tests__/getPageEnv.test.ts
+++ b/packages/app/src/__tests__/getPageEnv.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { getPageEnv, getPageEnvOrThrow } from "../utils/getPageEnv.js";
+
+/** Mutable view of the global scope, so tests can simulate a scope with no `document`. */
+const globalScope = globalThis as { document?: unknown };
+const realDocument = globalScope.document;
+
+/** Simulate a Worker / Node scope, where `document` is not defined at all. */
+function removeDocumentGlobal(): void {
+  globalScope.document = undefined;
+}
+
+describe("getPageEnv", () => {
+  afterEach(() => {
+    globalScope.document = realDocument;
+    document.head.innerHTML = "";
+  });
+
+  it("reads values from meta tags", () => {
+    document.head.innerHTML = `
+      <meta name="pack-appId" content="my-app" />
+      <meta name="osdk-foundryUrl" content="https://example.com" />
+      <meta name="pack-demoMode" content="true" />
+    `;
+
+    const env = getPageEnv();
+
+    expect(env.appId).toBe("my-app");
+    expect(env.baseUrl).toBe("https://example.com");
+    expect(env.demoMode).toBe(true);
+  });
+
+  it("throws when a meta tag still holds a build placeholder", () => {
+    document.head.innerHTML = `<meta name="pack-appId" content="%PACK_APP_ID%" />`;
+
+    expect(() => getPageEnv()).toThrow(/placeholder value/);
+  });
+
+  describe("in a non-DOM scope", () => {
+    it("returns null values instead of throwing", () => {
+      removeDocumentGlobal();
+
+      const env = getPageEnv();
+
+      expect(env.appId).toBeNull();
+      expect(env.baseUrl).toBeNull();
+      expect(env.clientId).toBeNull();
+      expect(env.documentTypeName).toBeNull();
+      expect(env.ontologyRid).toBeNull();
+      // demoMode is derived from a string compare, so it is false rather than null.
+      expect(env.demoMode).toBe(false);
+    });
+
+    it("reports the missing required tags rather than a ReferenceError", () => {
+      removeDocumentGlobal();
+
+      expect(() => getPageEnvOrThrow()).toThrow(
+        /Missing required page environment meta tags/,
+      );
+    });
+  });
+});

--- a/packages/app/src/utils/getPageEnv.ts
+++ b/packages/app/src/utils/getPageEnv.ts
@@ -99,6 +99,12 @@ export function getPageEnvOrThrow(): RequiredPageEnv {
 }
 
 function getMetaTagContent(tagName: string): string | null {
+  // Non-DOM scopes (Worker, SharedWorker, Node) have no meta tags to read. Callers that need a
+  // value there must pass it explicitly via options, all of which override the page env.
+  if (typeof document === "undefined") {
+    return null;
+  }
+
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
   const element = elements.item(elements.length - 1);
 


### PR DESCRIPTION
## Summary

`getPageEnv` called `document.querySelectorAll` unconditionally, so it threw `ReferenceError: document is not defined` in a Worker, SharedWorker, or Node scope. This was the only remaining DOM dependency on PACK's worker path — `state/*` and `auth` are otherwise DOM-free.

`getMetaTagContent` now returns `null` when `document` is undefined. Browser behaviour is byte-for-byte unchanged; the guard only fires where there is no DOM.

## Why it matters

Found by a team running `@palantir/pack.app` inside a browser SharedWorker, so that every tab of an application shares one PACK client and one connection rather than each opening its own.

## What callers see in a non-DOM scope

A hard `ReferenceError` becomes the same "missing configuration" errors a browser page produces when the meta tags are absent:

| Consumer | Behaviour |
|---|---|
| `getAppConfig` → `appId` | throws `No appId provided or present in document meta[pack-appId]` unless `options.app.appId` is passed |
| `getAppConfig` → `ontologyRid` | rejected promise `No ontologyRid provided…` unless `options.ontologyRid` is passed |
| `getAppConfig` → `appVersion` | `undefined` |
| `getAppConfig` → `baseUrl` / `fetchFn` | unaffected — sourced from `options.remote` or the OSDK client context |
| `getPageEnvOrThrow()` | throws listing exactly which tags are missing |
| `isDemoEnv()` | returns `false` |

So a worker consumer must pass `options.app.appId` and `options.ontologyRid`. Both omissions fail loudly.

## Test plan

- [x] New `getPageEnv.test.ts` — 4 tests. The file previously had no coverage at all, so 2 cover the existing DOM path and 2 the non-DOM path.
- [x] `@palantir/pack.app` test count 17 → 21 passing, with the **same 31 pre-existing failures** before and after (confirmed by stashing). Those are network-dependent OAuth tests resolving `test.palantir.com`, a non-routable placeholder host, and are unrelated to this change.
- [x] `typecheck`, `eslint`, `dprint`, `cspell` clean.

## Notes

Unrelated latent bug noticed while tracing consumers, **not** addressed here: `getPageEnv` computes `demoMode = demoModeStr === "true"`, always a boolean despite `PageEnv.demoMode` being typed `boolean | null`. So `isDemoEnv`'s documented "fall back to checking `baseUrl`" branch is unreachable. Fixing it changes browser behaviour, so it wants its own decision.