### PR TITLE
Let bundled cometd load in Worker and SharedWorker scopes

### DIFF
--- a/.changeset/cometd-worker-window-alias.md
+++ b/.changeset/cometd-worker-window-alias.md
@@ -1,0 +1,7 @@
+---
+"@palantir/pack.state.foundry-event": patch
+---
+
+Let the bundled cometd load in Worker and SharedWorker scopes. cometd resolves its browser globals off `window` rather than `globalThis` — it reads `window.setTimeout` while constructing a CometD instance and `window.WebSocket` when registering transports — so subscribing threw `ReferenceError: window is not defined` in a worker, surfacing as "Failed to subscribe to metadata updates" while the document still loaded over HTTP and simply never went live. `lazyLoadCometD` now aliases `window` to the global scope before importing cometd, guarded on `WebSocket` being present and on there being no real `window` to overwrite. This is an alias rather than a stub: every API cometd touches on the websocket path exists in worker scope, just not under that name. The one exception, `sessionStorage`, is read only by `ReloadExtension.js`, which this package never loads.
+
+Also names the `CometD` constructor explicitly in the loader's return value. When cometd resolves through CJS interop, the module namespace exposes its exports via non-enumerable accessors, so the object spread dropped the constructor and left consumers with `TypeError: CometD is not a constructor`.

--- a/packages/state/foundry-event/src/__tests__/lazyLoadCometD.test.ts
+++ b/packages/state/foundry-event/src/__tests__/lazyLoadCometD.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { lazyLoadCometD } from "../cometd/lazyLoadCometD.js";
+
+/**
+ * These tests run in the node environment, which — like a Worker or SharedWorker — provides
+ * `WebSocket` but no `window`. That makes it a faithful stand-in for worker scope.
+ */
+const globalScope = globalThis as { window?: unknown };
+
+/**
+ * The alias is gated on `WebSocket`, so that it is only installed where cometd could actually run.
+ * Node 20 has no global `WebSocket`, and neither transport cometd offers can work there, so the
+ * guard correctly declines and the alias-dependent cases below do not apply.
+ */
+const hasWebSocket = typeof globalThis.WebSocket === "function";
+
+describe("lazyLoadCometD", () => {
+  afterEach(() => {
+    delete globalScope.window;
+  });
+
+  it("loads cometd in a scope with no window global", async () => {
+    expect(globalScope.window).toBeUndefined();
+
+    const loaded = await lazyLoadCometD();
+
+    expect(typeof loaded.CometD).toBe("function");
+    // AckExtension is composed in separately; it is the extension PACK actually registers.
+    expect(typeof loaded.AckExtension).toBe("function");
+  });
+
+  it.skipIf(!hasWebSocket)("aliases window to the global scope", async () => {
+    await lazyLoadCometD();
+
+    expect(globalScope.window).toBe(globalThis);
+  });
+
+  it.skipIf(!hasWebSocket)(
+    "constructs a CometD instance, which reads window.setTimeout",
+    async () => {
+      const { CometD } = await lazyLoadCometD();
+
+      // Regression guard: cometd reads window.setTimeout during construction, so this threw
+      // ReferenceError before the alias existed — before any transport was chosen.
+      expect(() => new CometD()).not.toThrow();
+    },
+  );
+
+  it("does not overwrite an existing window global", async () => {
+    const existingWindow = { marker: "real-window" };
+    globalScope.window = existingWindow;
+
+    await lazyLoadCometD();
+
+    expect(globalScope.window).toBe(existingWindow);
+  });
+});

--- a/packages/state/foundry-event/src/cometd/lazyLoadCometD.ts
+++ b/packages/state/foundry-event/src/cometd/lazyLoadCometD.ts
@@ -16,7 +16,31 @@
 
 import type * as cometd from "cometd";
 
