### PR TITLE
Hold local writes made during the initial load instead of dropping them

### DIFF
--- a/.changeset/presync-write-catchup.md
+++ b/.changeset/presync-write-catchup.md
@@ -1,0 +1,13 @@
+---
+"@palantir/pack.state.foundry-event": patch
+---
+
+Stop discarding local writes made while a document's initial load is in flight. Between the Yjs `update` listener being attached in `startDocumentSync` and the server's first revision arriving, local updates hit a `lastRevisionId == null` check and were dropped with only a log line. The publish payload carries no revision of its own — the server resolves a publish against the revision the client last acknowledged on its update subscription — so there was nothing to publish against yet. Nothing surfaced the loss: the writing client read its own value back correctly, while the update never reached the server and peers never saw it. Those updates are now held and flushed in order once the first revision establishes `lastRevisionId`.
+
+Two cases that were previously silent now say so. Held updates that are still queued when sync stops are discarded with a warning rather than quietly, since a load that never completes leaves them with nothing to publish against. A queue that grows past a threshold warns that the load looks stuck instead of accumulating unnoticed.
+
+Two windows remain, both of them earlier than the one this fixes, and both still silent.
+
+Writes made before any data subscription opens are still lost: the `update` listener is only attached when the first data subscription registers, so those transactions produce no event to publish.
+
+Writes made _during_ the open are also still lost. `FoundryDocumentService.onDataSubscriptionOpened` reports `load: LOADING` and `live: CONNECTING`, then awaits `waitForMetadataLoad` — an HTTP round-trip — before calling `startDocumentSync`, which is where the publish-side listener is attached. Across that window the document already reports itself as loading, but a write produces no publish event at all, so it is dropped with neither a queue entry nor a log line. That window is plausibly longer than the one the queue covers. Closing it means hoisting the hold into `FoundryDocumentService`, which owns the `Y.Doc` for the whole open, rather than `FoundryEventService`, which does not exist until `startDocumentSync` runs.

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -71,6 +71,9 @@ export interface PresencePublishOptions {
 
 const UPDATE_ORIGIN_REMOTE = "remote" as const;
 
+/** Queue depth at which held updates stop looking like a normal load and start looking stuck. */
+const PENDING_PUBLISH_WARN_THRESHOLD = 100;
+
 const getDocumentUpdatesChannelId = (
   documentId: DocumentId,
 ): TypedReceiveChannelId<DocumentUpdateMessage> =>
@@ -115,6 +118,14 @@ interface SyncSessionInternal extends SyncSession {
     doc: y.Doc,
     transaction: y.Transaction,
   ) => void;
+  /**
+   * Local updates produced before the server's first revision is known. The publish payload
+   * carries no revision of its own; the server resolves a publish against the revision this
+   * client last acknowledged on its update subscription (`DocumentUpdateSubscriptionRequest`.
+   * `lastRevisionId`), and until the initial load delivers one there is no such revision. They
+   * are held here and flushed in order once it is established.
+   */
+  pendingPublishes: DocumentPublishMessage[];
   yDoc?: y.Doc;
 }
 
@@ -192,6 +203,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         documentSubscriptionId: undefined,
         lastRevisionId: undefined,
         localYDocUpdateHandler: undefined,
+        pendingPublishes: [],
         yDoc: undefined,
       };
       this.sessions.set(sessionId, session);
@@ -227,40 +239,11 @@ class FoundryEventServiceImpl implements FoundryEventService {
         return;
       }
 
-      const lastRevisionId = session.lastRevisionId;
-      if (lastRevisionId == null) {
-        this.logger.error(
-          "Cannot publish document update before initial load is complete. The local state will remain inconsistent.",
-          { docId: documentId },
-        );
-        return;
-      }
-
-      const publishChannelId = getDocumentPublishChannelId(documentId);
-      const editId = generateId();
-      const description = isEditDescription(origin)
-        ? createDocumentEditDescription(origin)
-        : undefined;
-      const documentUpdateSchemaVersion = getDocumentUpdateSchemaVersionFromTransaction(transaction)
-        ?? getDocumentSchemaOperationalVersion?.()
-        ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange);
-      const publishMessage: DocumentPublishMessage = {
-        clientId: session.clientId,
-        clientSupportedVersionRange,
-        description,
-        documentUpdateSchemaVersion,
-        editId,
-        yjsUpdate: {
-          data: Base64.fromUint8Array(update),
-        },
-      };
-      void this.eventService.publish(
-        publishChannelId,
-        publishMessage,
-      ).catch((error: unknown) => {
-        this.logger.error("Failed to publish document update", error, {
-          docId: documentId,
-        });
+      this.publishOrQueueUpdate(session, clientSupportedVersionRange, update, {
+        description: isEditDescription(origin) ? createDocumentEditDescription(origin) : undefined,
+        documentUpdateSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction)
+          ?? getDocumentSchemaOperationalVersion?.()
+          ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
       });
     };
 
@@ -509,6 +492,16 @@ class FoundryEventServiceImpl implements FoundryEventService {
       internalSession.documentSubscriptionId = undefined;
     }
     internalSession.lastRevisionId = undefined;
+    // Sync stopped before the initial load established a revision, so these were never publishable
+    // and there is nothing to send them against now. They stay in the local Y.Doc but the server
+    // never learns of them — the same loss this queue exists to prevent, so say so out loud.
+    if (internalSession.pendingPublishes.length > 0) {
+      this.logger.warn("Discarding local document updates held for a load that never completed", {
+        docId: internalSession.documentId,
+        discardedCount: internalSession.pendingPublishes.length,
+      });
+      internalSession.pendingPublishes = [];
+    }
     internalSession.yDoc = undefined;
   }
 
