### PR TITLE
Fail fast instead of hanging in waitForMetadataLoad

### DIFF
--- a/.changeset/wait-for-metadata-load-guard.md
+++ b/.changeset/wait-for-metadata-load-guard.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.state.core": patch
+---
+
+Fix `waitForMetadataLoad` hanging forever when no metadata load will ever start. Metadata loads are demand-driven in the same way as data loads, but `waitForMetadataLoad` had none of the fast-fail guarding that `waitForDataLoad` gained: calling it on a document with no metadata subscription returned a promise that never settled, with no timeout and no status transition to wake it. It now rejects with the same explanatory message shape as the data path. The guard keys off the load status rather than the subscription flag, so an in-flight load is still awaited even after its subscription is dropped.

--- a/packages/state/core/src/__tests__/DocumentStatusTracking.test.ts
+++ b/packages/state/core/src/__tests__/DocumentStatusTracking.test.ts
@@ -273,4 +273,43 @@ describe("Document Status Tracking", () => {
       /no data subscription is registered/,
     );
   });
+
+  it("should reject waitForMetadataLoad when no subscription is registered", async () => {
+    const mockApp = createTestApp();
+    const service = internalCreateInMemoryDocumentService(mockApp, { autoCreateDocuments: true });
+    const docRef = createDocRef(mockApp, DOCUMENT_ID, testSchema);
+
+    // No subscription means no load will ever start; must fail fast, not hang.
+    await expect(service.waitForMetadataLoad(docRef)).rejects.toThrow(
+      /no metadata subscription is registered/,
+    );
+  });
+
+  it("should resolve waitForMetadataLoad once a metadata subscription starts the load", async () => {
+    const mockApp = createTestApp();
+    const service = internalCreateInMemoryDocumentService(mockApp, { autoCreateDocuments: true });
+    const docRef = createDocRef(mockApp, DOCUMENT_ID, testSchema);
+
+    const unsubscribe = service.onMetadataChange(docRef, () => {});
+
+    await expect(service.waitForMetadataLoad(docRef)).resolves.toBeUndefined();
+    expect(service.getDocumentStatus(docRef).metadata.load).toBe(DocumentLoadStatus.LOADED);
+
+    unsubscribe();
+  });
+
+  it("should not reject waitForMetadataLoad while a load is already in flight", async () => {
+    const mockApp = createTestApp();
+    const service = internalCreateInMemoryDocumentService(mockApp, { autoCreateDocuments: true });
+    const docRef = createDocRef(mockApp, DOCUMENT_ID, testSchema);
+
+    // Subscribing puts the load in flight, then dropping the subscription clears
+    // hasMetadataSubscriptions. The guard keys off load status, not the flag, so an
+    // in-flight load must still be awaited rather than rejected on entry.
+    const unsubscribe = service.onMetadataChange(docRef, () => {});
+    const pending = service.waitForMetadataLoad(docRef);
+    unsubscribe();
+
+    await expect(pending).resolves.toBeUndefined();
+  });
 });

--- a/packages/state/core/src/service/BaseYjsDocumentService.ts
+++ b/packages/state/core/src/service/BaseYjsDocumentService.ts
@@ -1714,6 +1714,23 @@ export abstract class BaseYjsDocumentService<TDoc extends InternalYjsDoc = Inter
       );
     }
 
+    // Metadata loads are demand-driven, like data loads: they only start when a metadata
+    // subscription is registered, or when a subclass pulls metadata in for a data subscription
+    // (`ensureMetadataLoaded`). Both paths move the status off UNLOADED synchronously, so an
+    // UNLOADED status with no metadata subscription means no load will ever start — waiting on
+    // it would hang forever. Fail fast instead.
+    if (
+      !internalDoc.hasMetadataSubscriptions
+      && internalDoc.metadataStatus.load === DocumentLoadStatus.UNLOADED
+    ) {
+      return Promise.reject(
+        new Error(
+          "Cannot wait for metadata load: no metadata subscription is registered for this "
+            + "document, so no load will start. Subscribe (e.g. onMetadataChange) before waiting.",
+        ),
+      );
+    }
+
     // Wait for status to change to LOADED or ERROR
     return new Promise((resolve, reject) => {
       let hasStartedLoading = internalDoc.metadataStatus.load === DocumentLoadStatus.LOADING;


### PR DESCRIPTION
## Summary

Metadata loads are demand-driven in the same way as data loads — they only start when a metadata subscription is registered, or when a subclass pulls metadata in for a data subscription via `ensureMetadataLoaded`. But `waitForMetadataLoad` had none of the fast-fail guarding that `waitForDataLoad` gained in #295: calling it on a document with no metadata subscription returned a promise that **never settled**, with no timeout and no status transition to wake it.

It now rejects with the same message shape as the data path.

## Reproduced before fixing

```ts
const service = internalCreateInMemoryDocumentService(app, { autoCreateDocuments: true });
const docRef = createDocRef(app, DOCUMENT_ID, schema);

await service.waitForDataLoad(docRef);      // rejects (fixed by #295)
await service.waitForMetadataLoad(docRef);  // hangs forever
```

`waitForMetadataLoad` is public API, exposed on both `DocumentService` and `StateModule`.

## Why the guard keys off load status, not the subscription flag

My first attempt guarded on `!hasMetadataSubscriptions && !hasDataSubscriptions && load === UNLOADED`, and a test caught it: `InMemoryDocumentService` never loads metadata from a data subscription — only `FoundryDocumentService` and `DemoDocumentService` call `ensureMetadataLoaded`. That broader condition would have let it hang again.

Keying off `metadataStatus.load` works for all three implementations, because every path that starts a metadata load moves the status off `UNLOADED` **synchronously**. It also means an in-flight load is still awaited after its subscription is dropped, rather than being rejected on entry.

## Context

An external team hit the sibling hang on the data channel and reported it. That one was already fixed by unreleased #295 — they were running published `0.20.0`, which lacked the guard they quoted from source. This PR closes the same hole on the channel where it is still open at HEAD.

## Test plan

- [x] 3 new tests in `DocumentStatusTracking.test.ts`, each failing before the fix with a 5s timeout: rejects with no subscription; resolves once a subscription starts the load; does not reject while a load is already in flight.
- [x] `state/core` 125 passing.
- [x] Downstream unaffected: `state/foundry` 64, `foundry-event` 39, `demo` 11, `react` 21.
- [x] `typecheck`, `eslint`, `dprint` clean.
- [x] **Confirmed on a live Foundry stack** by an integration test added in #305: calling `waitForMetadataLoad` on a document whose subscription has been dropped **hangs for the full 90s timeout** without this fix, and rejects in 1.6s with it.