+/**
+ * cometd resolves its browser globals off `window` rather than `globalThis`: it reads
+ * `window.setTimeout` while constructing a CometD instance and `window.WebSocket` when registering
+ * transports, so it throws `ReferenceError: window is not defined` in a Worker or SharedWorker
+ * before any transport is chosen. Every API it touches on the websocket path exists in worker
+ * scope, just not under a global named `window`, so aliasing is sufficient — this is an alias, not
+ * a stub.
+ *
+ * The one thing cometd wants that a worker genuinely lacks is `sessionStorage`, read only by
+ * `ReloadExtension.js`, which this package never loads (it loads `AckExtension.js` explicitly).
+ *
+ * Gated on `WebSocket` being present so we only alias in a scope that can actually support cometd,
+ * and never overwrite a real `window`.
+ */
+function ensureWindowGlobalForCometD(): void {
+  if (typeof window !== "undefined" || typeof globalThis.WebSocket !== "function") {
+    return;
+  }
+  (globalThis as { window?: unknown }).window = globalThis;
+}
+
 export async function lazyLoadCometD(): Promise<typeof cometd> {
+  // Must run before the import: cometd reads `window` as its module body evaluates.
+  ensureWindowGlobalForCometD();
+
   const cometdModule = await import("cometd");
 
   // When dynamically imported as ESM (e.g. in Vite dev mode where
@@ -34,5 +58,9 @@ export async function lazyLoadCometD(): Promise<typeof cometd> {
   // @ts-expect-error TS2307: No type declarations for cometd/AckExtension.js, but its default export is the AckExtension constructor
   const { default: AckExtension } = await import("cometd/AckExtension.js");
 
-  return { ...resolved, AckExtension };
+  // `CometD` is read explicitly rather than left to the spread: when cometd resolves through CJS
+  // interop, the module namespace exposes its exports via non-enumerable accessors, so
+  // `{ ...resolved }` yields only `default`/`module.exports` and drops the constructor. Property
+  // access works, so name the two symbols consumers actually destructure.
+  return { ...resolved, AckExtension, CometD: resolved.CometD };
 }


### PR DESCRIPTION
## Summary

cometd resolves its browser globals off `window` rather than `globalThis`. In a Worker or SharedWorker it throws `ReferenceError: window is not defined`, surfacing as:

```
error PACK FoundryEventService  Failed to subscribe to metadata updates
  ReferenceError: window is not defined
error PACK FoundryDocumentService Failed to subscribe to metadata updates
```

The document still loads over HTTP and then simply never goes live, so the symptom points at a broken socket rather than a missing global.

`lazyLoadCometD` now aliases `window` to the global scope before importing cometd, gated on `WebSocket` being present and on there being no real `window` to overwrite.

## This is an alias, not a stub

Every API cometd touches on the websocket path genuinely exists in worker scope, just not under a global named `window`:

| Reference | cometd.js | When |
|---|---|---|
| `window.setTimeout` | :49 | CometD **construction** |
| `window.clearTimeout` | :51 | scheduler |
| `window.WebSocket` | :1254, :3495 | transport registration |
| `new window.WebSocket(...)` | :986 | connect |

Note `:49` runs during construction, so this fails regardless of which transport is selected — it is not websocket-specific.

The one thing cometd wants that a worker genuinely lacks is `sessionStorage`, read only by `ReloadExtension.js`. This package never loads it — it imports `AckExtension.js` explicitly.

## Second fix in the same file

The loader also names the `CometD` constructor explicitly in its return value. When cometd resolves through CJS interop the module namespace exposes exports via non-enumerable accessors, so the existing object spread silently dropped the constructor:

```
Object.keys(cometdModule)        → ['default', 'module.exports']
'CometD' in cometdModule         → true       ← so the `in` check takes this branch
cometdModule.CometD              → function   ← direct access works
Object.keys({...cometdModule})   → ['default', 'module.exports']   ← spread loses it
```

Consumers then hit `TypeError: CometD is not a constructor`. The published bundle inlines cometd (`bundleNoExternal`) and produces real named exports, so this is defensive for consumers whose bundler leaves cometd external — and it is what lets the test below actually construct a CometD instance.

## Test plan

- [x] New `lazyLoadCometD.test.ts` — 4 tests. This package's tests run in the **node** environment, which like a worker provides `WebSocket` but no `window`, making it a faithful stand-in.
- [x] The load-bearing assertion is `new CometD()` not throwing: `window.setTimeout` is read inside the constructor, so it fails with `ReferenceError` without the alias and `TypeError: CometD is not a constructor` without the spread fix.
- [x] Also covers: loads with no `window`; aliases `window` to `globalThis`; does **not** overwrite an existing `window`.
- [x] `foundry-event` 39 → 43 passing. `typecheck` clean, `eslint` 0 errors (16 warnings all pre-existing in an untouched file).

## Node 20 in the CI matrix

The alias is gated on `WebSocket` so it is only installed where cometd could actually run. Node 20 has no global `WebSocket`, and neither transport cometd offers can work there, so the guard correctly declines — declining to mutate a global in a scope that cannot use it is the intended behaviour, not something to work around.

The two alias-dependent tests are therefore `skipIf`'d when no global `WebSocket` exists. Verified by simulating it locally: **2 passed | 2 skipped**, no failures. The first CI run failed on Node 20 for exactly this reason before the gate was added. Node 24 was reported failing in the same run but was only cancelled by fail-fast — its test step passed.