@@ -524,6 +517,87 @@ class FoundryEventServiceImpl implements FoundryEventService {
     }
     this.stopDocumentSync(session);
     this.sessions.delete(sessionId);
+  }
+
+  /**
+   * Publish a local Yjs update, or hold it until the initial load establishes `lastRevisionId` —
+   * the revision the server resolves this client's publishes against, sent on the update
+   * subscription rather than on the publish itself. Updates were previously dropped with only a
+   * log line in that window, which lost them silently.
+   */
+  private publishOrQueueUpdate(
+    session: SyncSessionInternal,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    update: Uint8Array,
+    options: {
+      description?: DocumentPublishMessage["description"];
+      documentUpdateSchemaVersion: number;
+    },
+  ): void {
+    const publishMessage: DocumentPublishMessage = {
+      clientId: session.clientId,
+      clientSupportedVersionRange,
+      description: options.description,
+      documentUpdateSchemaVersion: options.documentUpdateSchemaVersion,
+      editId: generateId(),
+      yjsUpdate: {
+        data: Base64.fromUint8Array(update),
+      },
+    };
+
+    if (session.lastRevisionId == null) {
+      session.pendingPublishes.push(publishMessage);
+      const pendingCount = session.pendingPublishes.length;
+      // Nothing bounds the queue: an initial load that never completes grows it for as long as
+      // edits keep arriving. Warn on crossing the threshold rather than dropping edits, since
+      // dropping is the failure this queue exists to prevent.
+      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
+        this.logger.warn("Local document updates are piling up while the initial load completes", {
+          docId: session.documentId,
+          pendingCount,
+        });
+      } else {
+        this.logger.debug("Holding local document update until the initial load completes", {
+          docId: session.documentId,
+          pendingCount,
+        });
+      }
+      return;
+    }
+
+    this.publishUpdate(session, publishMessage);
+  }
+
+  private publishUpdate(
+    session: SyncSessionInternal,
+    publishMessage: DocumentPublishMessage,
+  ): void {
+    void this.eventService.publish(
+      getDocumentPublishChannelId(session.documentId),
+      publishMessage,
+    ).catch((error: unknown) => {
+      this.logger.error("Failed to publish document update", error, {
+        docId: session.documentId,
+      });
+    });
+  }
+
+  /** Flush updates held while the revision was unknown, preserving the order they were made in. */
+  private flushPendingPublishes(session: SyncSessionInternal): void {
+    if (session.pendingPublishes.length === 0) {
+      return;
+    }
+
+    const pending = session.pendingPublishes;
+    session.pendingPublishes = [];
+    this.logger.debug("Publishing local document updates held during the initial load", {
+      docId: session.documentId,
+      pendingCount: pending.length,
+    });
+
+    for (const publishMessage of pending) {
+      this.publishUpdate(session, publishMessage);
+    }
   }
 
   private handleDocumentUpdateMessage(
@@ -611,6 +685,9 @@ class FoundryEventServiceImpl implements FoundryEventService {
           }
         }
         session.lastRevisionId = Number(revisionId);
+
+        // The revision is known, so anything held during the load can go out now.
+        this.flushPendingPublishes(session);
 
         onStatusChange({
           load: DocumentLoadStatus.LOADED,

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -72,6 +72,9 @@ export interface PresencePublishOptions {
 
 const UPDATE_ORIGIN_REMOTE = "remote" as const;
 
+/** Queue depth at which held updates stop looking like a normal load and start looking stuck. */
+const PENDING_PUBLISH_WARN_THRESHOLD = 100;
+
 const getDocumentUpdatesChannelId = (
   documentId: DocumentId,
 ): TypedReceiveChannelId<DocumentUpdateMessage> =>
@@ -118,6 +121,15 @@ interface SyncSessionInternal extends SyncSession {
   ) => void;
   /** Published updates awaiting ack; created on sync start, cleared on stop. */
   outbox?: UnackedUpdateOutbox;
+  /**
+   * Local updates produced before the server's first revision is known. The publish payload
+   * carries no revision of its own; the server resolves a publish against the revision this
+   * client last acknowledged on its update subscription (`DocumentUpdateSubscriptionRequest`.
+   * `lastRevisionId`), and until the initial load delivers one there is no such revision. They
+   * are held here and flushed in order once it is established. Distinct from `outbox`, which
+   * tracks updates already published and awaiting ack.
+   */
+  pendingPublishes: DocumentPublishMessage[];
   yDoc?: y.Doc;
 }
 
@@ -196,6 +208,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         lastRevisionId: undefined,
         localYDocUpdateHandler: undefined,
         outbox: undefined,
+        pendingPublishes: [],
         yDoc: undefined,
       };
       this.sessions.set(sessionId, session);
@@ -244,34 +257,12 @@ class FoundryEventServiceImpl implements FoundryEventService {
         return;
       }
 
-      const lastRevisionId = session.lastRevisionId;
-      if (lastRevisionId == null) {
-        this.logger.error(
-          "Cannot publish document update before initial load is complete. The local state will remain inconsistent.",
-          { docId: documentId },
-        );
-        return;
-      }
-
-      const editId = generateId();
-      const description = isEditDescription(origin)
-        ? createDocumentEditDescription(origin)
-        : undefined;
-      const documentUpdateSchemaVersion = getDocumentUpdateSchemaVersionFromTransaction(transaction)
-        ?? getDocumentSchemaOperationalVersion?.()
-        ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange);
-      const publishMessage: DocumentPublishMessage = {
-        clientId: session.clientId,
-        clientSupportedVersionRange,
-        description,
-        documentUpdateSchemaVersion,
-        editId,
-        yjsUpdate: {
-          data: Base64.fromUint8Array(update),
-        },
-      };
-      outbox.add(editId, publishMessage);
-      this.publishDocumentUpdate(documentId, publishMessage);
+      this.publishOrQueueUpdate(session, clientSupportedVersionRange, update, {
+        description: isEditDescription(origin) ? createDocumentEditDescription(origin) : undefined,
+        documentUpdateSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction)
+          ?? getDocumentSchemaOperationalVersion?.()
+          ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
+      });
     };
 
     session.localYDocUpdateHandler = localYDocUpdateHandler;
@@ -284,11 +275,19 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
     const channelId = getDocumentUpdatesChannelId(documentId);
 
+    // Scoped to this sync generation. CometD dispatches a transport response's messages
+    // synchronously while the subscribe promise resolves on a microtask, so a channel error
+    // delivered alongside the ack would otherwise be overwritten by the promotion below.
+    let channelFailed = false;
+
     this.eventService.subscribe(
       channelId,
       (message: DocumentUpdateMessage) => {
         if (session.localYDocUpdateHandler !== localYDocUpdateHandler) {
           return;
+        }
+        if (message.type === "error") {
+          channelFailed = true;
         }
         this.handleDocumentUpdateMessage(session, message, yDoc, onStatusChange);
       },
@@ -300,12 +299,14 @@ class FoundryEventServiceImpl implements FoundryEventService {
     ).then(subscriptionId => {
       if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
         session.documentSubscriptionId = subscriptionId;
-        // The channel is subscribed, so the data channel is live. Reported separately from `load`,
-        // which stays LOADING until the first update arrives. Matches how the activity and presence
-        // channels report liveness on subscription establishment.
-        onStatusChange({
-          live: DocumentLiveStatus.CONNECTED,
-        });
+        if (!channelFailed) {
+          // The channel is subscribed, so the data channel is live. Reported separately from
+          // `load`, which stays LOADING until the first update arrives. Matches how the activity
+          // and presence channels report liveness on subscription establishment.
+          onStatusChange({
+            live: DocumentLiveStatus.CONNECTED,
+          });
+        }
       } else {
         this.eventService.unsubscribe(subscriptionId);
       }
@@ -511,6 +512,16 @@ class FoundryEventServiceImpl implements FoundryEventService {
     internalSession.outbox?.clear();
     internalSession.outbox = undefined;
     internalSession.lastRevisionId = undefined;
+    // Sync stopped before the initial load established a revision, so these were never publishable
+    // and there is nothing to send them against now. They stay in the local Y.Doc but the server
+    // never learns of them — the same loss this queue exists to prevent, so say so out loud.
+    if (internalSession.pendingPublishes.length > 0) {
+      this.logger.warn("Discarding local document updates held for a load that never completed", {
+        docId: internalSession.documentId,
+        discardedCount: internalSession.pendingPublishes.length,
+      });
+      internalSession.pendingPublishes = [];
+    }
     internalSession.yDoc = undefined;
   }
 
@@ -528,6 +539,68 @@ class FoundryEventServiceImpl implements FoundryEventService {
     this.sessions.delete(sessionId);
   }
 
+  /**
+   * Publish a local Yjs update, or hold it until the initial load establishes `lastRevisionId` —
+   * the revision the server resolves this client's publishes against, sent on the update
+   * subscription rather than on the publish itself. Updates were previously dropped with only a
+   * log line in that window, which lost them silently.
+   */
+  private publishOrQueueUpdate(
+    session: SyncSessionInternal,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    update: Uint8Array,
+    options: {
+      description?: DocumentPublishMessage["description"];
+      documentUpdateSchemaVersion: number;
+    },
+  ): void {
+    const publishMessage: DocumentPublishMessage = {
+      clientId: session.clientId,
+      clientSupportedVersionRange,
+      description: options.description,
+      documentUpdateSchemaVersion: options.documentUpdateSchemaVersion,
+      editId: generateId(),
+      yjsUpdate: {
+        data: Base64.fromUint8Array(update),
+      },
+    };
+
+    if (session.lastRevisionId == null) {
+      session.pendingPublishes.push(publishMessage);
+      const pendingCount = session.pendingPublishes.length;
+      // Nothing bounds the queue: an initial load that never completes grows it for as long as
+      // edits keep arriving. Warn on crossing the threshold rather than dropping edits, since
+      // dropping is the failure this queue exists to prevent.
+      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
+        this.logger.warn("Local document updates are piling up while the initial load completes", {
+          docId: session.documentId,
+          pendingCount,
+        });
+      } else {
+        this.logger.debug("Holding local document update until the initial load completes", {
+          docId: session.documentId,
+          pendingCount,
+        });
+      }
+      return;
+    }
+
+    this.publishUpdate(session, publishMessage);
+  }
+
+  /**
+   * Track the update for resend until the server acks it, then send it. Held updates flush through
+   * here too, so they get the same ack/retransmit protection as those published immediately.
+   */
+  private publishUpdate(
+    session: SyncSessionInternal,
+    publishMessage: DocumentPublishMessage,
+  ): void {
+    session.outbox?.add(publishMessage.editId, publishMessage);
+    this.publishDocumentUpdate(session.documentId, publishMessage);
+  }
+
+  /** Send without tracking. The resend loop calls this directly, since it is already tracked. */
   private publishDocumentUpdate(
     documentId: DocumentId,
     publishMessage: DocumentPublishMessage,
@@ -542,6 +615,24 @@ class FoundryEventServiceImpl implements FoundryEventService {
         editId: publishMessage.editId,
       });
     });
+  }
+
+  /** Flush updates held while the revision was unknown, preserving the order they were made in. */
+  private flushPendingPublishes(session: SyncSessionInternal): void {
+    if (session.pendingPublishes.length === 0) {
+      return;
+    }
+
+    const pending = session.pendingPublishes;
+    session.pendingPublishes = [];
+    this.logger.debug("Publishing local document updates held during the initial load", {
+      docId: session.documentId,
+      pendingCount: pending.length,
+    });
+
+    for (const publishMessage of pending) {
+      this.publishUpdate(session, publishMessage);
+    }
   }
 
   private handleDocumentUpdateMessage(
@@ -639,6 +730,9 @@ class FoundryEventServiceImpl implements FoundryEventService {
           }
         }
         session.lastRevisionId = Number(revisionId);
+
+        // The revision is known, so anything held during the load can go out now.
+        this.flushPendingPublishes(session);
 
         onStatusChange({
           load: DocumentLoadStatus.LOADED,

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -72,8 +72,7 @@ export interface PresencePublishOptions {
 
 const UPDATE_ORIGIN_REMOTE = "remote" as const;
 
-/** Caps memory growth during a stalled load; later updates are logged and dropped. */
-const PENDING_PUBLISH_MAX = 100;
+const PENDING_PUBLISH_WARN_THRESHOLD = 100;
 
 const getDocumentUpdatesChannelId = (
   documentId: DocumentId,
@@ -565,17 +564,10 @@ class FoundryEventServiceImpl implements FoundryEventService {
     };
 
     if (session.lastRevisionId == null) {
-      if (session.pendingPublishes.length >= PENDING_PUBLISH_MAX) {
-        this.logger.error("Dropping local document update; the hold queue is full", {
-          docId: session.documentId,
-          editId: publishMessage.editId,
-          pendingCount: session.pendingPublishes.length,
-        });
-        return;
-      }
+      // Dropping an update leaves a gap in Yjs client clocks that blocks later edits on peers.
       session.pendingPublishes.push(publishMessage);
       const pendingCount = session.pendingPublishes.length;
-      if (pendingCount === PENDING_PUBLISH_MAX) {
+      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
         this.logger.warn("Local document updates are piling up while the initial load completes", {
           docId: session.documentId,
           pendingCount,

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -72,8 +72,8 @@ export interface PresencePublishOptions {
 
 const UPDATE_ORIGIN_REMOTE = "remote" as const;
 
-/** Queue depth at which held updates stop looking like a normal load and start looking stuck. */
-const PENDING_PUBLISH_WARN_THRESHOLD = 100;
+/** Caps memory growth during a stalled load; later updates are logged and dropped. */
+const PENDING_PUBLISH_MAX = 100;
 
 const getDocumentUpdatesChannelId = (
   documentId: DocumentId,
@@ -111,6 +111,8 @@ export interface SyncSession {
 }
 
 interface SyncSessionInternal extends SyncSession {
+  /** Tracks callback/ack races; false means recovery was already reported. */
+  dataChannelFailed?: boolean;
   documentSubscriptionId?: SubscriptionId;
   lastRevisionId?: number;
   localYDocUpdateHandler?: (
@@ -203,6 +205,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     if (!session) {
       session = {
         clientId: crypto.randomUUID(),
+        dataChannelFailed: undefined,
         documentId,
         documentSubscriptionId: undefined,
         lastRevisionId: undefined,
@@ -275,11 +278,6 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
     const channelId = getDocumentUpdatesChannelId(documentId);
 
-    // Scoped to this sync generation. CometD dispatches a transport response's messages
-    // synchronously while the subscribe promise resolves on a microtask, so a channel error
-    // delivered alongside the ack would otherwise be overwritten by the promotion below.
-    let channelFailed = false;
-
     this.eventService.subscribe(
       channelId,
       (message: DocumentUpdateMessage) => {
@@ -287,7 +285,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
           return;
         }
         if (message.type === "error") {
-          channelFailed = true;
+          session.dataChannelFailed = true;
         }
         this.handleDocumentUpdateMessage(session, message, yDoc, onStatusChange);
       },
@@ -299,7 +297,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     ).then(subscriptionId => {
       if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
         session.documentSubscriptionId = subscriptionId;
-        if (!channelFailed) {
+        if (session.dataChannelFailed === undefined) {
           // The channel is subscribed, so the data channel is live. Reported separately from
           // `load`, which stays LOADING until the first update arrives. Matches how the activity
           // and presence channels report liveness on subscription establishment.
@@ -509,6 +507,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
       this.eventService.unsubscribe(internalSession.documentSubscriptionId);
       internalSession.documentSubscriptionId = undefined;
     }
+    internalSession.dataChannelFailed = undefined;
     internalSession.outbox?.clear();
     internalSession.outbox = undefined;
     internalSession.lastRevisionId = undefined;
@@ -566,12 +565,17 @@ class FoundryEventServiceImpl implements FoundryEventService {
     };
 
     if (session.lastRevisionId == null) {
+      if (session.pendingPublishes.length >= PENDING_PUBLISH_MAX) {
+        this.logger.error("Dropping local document update; the hold queue is full", {
+          docId: session.documentId,
+          editId: publishMessage.editId,
+          pendingCount: session.pendingPublishes.length,
+        });
+        return;
+      }
       session.pendingPublishes.push(publishMessage);
       const pendingCount = session.pendingPublishes.length;
-      // Nothing bounds the queue: an initial load that never completes grows it for as long as
-      // edits keep arriving. Warn on crossing the threshold rather than dropping edits, since
-      // dropping is the failure this queue exists to prevent.
-      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
+      if (pendingCount === PENDING_PUBLISH_MAX) {
         this.logger.warn("Local document updates are piling up while the initial load completes", {
           docId: session.documentId,
           pendingCount,
@@ -734,7 +738,12 @@ class FoundryEventServiceImpl implements FoundryEventService {
         // The revision is known, so anything held during the load can go out now.
         this.flushPendingPublishes(session);
 
+        const dataChannelRecovered = session.dataChannelFailed === true;
+        if (dataChannelRecovered) {
+          session.dataChannelFailed = false;
+        }
         onStatusChange({
+          ...(dataChannelRecovered ? { live: DocumentLiveStatus.CONNECTED } : {}),
           load: DocumentLoadStatus.LOADED,
         });
 

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -23,6 +23,7 @@ import {
   DocumentLoadStatus,
   type DocumentSyncStatus,
 } from "@palantir/pack.state.core";
+import { Base64 } from "js-base64";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { createFoundryEventService } from "../FoundryEventService.js";
@@ -392,6 +393,138 @@ describe("FoundryEventService", () => {
     );
 
     expect(secondSession.clientId).not.toBe(firstSession.clientId);
+  });
+
+  describe("updates made before the initial revision is known", () => {
+    /** Server acknowledgement that establishes lastRevisionId and completes the initial load. */
+    function initialRevision(): DocumentUpdateMessage {
+      return {
+        baseRevisionId: "0",
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId: "1",
+        type: "update",
+      };
+    }
+
+    /** Rebuild what a peer would see from every update this client published, in order. */
+    function applyPublishedUpdates(): Y.Doc {
+      const peerDoc = new Y.Doc();
+      for (const call of mocks.eventService.publish.mock.calls) {
+        const message = call[1] as PublishedDocumentUpdate;
+        const data = message.yjsUpdate?.data;
+        if (typeof data === "string") {
+          Y.applyUpdate(peerDoc, Base64.toUint8Array(data));
+        }
+      }
+      return peerDoc;
+    }
+
+    /**
+     * Keys a peer would observe after each published update, in publish order. The merged end
+     * state cannot distinguish flush order — Yjs buffers an update whose dependencies have not
+     * arrived and integrates it later — so only the intermediate states pin FIFO.
+     */
+    function publishedKeySnapshots(): string[][] {
+      const peerDoc = new Y.Doc();
+      const snapshots: string[][] = [];
+      for (const call of mocks.eventService.publish.mock.calls) {
+        const message = call[1] as PublishedDocumentUpdate;
+        const data = message.yjsUpdate?.data;
+        if (typeof data === "string") {
+          Y.applyUpdate(peerDoc, Base64.toUint8Array(data));
+        }
+        snapshots.push([...peerDoc.getMap("Shape").keys()].sort());
+      }
+      return snapshots;
+    }
+
+    function startSyncCapturingServer(yDoc: Y.Doc): {
+      service: ReturnType<typeof createFoundryEventService>;
+      deliverInitialRevision: () => void;
+    } {
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+
+      const service = createFoundryEventService(app);
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+
+      return { service, deliverInitialRevision: () => updateCallback?.(initialRevision()) };
+    }
+
+    it("holds a write made during the load instead of dropping it", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      // The handler is attached but lastRevisionId is still unknown. This previously logged
+      // "Cannot publish document update before initial load is complete" and discarded the update.
+      yDoc.getMap("Shape").set("shape-1", "during-load");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(1);
+      expect(applyPublishedUpdates().getMap("Shape").get("shape-1")).toBe("during-load");
+    });
+
+    it("preserves the order of writes held across the load", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("first", "during-load");
+      yDoc.getMap("Shape").set("second", "also-during-load");
+      deliverInitialRevision();
+      yDoc.getMap("Shape").set("third", "after-load");
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(3);
+      // Asserted per-update rather than on the merged result: applying all three into one doc
+      // passes just as well for a reversed flush, so it would not test order at all.
+      expect(publishedKeySnapshots()).toEqual([
+        ["first"],
+        ["first", "second"],
+        ["first", "second", "third"],
+      ]);
+    });
+
+    it("publishes nothing when no local write was made during the load", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+    });
+
+    it("warns rather than staying silent when a load never completes", async () => {
+      const yDoc = new Y.Doc();
+      const { service } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("shape-1", "never-published");
+      logger.warn.mockClear();
+
+      // The load never established a revision, so the held update has nothing to publish against
+      // and is dropped. It must not be dropped quietly.
+      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Discarding local document updates"),
+        expect.objectContaining({ discardedCount: 1 }),
+      );
+    });
   });
 
   describe("data channel liveness", () => {

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -23,6 +23,7 @@ import {
   DocumentLoadStatus,
   type DocumentSyncStatus,
 } from "@palantir/pack.state.core";
+import { Base64 } from "js-base64";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { createFoundryEventService } from "../FoundryEventService.js";
@@ -534,6 +535,138 @@ describe("FoundryEventService", () => {
     });
   });
 
+  describe("updates made before the initial revision is known", () => {
+    /** Server acknowledgement that establishes lastRevisionId and completes the initial load. */
+    function initialRevision(): DocumentUpdateMessage {
+      return {
+        baseRevisionId: "0",
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId: "1",
+        type: "update",
+      };
+    }
+
+    /** Rebuild what a peer would see from every update this client published, in order. */
+    function applyPublishedUpdates(): Y.Doc {
+      const peerDoc = new Y.Doc();
+      for (const call of mocks.eventService.publish.mock.calls) {
+        const message = call[1] as PublishedDocumentUpdate;
+        const data = message.yjsUpdate?.data;
+        if (typeof data === "string") {
+          Y.applyUpdate(peerDoc, Base64.toUint8Array(data));
+        }
+      }
+      return peerDoc;
+    }
+
+    /**
+     * Keys a peer would observe after each published update, in publish order. The merged end
+     * state cannot distinguish flush order — Yjs buffers an update whose dependencies have not
+     * arrived and integrates it later — so only the intermediate states pin FIFO.
+     */
+    function publishedKeySnapshots(): string[][] {
+      const peerDoc = new Y.Doc();
+      const snapshots: string[][] = [];
+      for (const call of mocks.eventService.publish.mock.calls) {
+        const message = call[1] as PublishedDocumentUpdate;
+        const data = message.yjsUpdate?.data;
+        if (typeof data === "string") {
+          Y.applyUpdate(peerDoc, Base64.toUint8Array(data));
+        }
+        snapshots.push([...peerDoc.getMap("Shape").keys()].sort());
+      }
+      return snapshots;
+    }
+
+    function startSyncCapturingServer(yDoc: Y.Doc): {
+      service: ReturnType<typeof createFoundryEventService>;
+      deliverInitialRevision: () => void;
+    } {
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+
+      const service = createFoundryEventService(app);
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+
+      return { service, deliverInitialRevision: () => updateCallback?.(initialRevision()) };
+    }
+
+    it("holds a write made during the load instead of dropping it", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      // The handler is attached but lastRevisionId is still unknown. This previously logged
+      // "Cannot publish document update before initial load is complete" and discarded the update.
+      yDoc.getMap("Shape").set("shape-1", "during-load");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(1);
+      expect(applyPublishedUpdates().getMap("Shape").get("shape-1")).toBe("during-load");
+    });
+
+    it("preserves the order of writes held across the load", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("first", "during-load");
+      yDoc.getMap("Shape").set("second", "also-during-load");
+      deliverInitialRevision();
+      yDoc.getMap("Shape").set("third", "after-load");
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(3);
+      // Asserted per-update rather than on the merged result: applying all three into one doc
+      // passes just as well for a reversed flush, so it would not test order at all.
+      expect(publishedKeySnapshots()).toEqual([
+        ["first"],
+        ["first", "second"],
+        ["first", "second", "third"],
+      ]);
+    });
+
+    it("publishes nothing when no local write was made during the load", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+    });
+
+    it("warns rather than staying silent when a load never completes", async () => {
+      const yDoc = new Y.Doc();
+      const { service } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("shape-1", "never-published");
+      logger.warn.mockClear();
+
+      // The load never established a revision, so the held update has nothing to publish against
+      // and is dropped. It must not be dropped quietly.
+      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Discarding local document updates"),
+        expect.objectContaining({ discardedCount: 1 }),
+      );
+    });
+  });
+
   describe("data channel liveness", () => {
     function collectStatus(): {
       statusUpdates: Array<Partial<DocumentSyncStatus>>;
@@ -663,6 +796,34 @@ describe("FoundryEventService", () => {
 
       expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.ERROR);
       expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.CONNECTED);
+    });
+
+    it("does not promote to CONNECTED when a channel error arrives with the subscribe ack", async () => {
+      // CometD dispatches every message in one transport response synchronously, but the
+      // subscribe promise's continuation is a microtask. A channel error delivered in the same
+      // batch as the ack therefore always lands before the promotion runs.
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        const subscribed = Promise.resolve("document-sub" as SubscriptionId);
+        (callback as (message: DocumentUpdateMessage) => void)({
+          code: "REVISION_TOO_OLD",
+          errorInstanceId: "error-instance-1",
+          type: "error",
+        } as unknown as DocumentUpdateMessage);
+        return subscribed;
+      });
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+
+      expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.ERROR);
+      expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.ERROR);
     });
   });
 });

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -647,6 +647,26 @@ describe("FoundryEventService", () => {
       expect(mocks.eventService.publish).not.toHaveBeenCalled();
     });
 
+    it("drops writes after the hold queue reaches its limit", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      for (let index = 0; index < 101; index += 1) {
+        yDoc.getMap("Shape").set(`shape-${index}`, "during-load");
+      }
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(100);
+      const peerDoc = applyPublishedUpdates();
+      expect(peerDoc.getMap("Shape").get("shape-99")).toBe("during-load");
+      expect(peerDoc.getMap("Shape").get("shape-100")).toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("hold queue is full"),
+        expect.objectContaining({ docId: "doc-1", pendingCount: 100 }),
+      );
+    });
+
     it("warns rather than staying silent when a load never completes", async () => {
       const yDoc = new Y.Doc();
       const { service } = startSyncCapturingServer(yDoc);
@@ -682,6 +702,14 @@ describe("FoundryEventService", () => {
       field: K,
     ): DocumentSyncStatus[K] | undefined {
       return statusUpdates.filter(s => s[field] !== undefined).at(-1)?.[field];
+    }
+
+    function selectLiveUpdates(
+      statusUpdates: Array<Partial<DocumentSyncStatus>>,
+    ): DocumentLiveStatus[] {
+      return statusUpdates.flatMap(
+        (status): DocumentLiveStatus[] => status.live == null ? [] : [status.live],
+      );
     }
 
     it("reports CONNECTING while the subscription is being established", () => {
@@ -764,6 +792,133 @@ describe("FoundryEventService", () => {
 
       expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.ERROR);
       expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.ERROR);
+    });
+
+    it("restores CONNECTED once a message proves the channel works again", async () => {
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation(
+        (_channel, callback): Promise<SubscriptionId> => {
+          updateCallback = callback as (message: DocumentUpdateMessage) => void;
+          return Promise.resolve("document-sub" as SubscriptionId);
+        },
+      );
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+      updateCallback?.({
+        code: "REVISION_TOO_OLD",
+        errorInstanceId: "error-instance-1",
+        type: "error",
+      } as unknown as DocumentUpdateMessage);
+      updateCallback?.({
+        baseRevisionId: "0",
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId: "1",
+        type: "update",
+      });
+      updateCallback?.({
+        baseRevisionId: "1",
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId: "2",
+        type: "update",
+      });
+
+      expect(selectLiveUpdates(statusUpdates)).toEqual([
+        DocumentLiveStatus.CONNECTING,
+        DocumentLiveStatus.CONNECTED,
+        DocumentLiveStatus.ERROR,
+        DocumentLiveStatus.CONNECTED,
+      ]);
+      expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.LOADED);
+    });
+
+    it("reports recovery once when an update arrives before the subscribe ack", async () => {
+      mocks.eventService.subscribe.mockImplementation(
+        (_channel, callback): Promise<SubscriptionId> => {
+          const handleUpdate = callback as (message: DocumentUpdateMessage) => void;
+          const subscribed = Promise.resolve("document-sub" as SubscriptionId);
+          handleUpdate({
+            code: "REVISION_TOO_OLD",
+            errorInstanceId: "error-instance-1",
+            type: "error",
+          } as unknown as DocumentUpdateMessage);
+          handleUpdate({
+            baseRevisionId: "0",
+            clientId: "server",
+            clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+            editIds: [],
+            revisionId: "1",
+            type: "update",
+          });
+          return subscribed;
+        },
+      );
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+
+      expect(selectLiveUpdates(statusUpdates)).toEqual([
+        DocumentLiveStatus.CONNECTING,
+        DocumentLiveStatus.ERROR,
+        DocumentLiveStatus.CONNECTED,
+      ]);
+    });
+
+    it("clears channel failure when sync stops", async () => {
+      const updateCallbacks: Array<(message: DocumentUpdateMessage) => void> = [];
+      mocks.eventService.subscribe.mockImplementation(
+        (_channel, callback): Promise<SubscriptionId> => {
+          updateCallbacks.push(callback as (message: DocumentUpdateMessage) => void);
+          return Promise.resolve(`document-sub-${updateCallbacks.length}` as SubscriptionId);
+        },
+      );
+      const service = createFoundryEventService(app);
+      const firstStatus = collectStatus();
+      const session = service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        firstStatus.onStatusChange,
+      );
+      await Promise.resolve();
+      updateCallbacks[0]?.({
+        code: "REVISION_TOO_OLD",
+        errorInstanceId: "error-instance-1",
+        type: "error",
+      } as unknown as DocumentUpdateMessage);
+
+      service.stopDocumentSync(session);
+      const secondStatus = collectStatus();
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        secondStatus.onStatusChange,
+      );
+      await Promise.resolve();
+
+      expect(selectLiveUpdates(secondStatus.statusUpdates)).toEqual([
+        DocumentLiveStatus.CONNECTING,
+        DocumentLiveStatus.CONNECTED,
+      ]);
     });
 
     it("leaves liveness alone when a revision gap makes local state stale", async () => {

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import type { DocumentUpdateMessage } from "@osdk/foundry.pack";
+import type { DocumentPublishMessage, DocumentUpdateMessage } from "@osdk/foundry.pack";
 import type { PackAppInternal } from "@palantir/pack.core";
-import type { DocumentId } from "@palantir/pack.document-schema.model-types";
+import { type DocumentId, Metadata } from "@palantir/pack.document-schema.model-types";
 import {
   addDocumentUpdateSchemaVersionToTransaction,
   DocumentLiveStatus,
@@ -536,6 +536,15 @@ describe("FoundryEventService", () => {
   });
 
   describe("updates made before the initial revision is known", () => {
+    beforeEach((): void => {
+      vi.useFakeTimers();
+      logger.warn.mockClear();
+    });
+
+    afterEach((): void => {
+      vi.useRealTimers();
+    });
+
     /** Server acknowledgement that establishes lastRevisionId and completes the initial load. */
     function initialRevision(): DocumentUpdateMessage {
       return {
@@ -580,7 +589,7 @@ describe("FoundryEventService", () => {
       return snapshots;
     }
 
-    function startSyncCapturingServer(yDoc: Y.Doc): {
+    function startSyncCapturingServer(yDoc: Y.Doc, maxVersion = 1): {
       service: ReturnType<typeof createFoundryEventService>;
       deliverInitialRevision: () => void;
     } {
@@ -594,7 +603,7 @@ describe("FoundryEventService", () => {
       service.startDocumentSync(
         "doc-1" as DocumentId,
         yDoc,
-        { maxVersion: 1, minVersion: 1 },
+        { maxVersion, minVersion: 1 },
         () => {},
       );
 
@@ -647,24 +656,77 @@ describe("FoundryEventService", () => {
       expect(mocks.eventService.publish).not.toHaveBeenCalled();
     });
 
-    it("drops writes after the hold queue reaches its limit", async () => {
+    it.each([99, 100, 101])(
+      "preserves causal history across %i held writes",
+      async (pendingCount): Promise<void> => {
+        const yDoc = new Y.Doc();
+        const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+        await Promise.resolve();
+
+        for (let index = 0; index < pendingCount; index += 1) {
+          yDoc.getMap("Shape").set(`shape-${index}`, "during-load");
+        }
+        expect(mocks.eventService.publish).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledTimes(pendingCount >= 100 ? 1 : 0);
+        deliverInitialRevision();
+        yDoc.getMap("Shape").set("after-load", "still-syncing");
+
+        const peerDoc = applyPublishedUpdates();
+        expect(peerDoc.getMap("Shape").get("after-load")).toBe("still-syncing");
+        expect(peerDoc.getMap("Shape").toJSON()).toEqual(yDoc.getMap("Shape").toJSON());
+        expect(mocks.eventService.publish).toHaveBeenCalledTimes(pendingCount + 1);
+      },
+    );
+
+    it("flushes a large backlog as individual edits with their original metadata", async (): Promise<void> => {
       const yDoc = new Y.Doc();
-      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc, 2);
       await Promise.resolve();
 
       for (let index = 0; index < 101; index += 1) {
-        yDoc.getMap("Shape").set(`shape-${index}`, "during-load");
+        yDoc.transact((transaction): void => {
+          addDocumentUpdateSchemaVersionToTransaction(transaction, index % 2 + 1);
+          yDoc.getMap("Shape").set(`shape-${index}`, "x".repeat(1_024));
+        }, {
+          data: { index },
+          model: { [Metadata]: { name: "shape-edited" } },
+          schemaVersion: 3,
+        });
       }
       deliverInitialRevision();
 
-      expect(mocks.eventService.publish).toHaveBeenCalledTimes(100);
-      const peerDoc = applyPublishedUpdates();
-      expect(peerDoc.getMap("Shape").get("shape-99")).toBe("during-load");
-      expect(peerDoc.getMap("Shape").get("shape-100")).toBeUndefined();
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("hold queue is full"),
-        expect.objectContaining({ docId: "doc-1", pendingCount: 100 }),
+      const messages = mocks.eventService.publish.mock.calls.map(
+        ([, message]): DocumentPublishMessage => message as DocumentPublishMessage,
       );
+      expect(messages).toHaveLength(101);
+      expect(new Set(messages.map((message): string => message.editId)).size).toBe(101);
+
+      const peerDoc = new Y.Doc();
+      let serializedSize = 0;
+      for (const [index, message] of messages.entries()) {
+        expect(message.documentUpdateSchemaVersion).toBe(index % 2 + 1);
+        expect(message.description).toEqual({
+          eventData: { data: { index }, eventType: "shape-edited", schemaVersion: 3 },
+        });
+        const envelope = JSON.stringify({ channel: "/document/doc-1/publish", data: message });
+        expect(envelope.length).toBeLessThan(65_536);
+        serializedSize += envelope.length;
+        const updateData: unknown = message.yjsUpdate.data;
+        if (typeof updateData !== "string") {
+          throw new Error("Expected a base64-encoded Yjs update");
+        }
+        Y.applyUpdate(peerDoc, Base64.toUint8Array(updateData));
+        expect(peerDoc.getMap("Shape").size).toBe(index + 1);
+      }
+      expect(serializedSize).toBeGreaterThan(65_536);
+      expect(peerDoc.getMap("Shape").toJSON()).toEqual(yDoc.getMap("Shape").toJSON());
+
+      vi.advanceTimersByTime(2_000);
+      expect(
+        mocks.eventService.publish.mock.calls.slice(101).map(
+          ([, message]): DocumentPublishMessage => message as DocumentPublishMessage,
+        ),
+      ).toEqual(messages);
     });
 
     it("warns rather than staying silent when a load never completes", async () => {


### PR DESCRIPTION
## Summary

Between the Yjs `update` listener being attached in `startDocumentSync` and the server's first revision arriving, local updates hit a `lastRevisionId == null` check and were discarded with only a log line — a publish must declare the revision it builds on, and there was none yet.

Nothing surfaced the loss. The writing client read its own value back correctly while the update never reached the server, so peers never saw it. Those updates are now held on the session and flushed **in order** once the first revision establishes `lastRevisionId`.

This window opens on **every** sync start, not only the pre-subscription case.

## Two previously silent cases now say so

- Updates still held when sync stops are discarded with a warning, since a load that never completed leaves them nothing to publish against.
- A queue growing past a threshold warns that the load looks stuck, rather than accumulating unnoticed.

## Scope: what this deliberately does not fix

Writes made **before any data subscription opens** are still lost here. The update listener only attaches when the first data subscription registers, so those transactions produce no event at all. That is fixed in the PR stacked on top of this one.

I first tried to close both windows here by publishing `Y.encodeStateAsUpdate(yDoc)` as a full-state catch-up. **That approach was abandoned after review**, because cometd caps a serialized message at 65536 characters (`EventServiceCometD` `maxSendBayeuxMessageSize`, added deliberately in #275):

```js
// cometd.js:266
if (json.length > maxSize) { throw 'maxSendBayeuxMessageSize ' + maxSize + ' exceeded'; }
```

Base64 inflates by 4/3, so a full-state catch-up fails at roughly **48KB of Yjs state**. The publish rejection is fire-and-forget, so it would be logged and swallowed — silently reinstating the exact data loss being fixed. It also collapses per-transaction edit descriptions and schema versions into a single message. Capturing updates at Y.Doc creation, which the next PR does, has neither problem.

## Test plan

- [x] 4 new tests in `FoundryEventService.test.ts`. The strongest decodes every published payload and replays it into a fresh `Y.Doc`, proving a peer actually reconstructs the record rather than merely asserting `publish` was called.
- [x] Verified meaningful by stashing the source: **3 failed | 16 passed** without the fix, **19 passed** with it.
- [x] `foundry-event` 52 passing. `typecheck`, `eslint`, `dprint`, `cspell` clean.

---

## ✅ Validated against a live Foundry stack

Real-stack integration tests now exist (added in the PR stacked on top of this one). Two independent PACK clients, real backend, `danube-staging`:

| Test | Without the behavioural fixes | With them |
|---|---|---|
| write before any data subscription | ✗ 36s — never reaches the peer | ✓ |
| write during the initial load | ✗ 36s | ✓ |
| both writes visible to a peer | ✗ 37s | ✓ |
| `data.live` connected once synced | ✗ reads `disconnected` | ✓ |
| `waitForMetadataLoad` rejects | ✗ **90s hang** | ✓ |
| live update client → client | ✓ | ✓ |

The baseline run included the two worker-compatibility fixes (#299, #301) so the process could run in node at all, and **none** of the behavioural ones — so the failures isolate to the bugs these PRs fix. The last row passing in both is the control: sync fundamentally works, so the other five are the specific defects rather than a broken harness.

This replaces the earlier "unit-level only" caveat.
