### PR TITLE
Capture local Yjs updates from document creation

### DIFF
--- a/.changeset/capture-updates-from-doc-creation.md
+++ b/.changeset/capture-updates-from-doc-creation.md
@@ -1,0 +1,14 @@
+---
+"@palantir/pack.state.foundry": patch
+"@palantir/pack.state.foundry-event": minor
+---
+
+Stop losing local writes made before a document's first data subscription opens. The Yjs `update` listener that publishes local changes was attached in `startDocumentSync`, which only runs once a data subscription registers, so any earlier write produced no event and never reached the server. Nothing surfaced the loss — the writing client read its own value back correctly — and because a later update references struct ids from the unpublished operations, receiving peers hold it pending against a causal gap that never closes, making the record invisible rather than merely late.
+
+Capture now begins when the document is created, via a new `FoundryEventService.beginDocumentCapture`. Updates are held and published against the first revision once a sync session establishes one, so each keeps its own edit description and schema version instead of being collapsed into a single full-state message.
+
+Capture also outlives `stopDocumentSync`, so writes made while sync is stopped are held and published when it resumes; only `disposeDocument` tears capture down, warning if it discards updates that were never published. Sync runs are now tracked by an explicit token rather than by the identity of the update handler, which no longer implies that sync is active.
+
+An update's schema version is resolved when it is published rather than when it is captured, since capture can happen before metadata loads, when the operational version is still a schema fallback that can understate what the content needs. Replacing a document's `Y.Doc` discards updates held for the previous one, with a warning, rather than publishing operations the current document does not have.
+
+This is a minor rather than patch release for `@palantir/pack.state.foundry-event`: `beginDocumentCapture` is a required member of the exported `FoundryEventService` interface, so any external implementation of that interface needs to add it.

--- a/.changeset/presync-write-catchup.md
+++ b/.changeset/presync-write-catchup.md
@@ -1,0 +1,13 @@
+---
+"@palantir/pack.state.foundry-event": patch
+---
+
+Stop discarding local writes made while a document's initial load is in flight. Between the Yjs `update` listener being attached in `startDocumentSync` and the server's first revision arriving, local updates hit a `lastRevisionId == null` check and were dropped with only a log line. The publish payload carries no revision of its own — the server resolves a publish against the revision the client last acknowledged on its update subscription — so there was nothing to publish against yet. Nothing surfaced the loss: the writing client read its own value back correctly, while the update never reached the server and peers never saw it. Those updates are now held and flushed in order once the first revision establishes `lastRevisionId`.
+
+Two cases that were previously silent now say so. Held updates that are still queued when sync stops are discarded with a warning rather than quietly, since a load that never completes leaves them with nothing to publish against. A queue that grows past a threshold warns that the load looks stuck instead of accumulating unnoticed.
+
+Two windows remain, both of them earlier than the one this fixes, and both still silent.
+
+Writes made before any data subscription opens are still lost: the `update` listener is only attached when the first data subscription registers, so those transactions produce no event to publish.
+
+Writes made _during_ the open are also still lost. `FoundryDocumentService.onDataSubscriptionOpened` reports `load: LOADING` and `live: CONNECTING`, then awaits `waitForMetadataLoad` — an HTTP round-trip — before calling `startDocumentSync`, which is where the publish-side listener is attached. Across that window the document already reports itself as loading, but a write produces no publish event at all, so it is dropped with neither a queue entry nor a log line. That window is plausibly longer than the one the queue covers. Closing it means hoisting the hold into `FoundryDocumentService`, which owns the `Y.Doc` for the whole open, rather than `FoundryEventService`, which does not exist until `startDocumentSync` runs.

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -71,7 +71,7 @@ export interface PresencePublishOptions {
 
 const UPDATE_ORIGIN_REMOTE = "remote" as const;
 
-/** Queue depth at which held updates stop looking like a normal load and start looking stuck. */
+/** Queue depth at which held updates stop looking like a normal wait and start looking stuck. */
 const PENDING_PUBLISH_WARN_THRESHOLD = 100;
 
 const getDocumentUpdatesChannelId = (
@@ -109,6 +109,19 @@ export interface SyncSession {
   readonly documentId: DocumentId;
 }
 
+/**
+ * A local Yjs update captured for publishing. Kept unresolved rather than as a finished
+ * `DocumentPublishMessage` so the schema version is decided when it is sent, not when it is made.
+ */
+interface PendingPublish {
+  readonly description?: DocumentPublishMessage["description"];
+  /** Resolves the document's operational version at publish time; absent for callers without one. */
+  readonly getDocumentSchemaOperationalVersion?: () => number;
+  /** Version stamped on the originating transaction, when it carried one. */
+  readonly transactionSchemaVersion?: number;
+  readonly update: Uint8Array;
+}
+
 interface SyncSessionInternal extends SyncSession {
   documentSubscriptionId?: SubscriptionId;
   lastRevisionId?: number;
@@ -125,7 +138,13 @@ interface SyncSessionInternal extends SyncSession {
    * `lastRevisionId`), and until the initial load delivers one there is no such revision. They
    * are held here and flushed in order once it is established.
    */
-  pendingPublishes: DocumentPublishMessage[];
+  pendingPublishes: PendingPublish[];
+  /**
+   * Identifies the current run of sync. Async callbacks compare against it to tell whether the run
+   * that started them is still the current one. The update handler cannot serve as that token: it
+   * outlives sync so local writes are still captured while sync is stopped.
+   */
+  syncToken?: object;
   yDoc?: y.Doc;
 }
 
@@ -134,6 +153,20 @@ interface SyncSessionInternal extends SyncSession {
  * our PACK Foundry backend's cometd service.
  */
 export interface FoundryEventService {
+  /**
+   * Begin capturing local Yjs updates for a document before any sync session exists, so writes
+   * made before the first data subscription opens are held rather than lost. Safe to call more
+   * than once for the same document and the same `Y.Doc`. Passing a different `Y.Doc` replaces
+   * the previous one: held updates are discarded and any sync run in flight is ended, since both
+   * belong to the document being replaced — the caller must restart sync.
+   */
+  beginDocumentCapture(
+    documentId: DocumentId,
+    yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    getDocumentSchemaOperationalVersion?: () => number,
+  ): void;
+
   disposeDocument(documentId: DocumentId): void;
 
   publishCustomPresence(
@@ -212,22 +245,62 @@ class FoundryEventServiceImpl implements FoundryEventService {
     return session;
   }
 
-  startDocumentSync(
+  beginDocumentCapture(
     documentId: DocumentId,
     yDoc: y.Doc,
     clientSupportedVersionRange: ClientSupportedVersionRange,
-    onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
     getDocumentSchemaOperationalVersion?: () => number,
-  ): SyncSession {
-    const session = this.getOrCreateSession(documentId);
+  ): void {
+    this.captureLocalUpdates(
+      documentId,
+      yDoc,
+      clientSupportedVersionRange,
+      getDocumentSchemaOperationalVersion,
+    );
+  }
 
-    if (
-      session.localYDocUpdateHandler != null
-      || session.documentSubscriptionId != null
-    ) {
-      throw new Error(`Document data sync already active for document ${documentId}`);
+  /**
+   * Start listening for local Yjs updates so none are missed, whether or not sync is running.
+   * Updates are held until a sync session establishes the revision to publish them against.
+   *
+   * Idempotent per Y.Doc: re-attaching for the same Y.Doc swaps in a handler bound to the latest
+   * arguments, leaving exactly one listener attached.
+   */
+  private captureLocalUpdates(
+    documentId: DocumentId,
+    yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    getDocumentSchemaOperationalVersion?: () => number,
+  ): void {
+    const session = this.getOrCreateSession(documentId);
+    const isReplacingYDoc = session.yDoc != null && session.yDoc !== yDoc;
+
+    if (session.localYDocUpdateHandler != null) {
+      session.yDoc?.off("update", session.localYDocUpdateHandler);
     }
-    session.yDoc = yDoc;
+
+    if (isReplacingYDoc) {
+      // Held updates describe operations in the previous Y.Doc. Publishing them against a document
+      // that has been replaced would inject state the local document no longer has, so they are
+      // dropped — loudly, because dropping writes is exactly what this queue exists to prevent.
+      if (session.pendingPublishes.length > 0) {
+        this.logger.warn("Discarding local document updates captured for a replaced Y.Doc", {
+          docId: documentId,
+          discardedCount: session.pendingPublishes.length,
+        });
+        session.pendingPublishes = [];
+      }
+      // The run in flight is bound to the previous Y.Doc: startDocumentSync closed over it, so
+      // remote updates would keep applying there, and a surviving lastRevisionId would let writes
+      // to the new document publish against a revision stream that is not theirs. End the run and
+      // leave restarting to the caller.
+      if (session.syncToken != null) {
+        this.logger.warn("Ending document sync because the Y.Doc was replaced mid-sync", {
+          docId: documentId,
+        });
+        this.stopDocumentSync(session);
+      }
+    }
 
     const localYDocUpdateHandler = (
       update: Uint8Array,
@@ -241,19 +314,55 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
       this.publishOrQueueUpdate(session, clientSupportedVersionRange, update, {
         description: isEditDescription(origin) ? createDocumentEditDescription(origin) : undefined,
-        documentUpdateSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction)
-          ?? getDocumentSchemaOperationalVersion?.()
-          ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
+        getDocumentSchemaOperationalVersion,
+        // Absent when the transaction carried no version. Left unresolved here so a queued update
+        // picks up the operational version at publish time: capture can happen before metadata
+        // loads, when the fallback would understate the version the content actually needs.
+        transactionSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction),
       });
     };
 
+    session.yDoc = yDoc;
     session.localYDocUpdateHandler = localYDocUpdateHandler;
     yDoc.on("update", localYDocUpdateHandler);
+  }
 
-    onStatusChange({
-      live: DocumentLiveStatus.CONNECTING,
-      load: DocumentLoadStatus.LOADING,
-    });
+  startDocumentSync(
+    documentId: DocumentId,
+    yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
+    getDocumentSchemaOperationalVersion?: () => number,
+  ): SyncSession {
+    const session = this.getOrCreateSession(documentId);
+
+    if (session.syncToken != null) {
+      throw new Error(`Document data sync already active for document ${documentId}`);
+    }
+    const syncToken = {};
+    session.syncToken = syncToken;
+
+    try {
+      // Capture normally began at document creation. Re-attaching here covers a caller that starts
+      // sync without having begun capture, and a document whose Y.Doc was replaced.
+      this.captureLocalUpdates(
+        documentId,
+        yDoc,
+        clientSupportedVersionRange,
+        getDocumentSchemaOperationalVersion,
+      );
+
+      // Fans out to caller-supplied status subscribers, which are not guarded against throwing.
+      onStatusChange({
+        live: DocumentLiveStatus.CONNECTING,
+        load: DocumentLoadStatus.LOADING,
+      });
+    } catch (e) {
+      // Without this the token stays set and every later start is rejected as already active,
+      // wedging the document for the lifetime of the session.
+      session.syncToken = undefined;
+      throw e;
+    }
 
     const channelId = getDocumentUpdatesChannelId(documentId);
 
@@ -265,13 +374,19 @@ class FoundryEventServiceImpl implements FoundryEventService {
     this.eventService.subscribe(
       channelId,
       (message: DocumentUpdateMessage) => {
-        if (session.localYDocUpdateHandler !== localYDocUpdateHandler) {
+        if (session.syncToken !== syncToken) {
           return;
         }
         if (message.type === "error") {
           channelFailed = true;
         }
-        this.handleDocumentUpdateMessage(session, message, yDoc, onStatusChange);
+        this.handleDocumentUpdateMessage(
+          session,
+          message,
+          yDoc,
+          clientSupportedVersionRange,
+          onStatusChange,
+        );
       },
       () => ({
         clientId: session.clientId,
@@ -279,7 +394,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         lastRevisionId: session.lastRevisionId?.toString(),
       } satisfies DocumentUpdateSubscriptionRequest),
     ).then(subscriptionId => {
-      if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
+      if (session.syncToken === syncToken) {
         session.documentSubscriptionId = subscriptionId;
         if (!channelFailed) {
           // The channel is subscribed, so the data channel is live. Reported separately from
@@ -293,7 +408,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         this.eventService.unsubscribe(subscriptionId);
       }
     }).catch((e: unknown) => {
-      if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
+      if (session.syncToken === syncToken) {
         onStatusChange({
           error: toUnknownChannelError(
             new Error("Failed to setup document data subscription", { cause: e }),
@@ -482,27 +597,28 @@ class FoundryEventServiceImpl implements FoundryEventService {
       return;
     }
 
-    if (internalSession.localYDocUpdateHandler != null) {
-      internalSession.yDoc?.off("update", internalSession.localYDocUpdateHandler);
-      internalSession.localYDocUpdateHandler = undefined;
-    }
-
     if (internalSession.documentSubscriptionId) {
       this.eventService.unsubscribe(internalSession.documentSubscriptionId);
       internalSession.documentSubscriptionId = undefined;
     }
+    internalSession.syncToken = undefined;
     internalSession.lastRevisionId = undefined;
-    // Sync stopped before the initial load established a revision, so these were never publishable
-    // and there is nothing to send them against now. They stay in the local Y.Doc but the server
-    // never learns of them — the same loss this queue exists to prevent, so say so out loud.
+    // The update handler and any held updates deliberately survive: the document is still open and
+    // writable, so writes made while sync is stopped are captured and published when sync resumes.
+    // Only disposeDocument tears capture down.
+    //
+    // Nothing guarantees sync resumes, though. disposeDocument is reached only via deleteDocument,
+    // while the ordinary path (onDataSubscriptionClosed) stops here — so this is where a backlog
+    // starts accruing unpublished writes, and it must not do so silently.
     if (internalSession.pendingPublishes.length > 0) {
-      this.logger.warn("Discarding local document updates held for a load that never completed", {
-        docId: internalSession.documentId,
-        discardedCount: internalSession.pendingPublishes.length,
-      });
-      internalSession.pendingPublishes = [];
+      this.logger.warn(
+        "Local document updates are held and never published while sync is stopped",
+        {
+          docId: internalSession.documentId,
+          heldCount: internalSession.pendingPublishes.length,
+        },
+      );
     }
-    internalSession.yDoc = undefined;
   }
 
   unsubscribe(subscriptionId: SubscriptionId): void {
@@ -516,6 +632,24 @@ class FoundryEventServiceImpl implements FoundryEventService {
       return;
     }
     this.stopDocumentSync(session);
+
+    if (session.localYDocUpdateHandler != null) {
+      session.yDoc?.off("update", session.localYDocUpdateHandler);
+      session.localYDocUpdateHandler = undefined;
+    }
+    session.yDoc = undefined;
+
+    // The document is going away, so held updates have no future sync session to publish them.
+    // They are lost from the server's perspective — the loss this queue exists to prevent, so it
+    // is stated rather than left silent.
+    if (session.pendingPublishes.length > 0) {
+      this.logger.warn("Discarding local document updates that were never published", {
+        docId: session.documentId,
+        discardedCount: session.pendingPublishes.length,
+      });
+      session.pendingPublishes = [];
+    }
+
     this.sessions.delete(sessionId);
   }
 
@@ -529,35 +663,26 @@ class FoundryEventServiceImpl implements FoundryEventService {
     session: SyncSessionInternal,
     clientSupportedVersionRange: ClientSupportedVersionRange,
     update: Uint8Array,
-    options: {
-      description?: DocumentPublishMessage["description"];
-      documentUpdateSchemaVersion: number;
-    },
+    options: Omit<PendingPublish, "update">,
   ): void {
-    const publishMessage: DocumentPublishMessage = {
-      clientId: session.clientId,
-      clientSupportedVersionRange,
-      description: options.description,
-      documentUpdateSchemaVersion: options.documentUpdateSchemaVersion,
-      editId: generateId(),
-      yjsUpdate: {
-        data: Base64.fromUint8Array(update),
-      },
-    };
-
     if (session.lastRevisionId == null) {
-      session.pendingPublishes.push(publishMessage);
+      session.pendingPublishes.push({ ...options, update });
       const pendingCount = session.pendingPublishes.length;
-      // Nothing bounds the queue: an initial load that never completes grows it for as long as
-      // edits keep arriving. Warn on crossing the threshold rather than dropping edits, since
-      // dropping is the failure this queue exists to prevent.
-      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
-        this.logger.warn("Local document updates are piling up while the initial load completes", {
-          docId: session.documentId,
-          pendingCount,
-        });
+      // Nothing bounds the queue: as long as there is no revision to publish against it grows
+      // for as long as edits keep arriving — a load that stalled, or a document that has never
+      // synced at all. Warn periodically rather than dropping edits, since dropping is the
+      // failure this queue exists to prevent — and warn again as it keeps growing, so it does not
+      // go quiet after one message.
+      if (pendingCount % PENDING_PUBLISH_WARN_THRESHOLD === 0) {
+        this.logger.warn(
+          "Local document updates are piling up with no revision to publish against",
+          {
+            docId: session.documentId,
+            pendingCount,
+          },
+        );
       } else {
-        this.logger.debug("Holding local document update until the initial load completes", {
+        this.logger.debug("Holding local document update until a revision is known", {
           docId: session.documentId,
           pendingCount,
         });
@@ -565,13 +690,30 @@ class FoundryEventServiceImpl implements FoundryEventService {
       return;
     }
 
-    this.publishUpdate(session, publishMessage);
+    this.publishUpdate(session, clientSupportedVersionRange, { ...options, update });
   }
 
   private publishUpdate(
     session: SyncSessionInternal,
-    publishMessage: DocumentPublishMessage,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    pending: PendingPublish,
   ): void {
+    const publishMessage: DocumentPublishMessage = {
+      clientId: session.clientId,
+      clientSupportedVersionRange,
+      description: pending.description,
+      // Resolved here rather than at capture: an update held through the initial load was captured
+      // before metadata was available, when the operational version would still be a schema
+      // fallback that can understate what the content needs.
+      documentUpdateSchemaVersion: pending.transactionSchemaVersion
+        ?? pending.getDocumentSchemaOperationalVersion?.()
+        ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
+      editId: generateId(),
+      yjsUpdate: {
+        data: Base64.fromUint8Array(pending.update),
+      },
+    };
+
     void this.eventService.publish(
       getDocumentPublishChannelId(session.documentId),
       publishMessage,
@@ -583,7 +725,10 @@ class FoundryEventServiceImpl implements FoundryEventService {
   }
 
   /** Flush updates held while the revision was unknown, preserving the order they were made in. */
-  private flushPendingPublishes(session: SyncSessionInternal): void {
+  private flushPendingPublishes(
+    session: SyncSessionInternal,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+  ): void {
     if (session.pendingPublishes.length === 0) {
       return;
     }
@@ -595,8 +740,8 @@ class FoundryEventServiceImpl implements FoundryEventService {
       pendingCount: pending.length,
     });
 
-    for (const publishMessage of pending) {
-      this.publishUpdate(session, publishMessage);
+    for (const pendingPublish of pending) {
+      this.publishUpdate(session, clientSupportedVersionRange, pendingPublish);
     }
   }
 
@@ -604,6 +749,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     session: SyncSessionInternal,
     message: DocumentUpdateMessage,
     yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
   ): void {
     switch (message.type) {
@@ -687,7 +833,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         session.lastRevisionId = Number(revisionId);
 
         // The revision is known, so anything held during the load can go out now.
-        this.flushPendingPublishes(session);
+        this.flushPendingPublishes(session, clientSupportedVersionRange);
 
         onStatusChange({
           load: DocumentLoadStatus.LOADED,

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -72,6 +72,9 @@ export interface PresencePublishOptions {
 
 const UPDATE_ORIGIN_REMOTE = "remote" as const;
 
+/** Queue depth at which held updates stop looking like a normal load and start looking stuck. */
+const PENDING_PUBLISH_WARN_THRESHOLD = 100;
+
 const getDocumentUpdatesChannelId = (
   documentId: DocumentId,
 ): TypedReceiveChannelId<DocumentUpdateMessage> =>
@@ -118,6 +121,15 @@ interface SyncSessionInternal extends SyncSession {
   ) => void;
   /** Published updates awaiting ack; created on sync start, cleared on stop. */
   outbox?: UnackedUpdateOutbox;
+  /**
+   * Local updates produced before the server's first revision is known. The publish payload
+   * carries no revision of its own; the server resolves a publish against the revision this
+   * client last acknowledged on its update subscription (`DocumentUpdateSubscriptionRequest`.
+   * `lastRevisionId`), and until the initial load delivers one there is no such revision. They
+   * are held here and flushed in order once it is established. Distinct from `outbox`, which
+   * tracks updates already published and awaiting ack.
+   */
+  pendingPublishes: DocumentPublishMessage[];
   yDoc?: y.Doc;
 }
 
@@ -196,6 +208,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         lastRevisionId: undefined,
         localYDocUpdateHandler: undefined,
         outbox: undefined,
+        pendingPublishes: [],
         yDoc: undefined,
       };
       this.sessions.set(sessionId, session);
@@ -244,34 +257,12 @@ class FoundryEventServiceImpl implements FoundryEventService {
         return;
       }
 
-      const lastRevisionId = session.lastRevisionId;
-      if (lastRevisionId == null) {
-        this.logger.error(
-          "Cannot publish document update before initial load is complete. The local state will remain inconsistent.",
-          { docId: documentId },
-        );
-        return;
-      }
-
-      const editId = generateId();
-      const description = isEditDescription(origin)
-        ? createDocumentEditDescription(origin)
-        : undefined;
-      const documentUpdateSchemaVersion = getDocumentUpdateSchemaVersionFromTransaction(transaction)
-        ?? getDocumentSchemaOperationalVersion?.()
-        ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange);
-      const publishMessage: DocumentPublishMessage = {
-        clientId: session.clientId,
-        clientSupportedVersionRange,
-        description,
-        documentUpdateSchemaVersion,
-        editId,
-        yjsUpdate: {
-          data: Base64.fromUint8Array(update),
-        },
-      };
-      outbox.add(editId, publishMessage);
-      this.publishDocumentUpdate(documentId, publishMessage);
+      this.publishOrQueueUpdate(session, clientSupportedVersionRange, update, {
+        description: isEditDescription(origin) ? createDocumentEditDescription(origin) : undefined,
+        documentUpdateSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction)
+          ?? getDocumentSchemaOperationalVersion?.()
+          ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
+      });
     };
 
     session.localYDocUpdateHandler = localYDocUpdateHandler;
@@ -284,11 +275,19 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
     const channelId = getDocumentUpdatesChannelId(documentId);
 
+    // Scoped to this sync generation. CometD dispatches a transport response's messages
+    // synchronously while the subscribe promise resolves on a microtask, so a channel error
+    // delivered alongside the ack would otherwise be overwritten by the promotion below.
+    let channelFailed = false;
+
     this.eventService.subscribe(
       channelId,
       (message: DocumentUpdateMessage) => {
         if (session.localYDocUpdateHandler !== localYDocUpdateHandler) {
           return;
+        }
+        if (message.type === "error") {
+          channelFailed = true;
         }
         this.handleDocumentUpdateMessage(session, message, yDoc, onStatusChange);
       },
@@ -300,12 +299,14 @@ class FoundryEventServiceImpl implements FoundryEventService {
     ).then(subscriptionId => {
       if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
         session.documentSubscriptionId = subscriptionId;
-        // The channel is subscribed, so the data channel is live. Reported separately from `load`,
-        // which stays LOADING until the first update arrives. Matches how the activity and presence
-        // channels report liveness on subscription establishment.
-        onStatusChange({
-          live: DocumentLiveStatus.CONNECTED,
-        });
+        if (!channelFailed) {
+          // The channel is subscribed, so the data channel is live. Reported separately from
+          // `load`, which stays LOADING until the first update arrives. Matches how the activity
+          // and presence channels report liveness on subscription establishment.
+          onStatusChange({
+            live: DocumentLiveStatus.CONNECTED,
+          });
+        }
       } else {
         this.eventService.unsubscribe(subscriptionId);
       }
@@ -511,6 +512,16 @@ class FoundryEventServiceImpl implements FoundryEventService {
     internalSession.outbox?.clear();
     internalSession.outbox = undefined;
     internalSession.lastRevisionId = undefined;
+    // Sync stopped before the initial load established a revision, so these were never publishable
+    // and there is nothing to send them against now. They stay in the local Y.Doc but the server
+    // never learns of them — the same loss this queue exists to prevent, so say so out loud.
+    if (internalSession.pendingPublishes.length > 0) {
+      this.logger.warn("Discarding local document updates held for a load that never completed", {
+        docId: internalSession.documentId,
+        discardedCount: internalSession.pendingPublishes.length,
+      });
+      internalSession.pendingPublishes = [];
+    }
     internalSession.yDoc = undefined;
   }
 
@@ -528,6 +539,68 @@ class FoundryEventServiceImpl implements FoundryEventService {
     this.sessions.delete(sessionId);
   }
 
+  /**
+   * Publish a local Yjs update, or hold it until the initial load establishes `lastRevisionId` —
+   * the revision the server resolves this client's publishes against, sent on the update
+   * subscription rather than on the publish itself. Updates were previously dropped with only a
+   * log line in that window, which lost them silently.
+   */
+  private publishOrQueueUpdate(
+    session: SyncSessionInternal,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    update: Uint8Array,
+    options: {
+      description?: DocumentPublishMessage["description"];
+      documentUpdateSchemaVersion: number;
+    },
+  ): void {
+    const publishMessage: DocumentPublishMessage = {
+      clientId: session.clientId,
+      clientSupportedVersionRange,
+      description: options.description,
+      documentUpdateSchemaVersion: options.documentUpdateSchemaVersion,
+      editId: generateId(),
+      yjsUpdate: {
+        data: Base64.fromUint8Array(update),
+      },
+    };
+
+    if (session.lastRevisionId == null) {
+      session.pendingPublishes.push(publishMessage);
+      const pendingCount = session.pendingPublishes.length;
+      // Nothing bounds the queue: an initial load that never completes grows it for as long as
+      // edits keep arriving. Warn on crossing the threshold rather than dropping edits, since
+      // dropping is the failure this queue exists to prevent.
+      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
+        this.logger.warn("Local document updates are piling up while the initial load completes", {
+          docId: session.documentId,
+          pendingCount,
+        });
+      } else {
+        this.logger.debug("Holding local document update until the initial load completes", {
+          docId: session.documentId,
+          pendingCount,
+        });
+      }
+      return;
+    }
+
+    this.publishUpdate(session, publishMessage);
+  }
+
+  /**
+   * Track the update for resend until the server acks it, then send it. Held updates flush through
+   * here too, so they get the same ack/retransmit protection as those published immediately.
+   */
+  private publishUpdate(
+    session: SyncSessionInternal,
+    publishMessage: DocumentPublishMessage,
+  ): void {
+    session.outbox?.add(publishMessage.editId, publishMessage);
+    this.publishDocumentUpdate(session.documentId, publishMessage);
+  }
+
+  /** Send without tracking. The resend loop calls this directly, since it is already tracked. */
   private publishDocumentUpdate(
     documentId: DocumentId,
     publishMessage: DocumentPublishMessage,
@@ -542,6 +615,24 @@ class FoundryEventServiceImpl implements FoundryEventService {
         editId: publishMessage.editId,
       });
     });
+  }
+
+  /** Flush updates held while the revision was unknown, preserving the order they were made in. */
+  private flushPendingPublishes(session: SyncSessionInternal): void {
+    if (session.pendingPublishes.length === 0) {
+      return;
+    }
+
+    const pending = session.pendingPublishes;
+    session.pendingPublishes = [];
+    this.logger.debug("Publishing local document updates held during the initial load", {
+      docId: session.documentId,
+      pendingCount: pending.length,
+    });
+
+    for (const publishMessage of pending) {
+      this.publishUpdate(session, publishMessage);
+    }
   }
 
   private handleDocumentUpdateMessage(
@@ -639,6 +730,9 @@ class FoundryEventServiceImpl implements FoundryEventService {
           }
         }
         session.lastRevisionId = Number(revisionId);
+
+        // The revision is known, so anything held during the load can go out now.
+        this.flushPendingPublishes(session);
 
         onStatusChange({
           load: DocumentLoadStatus.LOADED,

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -403,6 +403,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         }
         this.handleDocumentUpdateMessage(
           session,
+          syncToken,
           message,
           yDoc,
           clientSupportedVersionRange,
@@ -782,6 +783,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
   private handleDocumentUpdateMessage(
     session: SyncSessionInternal,
+    syncToken: object,
     message: DocumentUpdateMessage,
     yDoc: y.Doc,
     clientSupportedVersionRange: ClientSupportedVersionRange,
@@ -863,6 +865,9 @@ class FoundryEventServiceImpl implements FoundryEventService {
               lastRevisionId: session.lastRevisionId,
               message: messageDetail,
             });
+            if (session.syncToken !== syncToken) {
+              return;
+            }
             onStatusChange({
               error: toUnknownChannelError(
                 new Error(
@@ -874,6 +879,11 @@ class FoundryEventServiceImpl implements FoundryEventService {
             });
             return;
           }
+        }
+
+        // Yjs observers can stop or replace the sync run during applyUpdate.
+        if (session.syncToken !== syncToken) {
+          return;
         }
         session.lastRevisionId = Number(revisionId);
 

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -72,8 +72,7 @@ export interface PresencePublishOptions {
 
 const UPDATE_ORIGIN_REMOTE = "remote" as const;
 
-/** Caps memory growth during a stalled load; later updates are logged and dropped. */
-const PENDING_PUBLISH_MAX = 100;
+const PENDING_PUBLISH_WARN_THRESHOLD = 100;
 
 const getDocumentUpdatesChannelId = (
   documentId: DocumentId,
@@ -565,17 +564,10 @@ class FoundryEventServiceImpl implements FoundryEventService {
     };
 
     if (session.lastRevisionId == null) {
-      if (session.pendingPublishes.length >= PENDING_PUBLISH_MAX) {
-        this.logger.error("Dropping local document update; the hold queue is full", {
-          docId: session.documentId,
-          editId: publishMessage.editId,
-          pendingCount: session.pendingPublishes.length,
-        });
-        return;
-      }
+      // Dropping an update leaves a gap in Yjs client clocks that blocks later edits on peers.
       session.pendingPublishes.push(publishMessage);
       const pendingCount = session.pendingPublishes.length;
-      if (pendingCount === PENDING_PUBLISH_MAX) {
+      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
         this.logger.warn("Local document updates are piling up while the initial load completes", {
           docId: session.documentId,
           pendingCount,

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -109,6 +109,19 @@ export interface SyncSession {
   readonly documentId: DocumentId;
 }
 
+/**
+ * A local Yjs update captured for publishing. Kept unresolved rather than as a finished
+ * `DocumentPublishMessage` so the schema version is decided when it is sent, not when it is made.
+ */
+interface PendingPublish {
+  readonly description?: DocumentPublishMessage["description"];
+  /** Resolves the document's operational version at publish time; absent for callers without one. */
+  readonly getDocumentSchemaOperationalVersion?: () => number;
+  /** Version stamped on the originating transaction, when it carried one. */
+  readonly transactionSchemaVersion?: number;
+  readonly update: Uint8Array;
+}
+
 interface SyncSessionInternal extends SyncSession {
   /** Tracks callback/ack races; false means recovery was already reported. */
   dataChannelFailed?: boolean;
@@ -130,7 +143,13 @@ interface SyncSessionInternal extends SyncSession {
    * are held here and flushed in order once it is established. Distinct from `outbox`, which
    * tracks updates already published and awaiting ack.
    */
-  pendingPublishes: DocumentPublishMessage[];
+  pendingPublishes: PendingPublish[];
+  /**
+   * Identifies the current run of sync. Async callbacks compare against it to tell whether the run
+   * that started them is still the current one. The update handler cannot serve as that token: it
+   * outlives sync so local writes are still captured while sync is stopped.
+   */
+  syncToken?: object;
   yDoc?: y.Doc;
 }
 
@@ -139,6 +158,20 @@ interface SyncSessionInternal extends SyncSession {
  * our PACK Foundry backend's cometd service.
  */
 export interface FoundryEventService {
+  /**
+   * Begin capturing local Yjs updates for a document before any sync session exists, so writes
+   * made before the first data subscription opens are held rather than lost. Safe to call more
+   * than once for the same document and the same `Y.Doc`. Passing a different `Y.Doc` replaces
+   * the previous one: held updates are discarded and any sync run in flight is ended, since both
+   * belong to the document being replaced — the caller must restart sync.
+   */
+  beginDocumentCapture(
+    documentId: DocumentId,
+    yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    getDocumentSchemaOperationalVersion?: () => number,
+  ): void;
+
   disposeDocument(documentId: DocumentId): void;
 
   publishCustomPresence(
@@ -219,35 +252,62 @@ class FoundryEventServiceImpl implements FoundryEventService {
     return session;
   }
 
-  startDocumentSync(
+  beginDocumentCapture(
     documentId: DocumentId,
     yDoc: y.Doc,
     clientSupportedVersionRange: ClientSupportedVersionRange,
-    onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
     getDocumentSchemaOperationalVersion?: () => number,
-  ): SyncSession {
+  ): void {
+    this.captureLocalUpdates(
+      documentId,
+      yDoc,
+      clientSupportedVersionRange,
+      getDocumentSchemaOperationalVersion,
+    );
+  }
+
+  /**
+   * Start listening for local Yjs updates so none are missed, whether or not sync is running.
+   * Updates are held until a sync session establishes the revision to publish them against.
+   *
+   * Idempotent per Y.Doc: re-attaching for the same Y.Doc swaps in a handler bound to the latest
+   * arguments, leaving exactly one listener attached.
+   */
+  private captureLocalUpdates(
+    documentId: DocumentId,
+    yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    getDocumentSchemaOperationalVersion?: () => number,
+  ): void {
     const session = this.getOrCreateSession(documentId);
+    const isReplacingYDoc = session.yDoc != null && session.yDoc !== yDoc;
 
-    if (
-      session.localYDocUpdateHandler != null
-      || session.documentSubscriptionId != null
-    ) {
-      throw new Error(`Document data sync already active for document ${documentId}`);
+    if (session.localYDocUpdateHandler != null) {
+      session.yDoc?.off("update", session.localYDocUpdateHandler);
     }
-    session.yDoc = yDoc;
 
-    // Resends published updates until the server acks them (see handleDocumentUpdateMessage).
-    const outbox = createUnackedUpdateOutbox(unackedUpdates => {
-      for (const { publishMessage, sendCount } of unackedUpdates) {
-        this.logger.debug("Resending unacked document update", {
+    if (isReplacingYDoc) {
+      // Held updates describe operations in the previous Y.Doc. Publishing them against a document
+      // that has been replaced would inject state the local document no longer has, so they are
+      // dropped — loudly, because dropping writes is exactly what this queue exists to prevent.
+      if (session.pendingPublishes.length > 0) {
+        this.logger.warn("Discarding local document updates captured for a replaced Y.Doc", {
           docId: documentId,
-          editId: publishMessage.editId,
-          sendCount,
+          discardedCount: session.pendingPublishes.length,
         });
-        this.publishDocumentUpdate(documentId, publishMessage);
+        session.pendingPublishes = [];
       }
-    });
-    session.outbox = outbox;
+      // The run in flight is bound to the previous Y.Doc: startDocumentSync closed over it, so
+      // remote updates would keep applying there, and a surviving lastRevisionId would let writes
+      // to the new document publish against a revision stream that is not theirs. End the run and
+      // leave restarting to the caller.
+      if (session.syncToken != null) {
+        this.logger.warn("Ending document sync because the Y.Doc was replaced mid-sync", {
+          docId: documentId,
+        });
+        this.stopDocumentSync(session);
+      }
+    }
 
     const localYDocUpdateHandler = (
       update: Uint8Array,
@@ -261,32 +321,93 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
       this.publishOrQueueUpdate(session, clientSupportedVersionRange, update, {
         description: isEditDescription(origin) ? createDocumentEditDescription(origin) : undefined,
-        documentUpdateSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction)
-          ?? getDocumentSchemaOperationalVersion?.()
-          ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
+        getDocumentSchemaOperationalVersion,
+        // Absent when the transaction carried no version. Left unresolved here so a queued update
+        // picks up the operational version at publish time: capture can happen before metadata
+        // loads, when the fallback would understate the version the content actually needs.
+        transactionSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction),
       });
     };
 
+    session.yDoc = yDoc;
     session.localYDocUpdateHandler = localYDocUpdateHandler;
     yDoc.on("update", localYDocUpdateHandler);
+  }
 
-    onStatusChange({
-      live: DocumentLiveStatus.CONNECTING,
-      load: DocumentLoadStatus.LOADING,
+  startDocumentSync(
+    documentId: DocumentId,
+    yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
+    getDocumentSchemaOperationalVersion?: () => number,
+  ): SyncSession {
+    const session = this.getOrCreateSession(documentId);
+
+    if (session.syncToken != null) {
+      throw new Error(`Document data sync already active for document ${documentId}`);
+    }
+
+    // Capture normally began at document creation. Re-attaching here covers a caller that starts
+    // sync without having begun capture, and a document whose Y.Doc was replaced.
+    this.captureLocalUpdates(
+      documentId,
+      yDoc,
+      clientSupportedVersionRange,
+      getDocumentSchemaOperationalVersion,
+    );
+
+    const syncToken = {};
+    session.syncToken = syncToken;
+    session.dataChannelFailed = undefined;
+
+    // Resends published updates until the server acks them (see handleDocumentUpdateMessage).
+    const outbox = createUnackedUpdateOutbox((unackedUpdates): void => {
+      for (const { publishMessage, sendCount } of unackedUpdates) {
+        this.logger.debug("Resending unacked document update", {
+          docId: documentId,
+          editId: publishMessage.editId,
+          sendCount,
+        });
+        this.publishDocumentUpdate(documentId, publishMessage);
+      }
     });
+    session.outbox = outbox;
+
+    try {
+      // Fans out to caller-supplied status subscribers, which are not guarded against throwing.
+      onStatusChange({
+        live: DocumentLiveStatus.CONNECTING,
+        load: DocumentLoadStatus.LOADING,
+      });
+    } catch (e) {
+      if (session.syncToken === syncToken) {
+        session.syncToken = undefined;
+      }
+      if (session.outbox === outbox) {
+        outbox.clear();
+        session.outbox = undefined;
+      }
+      throw e;
+    }
 
     const channelId = getDocumentUpdatesChannelId(documentId);
 
     this.eventService.subscribe(
       channelId,
       (message: DocumentUpdateMessage) => {
-        if (session.localYDocUpdateHandler !== localYDocUpdateHandler) {
+        if (session.syncToken !== syncToken) {
           return;
         }
         if (message.type === "error") {
           session.dataChannelFailed = true;
         }
-        this.handleDocumentUpdateMessage(session, message, yDoc, onStatusChange);
+        this.handleDocumentUpdateMessage(
+          session,
+          message,
+          yDoc,
+          clientSupportedVersionRange,
+          onStatusChange,
+        );
       },
       () => ({
         clientId: session.clientId,
@@ -294,7 +415,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         lastRevisionId: session.lastRevisionId?.toString(),
       } satisfies DocumentUpdateSubscriptionRequest),
     ).then(subscriptionId => {
-      if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
+      if (session.syncToken === syncToken) {
         session.documentSubscriptionId = subscriptionId;
         if (session.dataChannelFailed === undefined) {
           // The channel is subscribed, so the data channel is live. Reported separately from
@@ -308,7 +429,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         this.eventService.unsubscribe(subscriptionId);
       }
     }).catch((e: unknown) => {
-      if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
+      if (session.syncToken === syncToken) {
         onStatusChange({
           error: toUnknownChannelError(
             new Error("Failed to setup document data subscription", { cause: e }),
@@ -497,11 +618,6 @@ class FoundryEventServiceImpl implements FoundryEventService {
       return;
     }
 
-    if (internalSession.localYDocUpdateHandler != null) {
-      internalSession.yDoc?.off("update", internalSession.localYDocUpdateHandler);
-      internalSession.localYDocUpdateHandler = undefined;
-    }
-
     if (internalSession.documentSubscriptionId) {
       this.eventService.unsubscribe(internalSession.documentSubscriptionId);
       internalSession.documentSubscriptionId = undefined;
@@ -509,18 +625,24 @@ class FoundryEventServiceImpl implements FoundryEventService {
     internalSession.dataChannelFailed = undefined;
     internalSession.outbox?.clear();
     internalSession.outbox = undefined;
+    internalSession.syncToken = undefined;
     internalSession.lastRevisionId = undefined;
-    // Sync stopped before the initial load established a revision, so these were never publishable
-    // and there is nothing to send them against now. They stay in the local Y.Doc but the server
-    // never learns of them — the same loss this queue exists to prevent, so say so out loud.
+    // The update handler and any held updates deliberately survive: the document is still open and
+    // writable, so writes made while sync is stopped are captured and published when sync resumes.
+    // Only disposeDocument tears capture down.
+    //
+    // Nothing guarantees sync resumes, though. disposeDocument is reached only via deleteDocument,
+    // while the ordinary path (onDataSubscriptionClosed) stops here — so this is where a backlog
+    // starts accruing unpublished writes, and it must not do so silently.
     if (internalSession.pendingPublishes.length > 0) {
-      this.logger.warn("Discarding local document updates held for a load that never completed", {
-        docId: internalSession.documentId,
-        discardedCount: internalSession.pendingPublishes.length,
-      });
-      internalSession.pendingPublishes = [];
+      this.logger.warn(
+        "Local document updates are held and never published while sync is stopped",
+        {
+          docId: internalSession.documentId,
+          heldCount: internalSession.pendingPublishes.length,
+        },
+      );
     }
-    internalSession.yDoc = undefined;
   }
 
   unsubscribe(subscriptionId: SubscriptionId): void {
@@ -534,11 +656,29 @@ class FoundryEventServiceImpl implements FoundryEventService {
       return;
     }
     this.stopDocumentSync(session);
+
+    if (session.localYDocUpdateHandler != null) {
+      session.yDoc?.off("update", session.localYDocUpdateHandler);
+      session.localYDocUpdateHandler = undefined;
+    }
+    session.yDoc = undefined;
+
+    // The document is going away, so held updates have no future sync session to publish them.
+    // They are lost from the server's perspective — the loss this queue exists to prevent, so it
+    // is stated rather than left silent.
+    if (session.pendingPublishes.length > 0) {
+      this.logger.warn("Discarding local document updates that were never published", {
+        docId: session.documentId,
+        discardedCount: session.pendingPublishes.length,
+      });
+      session.pendingPublishes = [];
+    }
+
     this.sessions.delete(sessionId);
   }
 
   /**
-   * Publish a local Yjs update, or hold it until the initial load establishes `lastRevisionId` —
+   * Publish a local Yjs update, or hold it until sync establishes `lastRevisionId` —
    * the revision the server resolves this client's publishes against, sent on the update
    * subscription rather than on the publish itself. Updates were previously dropped with only a
    * log line in that window, which lost them silently.
@@ -547,33 +687,22 @@ class FoundryEventServiceImpl implements FoundryEventService {
     session: SyncSessionInternal,
     clientSupportedVersionRange: ClientSupportedVersionRange,
     update: Uint8Array,
-    options: {
-      description?: DocumentPublishMessage["description"];
-      documentUpdateSchemaVersion: number;
-    },
+    options: Omit<PendingPublish, "update">,
   ): void {
-    const publishMessage: DocumentPublishMessage = {
-      clientId: session.clientId,
-      clientSupportedVersionRange,
-      description: options.description,
-      documentUpdateSchemaVersion: options.documentUpdateSchemaVersion,
-      editId: generateId(),
-      yjsUpdate: {
-        data: Base64.fromUint8Array(update),
-      },
-    };
-
     if (session.lastRevisionId == null) {
       // Dropping an update leaves a gap in Yjs client clocks that blocks later edits on peers.
-      session.pendingPublishes.push(publishMessage);
+      session.pendingPublishes.push({ ...options, update });
       const pendingCount = session.pendingPublishes.length;
       if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
-        this.logger.warn("Local document updates are piling up while the initial load completes", {
-          docId: session.documentId,
-          pendingCount,
-        });
+        this.logger.warn(
+          "Local document updates are piling up with no revision to publish against",
+          {
+            docId: session.documentId,
+            pendingCount,
+          },
+        );
       } else {
-        this.logger.debug("Holding local document update until the initial load completes", {
+        this.logger.debug("Holding local document update until a revision is known", {
           docId: session.documentId,
           pendingCount,
         });
@@ -581,7 +710,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
       return;
     }
 
-    this.publishUpdate(session, publishMessage);
+    this.publishUpdate(session, clientSupportedVersionRange, { ...options, update });
   }
 
   /**
@@ -590,8 +719,25 @@ class FoundryEventServiceImpl implements FoundryEventService {
    */
   private publishUpdate(
     session: SyncSessionInternal,
-    publishMessage: DocumentPublishMessage,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    pending: PendingPublish,
   ): void {
+    const publishMessage: DocumentPublishMessage = {
+      clientId: session.clientId,
+      clientSupportedVersionRange,
+      description: pending.description,
+      // Resolved here rather than at capture: an update held through the initial load was captured
+      // before metadata was available, when the operational version would still be a schema
+      // fallback that can understate what the content needs.
+      documentUpdateSchemaVersion: pending.transactionSchemaVersion
+        ?? pending.getDocumentSchemaOperationalVersion?.()
+        ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
+      editId: generateId(),
+      yjsUpdate: {
+        data: Base64.fromUint8Array(pending.update),
+      },
+    };
+
     session.outbox?.add(publishMessage.editId, publishMessage);
     this.publishDocumentUpdate(session.documentId, publishMessage);
   }
@@ -614,20 +760,23 @@ class FoundryEventServiceImpl implements FoundryEventService {
   }
 
   /** Flush updates held while the revision was unknown, preserving the order they were made in. */
-  private flushPendingPublishes(session: SyncSessionInternal): void {
+  private flushPendingPublishes(
+    session: SyncSessionInternal,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+  ): void {
     if (session.pendingPublishes.length === 0) {
       return;
     }
 
     const pending = session.pendingPublishes;
     session.pendingPublishes = [];
-    this.logger.debug("Publishing local document updates held during the initial load", {
+    this.logger.debug("Publishing local document updates held until a revision was known", {
       docId: session.documentId,
       pendingCount: pending.length,
     });
 
-    for (const publishMessage of pending) {
-      this.publishUpdate(session, publishMessage);
+    for (const pendingPublish of pending) {
+      this.publishUpdate(session, clientSupportedVersionRange, pendingPublish);
     }
   }
 
@@ -635,6 +784,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     session: SyncSessionInternal,
     message: DocumentUpdateMessage,
     yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
   ): void {
     switch (message.type) {
@@ -728,7 +878,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         session.lastRevisionId = Number(revisionId);
 
         // The revision is known, so anything held during the load can go out now.
-        this.flushPendingPublishes(session);
+        this.flushPendingPublishes(session, clientSupportedVersionRange);
 
         const dataChannelRecovered = session.dataChannelFailed === true;
         if (dataChannelRecovered) {

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -72,8 +72,8 @@ export interface PresencePublishOptions {
 
 const UPDATE_ORIGIN_REMOTE = "remote" as const;
 
-/** Queue depth at which held updates stop looking like a normal load and start looking stuck. */
-const PENDING_PUBLISH_WARN_THRESHOLD = 100;
+/** Caps memory growth during a stalled load; later updates are logged and dropped. */
+const PENDING_PUBLISH_MAX = 100;
 
 const getDocumentUpdatesChannelId = (
   documentId: DocumentId,
@@ -111,6 +111,8 @@ export interface SyncSession {
 }
 
 interface SyncSessionInternal extends SyncSession {
+  /** Tracks callback/ack races; false means recovery was already reported. */
+  dataChannelFailed?: boolean;
   documentSubscriptionId?: SubscriptionId;
   lastRevisionId?: number;
   localYDocUpdateHandler?: (
@@ -203,6 +205,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     if (!session) {
       session = {
         clientId: crypto.randomUUID(),
+        dataChannelFailed: undefined,
         documentId,
         documentSubscriptionId: undefined,
         lastRevisionId: undefined,
@@ -275,11 +278,6 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
     const channelId = getDocumentUpdatesChannelId(documentId);
 
-    // Scoped to this sync generation. CometD dispatches a transport response's messages
-    // synchronously while the subscribe promise resolves on a microtask, so a channel error
-    // delivered alongside the ack would otherwise be overwritten by the promotion below.
-    let channelFailed = false;
-
     this.eventService.subscribe(
       channelId,
       (message: DocumentUpdateMessage) => {
@@ -287,7 +285,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
           return;
         }
         if (message.type === "error") {
-          channelFailed = true;
+          session.dataChannelFailed = true;
         }
         this.handleDocumentUpdateMessage(session, message, yDoc, onStatusChange);
       },
@@ -299,7 +297,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     ).then(subscriptionId => {
       if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
         session.documentSubscriptionId = subscriptionId;
-        if (!channelFailed) {
+        if (session.dataChannelFailed === undefined) {
           // The channel is subscribed, so the data channel is live. Reported separately from
           // `load`, which stays LOADING until the first update arrives. Matches how the activity
           // and presence channels report liveness on subscription establishment.
@@ -509,6 +507,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
       this.eventService.unsubscribe(internalSession.documentSubscriptionId);
       internalSession.documentSubscriptionId = undefined;
     }
+    internalSession.dataChannelFailed = undefined;
     internalSession.outbox?.clear();
     internalSession.outbox = undefined;
     internalSession.lastRevisionId = undefined;
@@ -566,12 +565,17 @@ class FoundryEventServiceImpl implements FoundryEventService {
     };
 
     if (session.lastRevisionId == null) {
+      if (session.pendingPublishes.length >= PENDING_PUBLISH_MAX) {
+        this.logger.error("Dropping local document update; the hold queue is full", {
+          docId: session.documentId,
+          editId: publishMessage.editId,
+          pendingCount: session.pendingPublishes.length,
+        });
+        return;
+      }
       session.pendingPublishes.push(publishMessage);
       const pendingCount = session.pendingPublishes.length;
-      // Nothing bounds the queue: an initial load that never completes grows it for as long as
-      // edits keep arriving. Warn on crossing the threshold rather than dropping edits, since
-      // dropping is the failure this queue exists to prevent.
-      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
+      if (pendingCount === PENDING_PUBLISH_MAX) {
         this.logger.warn("Local document updates are piling up while the initial load completes", {
           docId: session.documentId,
           pendingCount,
@@ -734,7 +738,12 @@ class FoundryEventServiceImpl implements FoundryEventService {
         // The revision is known, so anything held during the load can go out now.
         this.flushPendingPublishes(session);
 
+        const dataChannelRecovered = session.dataChannelFailed === true;
+        if (dataChannelRecovered) {
+          session.dataChannelFailed = false;
+        }
         onStatusChange({
+          ...(dataChannelRecovered ? { live: DocumentLiveStatus.CONNECTED } : {}),
           load: DocumentLoadStatus.LOADED,
         });
 

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -330,6 +330,11 @@ describe("FoundryEventService", () => {
 
     service.stopDocumentSync(session);
 
+    // Capture outlives sync so writes made while stopped are still held; only disposal detaches.
+    expect(activeOff).not.toHaveBeenCalled();
+
+    service.disposeDocument("doc-1" as DocumentId);
+
     expect(activeOff).toHaveBeenCalledWith("update", expect.any(Function));
     expect(rejectedOff).not.toHaveBeenCalled();
     expect(mocks.eventService.subscribe).toHaveBeenCalledTimes(1);
@@ -461,6 +466,34 @@ describe("FoundryEventService", () => {
       return { service, deliverInitialRevision: () => updateCallback?.(initialRevision()) };
     }
 
+    it("holds a write made before any sync session exists", async () => {
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+
+      // Capture begins when the document is created, well before a data subscription opens.
+      service.beginDocumentCapture("doc-1" as DocumentId, yDoc, { maxVersion: 1, minVersion: 1 });
+      yDoc.getMap("Shape").set("shape-1", "before-any-sync");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+      await Promise.resolve();
+      updateCallback?.(initialRevision());
+
+      // One update carrying the original transaction, not a full-state snapshot of the document.
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(1);
+      expect(applyPublishedUpdates().getMap("Shape").get("shape-1")).toBe("before-any-sync");
+    });
+
     it("holds a write made during the load instead of dropping it", async () => {
       const yDoc = new Y.Doc();
       const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
@@ -507,7 +540,189 @@ describe("FoundryEventService", () => {
       expect(mocks.eventService.publish).not.toHaveBeenCalled();
     });
 
-    it("warns rather than staying silent when a load never completes", async () => {
+    it("keeps held updates across a stop and publishes them when sync resumes", async () => {
+      const yDoc = new Y.Doc();
+      const { service } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("shape-1", "held-across-stop");
+      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+
+      // Stopping sync does not end the document, so the write must survive to the next session.
+      yDoc.getMap("Shape").set("shape-2", "written-while-stopped");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      let resumedCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        resumedCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-2" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+      await Promise.resolve();
+      resumedCallback?.(initialRevision());
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(2);
+      const peerShapes = applyPublishedUpdates().getMap("Shape");
+      expect(peerShapes.get("shape-1")).toBe("held-across-stop");
+      expect(peerShapes.get("shape-2")).toBe("written-while-stopped");
+    });
+
+    it("reports held updates left behind when sync stops", async () => {
+      const yDoc = new Y.Doc();
+      const { service } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("shape-1", "held-across-stop");
+      logger.warn.mockClear();
+
+      // stopDocumentSync is the teardown the ordinary lifecycle actually runs —
+      // onDataSubscriptionClosed calls it, and disposeDocument is only reached via
+      // deleteDocument. Held updates survive on purpose, but must not do so silently: nothing
+      // guarantees sync ever resumes, and until it does these writes are not on the server.
+      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("never published"),
+        expect.objectContaining({ docId: "doc-1", heldCount: 1 }),
+      );
+    });
+
+    it("resolves the schema version when publishing, not when capturing", async () => {
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+
+      // Capture happens before metadata loads, when the operational version is still a fallback.
+      let operationalVersion = 1;
+      service.beginDocumentCapture(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 5, minVersion: 1 },
+        () => operationalVersion,
+      );
+      yDoc.getMap("Shape").set("shape-1", "captured-early");
+
+      // Metadata lands during the load and raises the operational version.
+      operationalVersion = 3;
+
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 5, minVersion: 1 },
+        () => {},
+        () => operationalVersion,
+      );
+      await Promise.resolve();
+      updateCallback?.(initialRevision());
+
+      const publishCall = mocks.eventService.publish.mock.calls[0] as
+        | [unknown, PublishedDocumentUpdate]
+        | undefined;
+      expect(publishCall?.[1].documentUpdateSchemaVersion).toBe(3);
+    });
+
+    it("does not wedge the document when starting sync throws", () => {
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+      mocks.eventService.subscribe.mockResolvedValue("sub-1" as SubscriptionId);
+
+      const failingStatusCallback = () => {
+        throw new Error("subscriber blew up");
+      };
+
+      expect(() =>
+        service.startDocumentSync(
+          "doc-1" as DocumentId,
+          yDoc,
+          { maxVersion: 1, minVersion: 1 },
+          failingStatusCallback,
+        )
+      ).toThrow("subscriber blew up");
+
+      // The failed attempt must not leave the document permanently "already active".
+      expect(() =>
+        service.startDocumentSync(
+          "doc-1" as DocumentId,
+          yDoc,
+          { maxVersion: 1, minVersion: 1 },
+          () => {},
+        )
+      ).not.toThrow();
+    });
+
+    it("discards held updates loudly when the Y.Doc is replaced", async () => {
+      const originalYDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+      service.beginDocumentCapture("doc-1" as DocumentId, originalYDoc, {
+        maxVersion: 1,
+        minVersion: 1,
+      });
+      originalYDoc.getMap("Shape").set("shape-1", "belongs-to-old-doc");
+      logger.warn.mockClear();
+
+      // Held updates describe operations in a document that is being replaced, so publishing them
+      // against the replacement would inject state it does not have.
+      const replacementYDoc = new Y.Doc();
+      service.beginDocumentCapture("doc-1" as DocumentId, replacementYDoc, {
+        maxVersion: 1,
+        minVersion: 1,
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("replaced Y.Doc"),
+        expect.objectContaining({ discardedCount: 1 }),
+      );
+
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        replacementYDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+      await Promise.resolve();
+      updateCallback?.(initialRevision());
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+    });
+
+    it("ends the sync run when the Y.Doc is replaced mid-sync", async () => {
+      const originalYDoc = new Y.Doc();
+      const { service, deliverInitialRevision } = startSyncCapturingServer(originalYDoc);
+      await Promise.resolve();
+      deliverInitialRevision();
+      mocks.eventService.publish.mockClear();
+
+      // Replacing the document under an active sync leaves the subscription and lastRevisionId
+      // bound to the old Y.Doc. Left in place, remote updates keep applying to the replaced
+      // document while writes to the new one publish against a revision stream that is not
+      // theirs — so the run has to end and be restarted by the caller.
+      const replacementYDoc = new Y.Doc();
+      service.beginDocumentCapture("doc-1" as DocumentId, replacementYDoc, {
+        maxVersion: 1,
+        minVersion: 1,
+      });
+
+      expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("sub-1");
+
+      replacementYDoc.getMap("Shape").set("shape-1", "belongs-to-new-doc");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+    });
+
+    it("warns rather than staying silent when a disposed document had unpublished writes", async () => {
       const yDoc = new Y.Doc();
       const { service } = startSyncCapturingServer(yDoc);
       await Promise.resolve();
@@ -515,9 +730,8 @@ describe("FoundryEventService", () => {
       yDoc.getMap("Shape").set("shape-1", "never-published");
       logger.warn.mockClear();
 
-      // The load never established a revision, so the held update has nothing to publish against
-      // and is dropped. It must not be dropped quietly.
-      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+      // Disposal ends the document, so held updates have no future session to publish them.
+      service.disposeDocument("doc-1" as DocumentId);
 
       expect(mocks.eventService.publish).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -23,6 +23,7 @@ import {
   DocumentLoadStatus,
   type DocumentSyncStatus,
 } from "@palantir/pack.state.core";
+import { Base64 } from "js-base64";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { createFoundryEventService } from "../FoundryEventService.js";
@@ -534,6 +535,138 @@ describe("FoundryEventService", () => {
     });
   });
 
+  describe("updates made before the initial revision is known", () => {
+    /** Server acknowledgement that establishes lastRevisionId and completes the initial load. */
+    function initialRevision(): DocumentUpdateMessage {
+      return {
+        baseRevisionId: "0",
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId: "1",
+        type: "update",
+      };
+    }
+
+    /** Rebuild what a peer would see from every update this client published, in order. */
+    function applyPublishedUpdates(): Y.Doc {
+      const peerDoc = new Y.Doc();
+      for (const call of mocks.eventService.publish.mock.calls) {
+        const message = call[1] as PublishedDocumentUpdate;
+        const data = message.yjsUpdate?.data;
+        if (typeof data === "string") {
+          Y.applyUpdate(peerDoc, Base64.toUint8Array(data));
+        }
+      }
+      return peerDoc;
+    }
+
+    /**
+     * Keys a peer would observe after each published update, in publish order. The merged end
+     * state cannot distinguish flush order — Yjs buffers an update whose dependencies have not
+     * arrived and integrates it later — so only the intermediate states pin FIFO.
+     */
+    function publishedKeySnapshots(): string[][] {
+      const peerDoc = new Y.Doc();
+      const snapshots: string[][] = [];
+      for (const call of mocks.eventService.publish.mock.calls) {
+        const message = call[1] as PublishedDocumentUpdate;
+        const data = message.yjsUpdate?.data;
+        if (typeof data === "string") {
+          Y.applyUpdate(peerDoc, Base64.toUint8Array(data));
+        }
+        snapshots.push([...peerDoc.getMap("Shape").keys()].sort());
+      }
+      return snapshots;
+    }
+
+    function startSyncCapturingServer(yDoc: Y.Doc): {
+      service: ReturnType<typeof createFoundryEventService>;
+      deliverInitialRevision: () => void;
+    } {
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+
+      const service = createFoundryEventService(app);
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+
+      return { service, deliverInitialRevision: () => updateCallback?.(initialRevision()) };
+    }
+
+    it("holds a write made during the load instead of dropping it", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      // The handler is attached but lastRevisionId is still unknown. This previously logged
+      // "Cannot publish document update before initial load is complete" and discarded the update.
+      yDoc.getMap("Shape").set("shape-1", "during-load");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(1);
+      expect(applyPublishedUpdates().getMap("Shape").get("shape-1")).toBe("during-load");
+    });
+
+    it("preserves the order of writes held across the load", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("first", "during-load");
+      yDoc.getMap("Shape").set("second", "also-during-load");
+      deliverInitialRevision();
+      yDoc.getMap("Shape").set("third", "after-load");
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(3);
+      // Asserted per-update rather than on the merged result: applying all three into one doc
+      // passes just as well for a reversed flush, so it would not test order at all.
+      expect(publishedKeySnapshots()).toEqual([
+        ["first"],
+        ["first", "second"],
+        ["first", "second", "third"],
+      ]);
+    });
+
+    it("publishes nothing when no local write was made during the load", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+    });
+
+    it("warns rather than staying silent when a load never completes", async () => {
+      const yDoc = new Y.Doc();
+      const { service } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("shape-1", "never-published");
+      logger.warn.mockClear();
+
+      // The load never established a revision, so the held update has nothing to publish against
+      // and is dropped. It must not be dropped quietly.
+      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Discarding local document updates"),
+        expect.objectContaining({ discardedCount: 1 }),
+      );
+    });
+  });
+
   describe("data channel liveness", () => {
     function collectStatus(): {
       statusUpdates: Array<Partial<DocumentSyncStatus>>;
@@ -663,6 +796,34 @@ describe("FoundryEventService", () => {
 
       expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.ERROR);
       expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.CONNECTED);
+    });
+
+    it("does not promote to CONNECTED when a channel error arrives with the subscribe ack", async () => {
+      // CometD dispatches every message in one transport response synchronously, but the
+      // subscribe promise's continuation is a microtask. A channel error delivered in the same
+      // batch as the ack therefore always lands before the promotion runs.
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        const subscribed = Promise.resolve("document-sub" as SubscriptionId);
+        (callback as (message: DocumentUpdateMessage) => void)({
+          code: "REVISION_TOO_OLD",
+          errorInstanceId: "error-instance-1",
+          type: "error",
+        } as unknown as DocumentUpdateMessage);
+        return subscribed;
+      });
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+
+      expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.ERROR);
+      expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.ERROR);
     });
   });
 });

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -647,6 +647,26 @@ describe("FoundryEventService", () => {
       expect(mocks.eventService.publish).not.toHaveBeenCalled();
     });
 
+    it("drops writes after the hold queue reaches its limit", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      for (let index = 0; index < 101; index += 1) {
+        yDoc.getMap("Shape").set(`shape-${index}`, "during-load");
+      }
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(100);
+      const peerDoc = applyPublishedUpdates();
+      expect(peerDoc.getMap("Shape").get("shape-99")).toBe("during-load");
+      expect(peerDoc.getMap("Shape").get("shape-100")).toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("hold queue is full"),
+        expect.objectContaining({ docId: "doc-1", pendingCount: 100 }),
+      );
+    });
+
     it("warns rather than staying silent when a load never completes", async () => {
       const yDoc = new Y.Doc();
       const { service } = startSyncCapturingServer(yDoc);
@@ -682,6 +702,14 @@ describe("FoundryEventService", () => {
       field: K,
     ): DocumentSyncStatus[K] | undefined {
       return statusUpdates.filter(s => s[field] !== undefined).at(-1)?.[field];
+    }
+
+    function selectLiveUpdates(
+      statusUpdates: Array<Partial<DocumentSyncStatus>>,
+    ): DocumentLiveStatus[] {
+      return statusUpdates.flatMap(
+        (status): DocumentLiveStatus[] => status.live == null ? [] : [status.live],
+      );
     }
 
     it("reports CONNECTING while the subscription is being established", () => {
@@ -764,6 +792,133 @@ describe("FoundryEventService", () => {
 
       expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.ERROR);
       expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.ERROR);
+    });
+
+    it("restores CONNECTED once a message proves the channel works again", async () => {
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation(
+        (_channel, callback): Promise<SubscriptionId> => {
+          updateCallback = callback as (message: DocumentUpdateMessage) => void;
+          return Promise.resolve("document-sub" as SubscriptionId);
+        },
+      );
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+      updateCallback?.({
+        code: "REVISION_TOO_OLD",
+        errorInstanceId: "error-instance-1",
+        type: "error",
+      } as unknown as DocumentUpdateMessage);
+      updateCallback?.({
+        baseRevisionId: "0",
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId: "1",
+        type: "update",
+      });
+      updateCallback?.({
+        baseRevisionId: "1",
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId: "2",
+        type: "update",
+      });
+
+      expect(selectLiveUpdates(statusUpdates)).toEqual([
+        DocumentLiveStatus.CONNECTING,
+        DocumentLiveStatus.CONNECTED,
+        DocumentLiveStatus.ERROR,
+        DocumentLiveStatus.CONNECTED,
+      ]);
+      expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.LOADED);
+    });
+
+    it("reports recovery once when an update arrives before the subscribe ack", async () => {
+      mocks.eventService.subscribe.mockImplementation(
+        (_channel, callback): Promise<SubscriptionId> => {
+          const handleUpdate = callback as (message: DocumentUpdateMessage) => void;
+          const subscribed = Promise.resolve("document-sub" as SubscriptionId);
+          handleUpdate({
+            code: "REVISION_TOO_OLD",
+            errorInstanceId: "error-instance-1",
+            type: "error",
+          } as unknown as DocumentUpdateMessage);
+          handleUpdate({
+            baseRevisionId: "0",
+            clientId: "server",
+            clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+            editIds: [],
+            revisionId: "1",
+            type: "update",
+          });
+          return subscribed;
+        },
+      );
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+
+      expect(selectLiveUpdates(statusUpdates)).toEqual([
+        DocumentLiveStatus.CONNECTING,
+        DocumentLiveStatus.ERROR,
+        DocumentLiveStatus.CONNECTED,
+      ]);
+    });
+
+    it("clears channel failure when sync stops", async () => {
+      const updateCallbacks: Array<(message: DocumentUpdateMessage) => void> = [];
+      mocks.eventService.subscribe.mockImplementation(
+        (_channel, callback): Promise<SubscriptionId> => {
+          updateCallbacks.push(callback as (message: DocumentUpdateMessage) => void);
+          return Promise.resolve(`document-sub-${updateCallbacks.length}` as SubscriptionId);
+        },
+      );
+      const service = createFoundryEventService(app);
+      const firstStatus = collectStatus();
+      const session = service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        firstStatus.onStatusChange,
+      );
+      await Promise.resolve();
+      updateCallbacks[0]?.({
+        code: "REVISION_TOO_OLD",
+        errorInstanceId: "error-instance-1",
+        type: "error",
+      } as unknown as DocumentUpdateMessage);
+
+      service.stopDocumentSync(session);
+      const secondStatus = collectStatus();
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        secondStatus.onStatusChange,
+      );
+      await Promise.resolve();
+
+      expect(selectLiveUpdates(secondStatus.statusUpdates)).toEqual([
+        DocumentLiveStatus.CONNECTING,
+        DocumentLiveStatus.CONNECTED,
+      ]);
     });
 
     it("leaves liveness alone when a revision gap makes local state stale", async () => {

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import type { DocumentUpdateMessage } from "@osdk/foundry.pack";
+import type { DocumentPublishMessage, DocumentUpdateMessage } from "@osdk/foundry.pack";
 import type { PackAppInternal } from "@palantir/pack.core";
-import type { DocumentId } from "@palantir/pack.document-schema.model-types";
+import { type DocumentId, Metadata } from "@palantir/pack.document-schema.model-types";
 import {
   addDocumentUpdateSchemaVersionToTransaction,
   DocumentLiveStatus,
@@ -536,6 +536,15 @@ describe("FoundryEventService", () => {
   });
 
   describe("updates made before the initial revision is known", () => {
+    beforeEach((): void => {
+      vi.useFakeTimers();
+      logger.warn.mockClear();
+    });
+
+    afterEach((): void => {
+      vi.useRealTimers();
+    });
+
     /** Server acknowledgement that establishes lastRevisionId and completes the initial load. */
     function initialRevision(): DocumentUpdateMessage {
       return {
@@ -580,7 +589,7 @@ describe("FoundryEventService", () => {
       return snapshots;
     }
 
-    function startSyncCapturingServer(yDoc: Y.Doc): {
+    function startSyncCapturingServer(yDoc: Y.Doc, maxVersion = 1): {
       service: ReturnType<typeof createFoundryEventService>;
       deliverInitialRevision: () => void;
     } {
@@ -594,7 +603,7 @@ describe("FoundryEventService", () => {
       service.startDocumentSync(
         "doc-1" as DocumentId,
         yDoc,
-        { maxVersion: 1, minVersion: 1 },
+        { maxVersion, minVersion: 1 },
         () => {},
       );
 
@@ -647,24 +656,77 @@ describe("FoundryEventService", () => {
       expect(mocks.eventService.publish).not.toHaveBeenCalled();
     });
 
-    it("drops writes after the hold queue reaches its limit", async () => {
+    it.each([99, 100, 101])(
+      "preserves causal history across %i held writes",
+      async (pendingCount): Promise<void> => {
+        const yDoc = new Y.Doc();
+        const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+        await Promise.resolve();
+
+        for (let index = 0; index < pendingCount; index += 1) {
+          yDoc.getMap("Shape").set(`shape-${index}`, "during-load");
+        }
+        expect(mocks.eventService.publish).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledTimes(pendingCount >= 100 ? 1 : 0);
+        deliverInitialRevision();
+        yDoc.getMap("Shape").set("after-load", "still-syncing");
+
+        const peerDoc = applyPublishedUpdates();
+        expect(peerDoc.getMap("Shape").get("after-load")).toBe("still-syncing");
+        expect(peerDoc.getMap("Shape").toJSON()).toEqual(yDoc.getMap("Shape").toJSON());
+        expect(mocks.eventService.publish).toHaveBeenCalledTimes(pendingCount + 1);
+      },
+    );
+
+    it("flushes a large backlog as individual edits with their original metadata", async (): Promise<void> => {
       const yDoc = new Y.Doc();
-      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc, 2);
       await Promise.resolve();
 
       for (let index = 0; index < 101; index += 1) {
-        yDoc.getMap("Shape").set(`shape-${index}`, "during-load");
+        yDoc.transact((transaction): void => {
+          addDocumentUpdateSchemaVersionToTransaction(transaction, index % 2 + 1);
+          yDoc.getMap("Shape").set(`shape-${index}`, "x".repeat(1_024));
+        }, {
+          data: { index },
+          model: { [Metadata]: { name: "shape-edited" } },
+          schemaVersion: 3,
+        });
       }
       deliverInitialRevision();
 
-      expect(mocks.eventService.publish).toHaveBeenCalledTimes(100);
-      const peerDoc = applyPublishedUpdates();
-      expect(peerDoc.getMap("Shape").get("shape-99")).toBe("during-load");
-      expect(peerDoc.getMap("Shape").get("shape-100")).toBeUndefined();
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("hold queue is full"),
-        expect.objectContaining({ docId: "doc-1", pendingCount: 100 }),
+      const messages = mocks.eventService.publish.mock.calls.map(
+        ([, message]): DocumentPublishMessage => message as DocumentPublishMessage,
       );
+      expect(messages).toHaveLength(101);
+      expect(new Set(messages.map((message): string => message.editId)).size).toBe(101);
+
+      const peerDoc = new Y.Doc();
+      let serializedSize = 0;
+      for (const [index, message] of messages.entries()) {
+        expect(message.documentUpdateSchemaVersion).toBe(index % 2 + 1);
+        expect(message.description).toEqual({
+          eventData: { data: { index }, eventType: "shape-edited", schemaVersion: 3 },
+        });
+        const envelope = JSON.stringify({ channel: "/document/doc-1/publish", data: message });
+        expect(envelope.length).toBeLessThan(65_536);
+        serializedSize += envelope.length;
+        const updateData: unknown = message.yjsUpdate.data;
+        if (typeof updateData !== "string") {
+          throw new Error("Expected a base64-encoded Yjs update");
+        }
+        Y.applyUpdate(peerDoc, Base64.toUint8Array(updateData));
+        expect(peerDoc.getMap("Shape").size).toBe(index + 1);
+      }
+      expect(serializedSize).toBeGreaterThan(65_536);
+      expect(peerDoc.getMap("Shape").toJSON()).toEqual(yDoc.getMap("Shape").toJSON());
+
+      vi.advanceTimersByTime(2_000);
+      expect(
+        mocks.eventService.publish.mock.calls.slice(101).map(
+          ([, message]): DocumentPublishMessage => message as DocumentPublishMessage,
+        ),
+      ).toEqual(messages);
     });
 
     it("warns rather than staying silent when a load never completes", async () => {

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -625,7 +625,7 @@ describe("FoundryEventService", () => {
     });
 
     /** Server acknowledgement that establishes lastRevisionId and completes the initial load. */
-    function initialRevision(): DocumentUpdateMessage {
+    function initialRevision(): Extract<DocumentUpdateMessage, { type: "update" }> {
       return {
         baseRevisionId: "0",
         clientId: "server",
@@ -866,6 +866,96 @@ describe("FoundryEventService", () => {
       const peerShapes = applyPublishedUpdates().getMap("Shape");
       expect(peerShapes.get("shape-1")).toBe("held-across-stop");
       expect(peerShapes.get("shape-2")).toBe("written-while-stopped");
+    });
+
+    describe("sync stopped by a remote update observer", () => {
+      beforeEach((): void => {
+        vi.useFakeTimers();
+      });
+
+      afterEach((): void => {
+        vi.useRealTimers();
+      });
+
+      it.each([
+        { restartDuringUpdate: false, throwInObserver: false },
+        { restartDuringUpdate: true, throwInObserver: false },
+        { restartDuringUpdate: false, throwInObserver: true },
+        { restartDuringUpdate: true, throwInObserver: true },
+      ])(
+        "holds writes until the next revision (restart=$restartDuringUpdate, throw=$throwInObserver)",
+        async ({ restartDuringUpdate, throwInObserver }): Promise<void> => {
+          const updateCallbacks: Array<(message: DocumentUpdateMessage) => void> = [];
+          mocks.eventService.subscribe.mockImplementation(
+            (_channel, callback): Promise<SubscriptionId> => {
+              updateCallbacks.push(callback as (message: DocumentUpdateMessage) => void);
+              return Promise.resolve(`sub-${updateCallbacks.length}` as SubscriptionId);
+            },
+          );
+          const service = createFoundryEventService(app);
+          const yDoc = new Y.Doc();
+          const onStatusChange = vi.fn();
+          const onRestartedStatusChange = vi.fn();
+          const session = service.startDocumentSync(
+            "doc-1" as DocumentId,
+            yDoc,
+            { maxVersion: 1, minVersion: 1 },
+            onStatusChange,
+          );
+          const restartSync = (): void => {
+            service.startDocumentSync(
+              "doc-1" as DocumentId,
+              yDoc,
+              { maxVersion: 1, minVersion: 1 },
+              onRestartedStatusChange,
+            );
+          };
+          await Promise.resolve();
+          onStatusChange.mockClear();
+          yDoc.getMap("Shape").set("before-stop", "held");
+
+          const serverYDoc = new Y.Doc();
+          serverYDoc.getMap("Shape").set("server-shape", "remote");
+          const stopFromObserver = (): void => {
+            yDoc.getMap("Shape").unobserve(stopFromObserver);
+            service.stopDocumentSync(session);
+            if (restartDuringUpdate) {
+              restartSync();
+            }
+            if (throwInObserver) {
+              throw new Error("Observer failed after stopping sync");
+            }
+          };
+          yDoc.getMap("Shape").observe(stopFromObserver);
+          updateCallbacks[0]?.({
+            ...initialRevision(),
+            update: { data: Base64.fromUint8Array(Y.encodeStateAsUpdate(serverYDoc)) },
+          });
+
+          yDoc.getMap("Shape").set("after-stop", "also-held");
+          expect(mocks.eventService.publish).not.toHaveBeenCalled();
+          expect(onStatusChange).not.toHaveBeenCalled();
+          if (!restartDuringUpdate) {
+            restartSync();
+          }
+          await Promise.resolve();
+          expect(onRestartedStatusChange).not.toHaveBeenCalledWith(
+            expect.objectContaining({ load: DocumentLoadStatus.LOADED }),
+          );
+
+          updateCallbacks[1]?.(initialRevision());
+
+          expect(mocks.eventService.publish).toHaveBeenCalledTimes(2);
+          expect(applyPublishedUpdates().getMap("Shape").toJSON()).toEqual({
+            "before-stop": "held",
+            "after-stop": "also-held",
+          });
+          expect(onRestartedStatusChange).toHaveBeenLastCalledWith({
+            load: DocumentLoadStatus.LOADED,
+          });
+          service.disposeDocument("doc-1" as DocumentId);
+        },
+      );
     });
 
     it("starts sync with a replacement Y.Doc after the previous run stops", async () => {

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -330,6 +330,11 @@ describe("FoundryEventService", () => {
 
     service.stopDocumentSync(session);
 
+    // Capture outlives sync so writes made while stopped are still held; only disposal detaches.
+    expect(activeOff).not.toHaveBeenCalled();
+
+    service.disposeDocument("doc-1" as DocumentId);
+
     expect(activeOff).toHaveBeenCalledWith("update", expect.any(Function));
     expect(rejectedOff).not.toHaveBeenCalled();
     expect(mocks.eventService.subscribe).toHaveBeenCalledTimes(1);
@@ -533,6 +538,80 @@ describe("FoundryEventService", () => {
       vi.advanceTimersByTime(6_000);
       expect(publishCallsFor("doc-1")).toHaveLength(1);
     });
+
+    it("keeps tracking an unacked update when capture is refreshed", async () => {
+      const { service, session, yDoc, sendServerMessage } = await startSyncedDoc();
+
+      yDoc.getMap("Shape").set("shape-1", new Y.Map());
+      const editId = (publishCallsFor("doc-1")[0]![1] as { editId: string }).editId;
+
+      service.beginDocumentCapture(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+      );
+      vi.advanceTimersByTime(2_000);
+      expect(publishCallsFor("doc-1")).toHaveLength(2);
+
+      sendServerMessage({
+        baseRevisionId: "1",
+        clientId: session.clientId,
+        clientSupportedVersionRange: { minVersion: 1, maxVersion: 1 },
+        editIds: [editId],
+        revisionId: "2",
+        type: "update",
+      });
+      vi.advanceTimersByTime(2_000);
+
+      expect(publishCallsFor("doc-1")).toHaveLength(2);
+    });
+
+    it("resends a held update with the same edit ID after the initial revision", async () => {
+      let sendServerMessage: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation(
+        (_channel, callback): Promise<SubscriptionId> => {
+          sendServerMessage = callback as (message: DocumentUpdateMessage) => void;
+          return Promise.resolve("document-sub" as SubscriptionId);
+        },
+      );
+
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+      const session = service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        (): void => {},
+      );
+
+      yDoc.getMap("Shape").set("shape-1", "held");
+      expect(publishCallsFor("doc-1")).toHaveLength(0);
+
+      await Promise.resolve();
+      sendServerMessage!({
+        baseRevisionId: "0",
+        clientId: "server",
+        clientSupportedVersionRange: { minVersion: 1, maxVersion: 1 },
+        editIds: [],
+        revisionId: "1",
+        type: "update",
+      });
+      const editId = (publishCallsFor("doc-1")[0]![1] as { editId: string }).editId;
+
+      vi.advanceTimersByTime(2_000);
+
+      expect(publishCallsFor("doc-1")).toHaveLength(2);
+      expect((publishCallsFor("doc-1")[1]![1] as { editId: string }).editId).toBe(editId);
+
+      sendServerMessage!({
+        baseRevisionId: "1",
+        clientId: session.clientId,
+        clientSupportedVersionRange: { minVersion: 1, maxVersion: 1 },
+        editIds: [editId],
+        revisionId: "2",
+        type: "update",
+      });
+    });
   });
 
   describe("updates made before the initial revision is known", () => {
@@ -609,6 +688,34 @@ describe("FoundryEventService", () => {
 
       return { service, deliverInitialRevision: () => updateCallback?.(initialRevision()) };
     }
+
+    it("holds a write made before any sync session exists", async () => {
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+
+      // Capture begins when the document is created, well before a data subscription opens.
+      service.beginDocumentCapture("doc-1" as DocumentId, yDoc, { maxVersion: 1, minVersion: 1 });
+      yDoc.getMap("Shape").set("shape-1", "before-any-sync");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+      await Promise.resolve();
+      updateCallback?.(initialRevision());
+
+      // One update carrying the original transaction, not a full-state snapshot of the document.
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(1);
+      expect(applyPublishedUpdates().getMap("Shape").get("shape-1")).toBe("before-any-sync");
+    });
 
     it("holds a write made during the load instead of dropping it", async () => {
       const yDoc = new Y.Doc();
@@ -729,7 +836,223 @@ describe("FoundryEventService", () => {
       ).toEqual(messages);
     });
 
-    it("warns rather than staying silent when a load never completes", async () => {
+    it("keeps held updates across a stop and publishes them when sync resumes", async () => {
+      const yDoc = new Y.Doc();
+      const { service } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("shape-1", "held-across-stop");
+      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+
+      // Stopping sync does not end the document, so the write must survive to the next session.
+      yDoc.getMap("Shape").set("shape-2", "written-while-stopped");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      let resumedCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        resumedCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-2" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+      await Promise.resolve();
+      resumedCallback?.(initialRevision());
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(2);
+      const peerShapes = applyPublishedUpdates().getMap("Shape");
+      expect(peerShapes.get("shape-1")).toBe("held-across-stop");
+      expect(peerShapes.get("shape-2")).toBe("written-while-stopped");
+    });
+
+    it("starts sync with a replacement Y.Doc after the previous run stops", async () => {
+      const updateCallbacks: Array<(message: DocumentUpdateMessage) => void> = [];
+      mocks.eventService.subscribe.mockImplementation(
+        (_channel, callback): Promise<SubscriptionId> => {
+          updateCallbacks.push(callback as (message: DocumentUpdateMessage) => void);
+          return Promise.resolve(`sub-${updateCallbacks.length}` as SubscriptionId);
+        },
+      );
+
+      const service = createFoundryEventService(app);
+      const firstSession = service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        (): void => {},
+      );
+      await Promise.resolve();
+      service.stopDocumentSync(firstSession);
+
+      const replacementYDoc = new Y.Doc();
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        replacementYDoc,
+        { maxVersion: 1, minVersion: 1 },
+        (): void => {},
+      );
+      await Promise.resolve();
+      updateCallbacks[1]?.(initialRevision());
+      replacementYDoc.getMap("Shape").set("shape-1", "replacement");
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(1);
+      expect(applyPublishedUpdates().getMap("Shape").get("shape-1")).toBe("replacement");
+    });
+
+    it("reports held updates left behind when sync stops", async () => {
+      const yDoc = new Y.Doc();
+      const { service } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("shape-1", "held-across-stop");
+      logger.warn.mockClear();
+
+      // stopDocumentSync is the teardown the ordinary lifecycle actually runs —
+      // onDataSubscriptionClosed calls it, and disposeDocument is only reached via
+      // deleteDocument. Held updates survive on purpose, but must not do so silently: nothing
+      // guarantees sync ever resumes, and until it does these writes are not on the server.
+      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("never published"),
+        expect.objectContaining({ docId: "doc-1", heldCount: 1 }),
+      );
+    });
+
+    it("resolves the schema version when publishing, not when capturing", async () => {
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+
+      // Capture happens before metadata loads, when the operational version is still a fallback.
+      let operationalVersion = 1;
+      service.beginDocumentCapture(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 5, minVersion: 1 },
+        () => operationalVersion,
+      );
+      yDoc.getMap("Shape").set("shape-1", "captured-early");
+
+      // Metadata lands during the load and raises the operational version.
+      operationalVersion = 3;
+
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 5, minVersion: 1 },
+        () => {},
+        () => operationalVersion,
+      );
+      await Promise.resolve();
+      updateCallback?.(initialRevision());
+
+      const publishCall = mocks.eventService.publish.mock.calls[0] as
+        | [unknown, PublishedDocumentUpdate]
+        | undefined;
+      expect(publishCall?.[1].documentUpdateSchemaVersion).toBe(3);
+    });
+
+    it("does not wedge the document when starting sync throws", () => {
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+      mocks.eventService.subscribe.mockResolvedValue("sub-1" as SubscriptionId);
+
+      const failingStatusCallback = () => {
+        throw new Error("subscriber blew up");
+      };
+
+      expect(() =>
+        service.startDocumentSync(
+          "doc-1" as DocumentId,
+          yDoc,
+          { maxVersion: 1, minVersion: 1 },
+          failingStatusCallback,
+        )
+      ).toThrow("subscriber blew up");
+
+      // The failed attempt must not leave the document permanently "already active".
+      expect(() =>
+        service.startDocumentSync(
+          "doc-1" as DocumentId,
+          yDoc,
+          { maxVersion: 1, minVersion: 1 },
+          () => {},
+        )
+      ).not.toThrow();
+    });
+
+    it("discards held updates loudly when the Y.Doc is replaced", async () => {
+      const originalYDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+      service.beginDocumentCapture("doc-1" as DocumentId, originalYDoc, {
+        maxVersion: 1,
+        minVersion: 1,
+      });
+      originalYDoc.getMap("Shape").set("shape-1", "belongs-to-old-doc");
+      logger.warn.mockClear();
+
+      // Held updates describe operations in a document that is being replaced, so publishing them
+      // against the replacement would inject state it does not have.
+      const replacementYDoc = new Y.Doc();
+      service.beginDocumentCapture("doc-1" as DocumentId, replacementYDoc, {
+        maxVersion: 1,
+        minVersion: 1,
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("replaced Y.Doc"),
+        expect.objectContaining({ discardedCount: 1 }),
+      );
+
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        replacementYDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+      await Promise.resolve();
+      updateCallback?.(initialRevision());
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+    });
+
+    it("ends the sync run when the Y.Doc is replaced mid-sync", async () => {
+      const originalYDoc = new Y.Doc();
+      const { service, deliverInitialRevision } = startSyncCapturingServer(originalYDoc);
+      await Promise.resolve();
+      deliverInitialRevision();
+      mocks.eventService.publish.mockClear();
+
+      // Replacing the document under an active sync leaves the subscription and lastRevisionId
+      // bound to the old Y.Doc. Left in place, remote updates keep applying to the replaced
+      // document while writes to the new one publish against a revision stream that is not
+      // theirs — so the run has to end and be restarted by the caller.
+      const replacementYDoc = new Y.Doc();
+      service.beginDocumentCapture("doc-1" as DocumentId, replacementYDoc, {
+        maxVersion: 1,
+        minVersion: 1,
+      });
+
+      expect(mocks.eventService.unsubscribe).toHaveBeenCalledWith("sub-1");
+
+      replacementYDoc.getMap("Shape").set("shape-1", "belongs-to-new-doc");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+    });
+
+    it("warns rather than staying silent when a disposed document had unpublished writes", async () => {
       const yDoc = new Y.Doc();
       const { service } = startSyncCapturingServer(yDoc);
       await Promise.resolve();
@@ -737,9 +1060,8 @@ describe("FoundryEventService", () => {
       yDoc.getMap("Shape").set("shape-1", "never-published");
       logger.warn.mockClear();
 
-      // The load never established a revision, so the held update has nothing to publish against
-      // and is dropped. It must not be dropped quietly.
-      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+      // Disposal ends the document, so held updates have no future session to publish them.
+      service.disposeDocument("doc-1" as DocumentId);
 
       expect(mocks.eventService.publish).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -146,10 +146,22 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     ref: DocumentRef,
     metadata: DocumentMetadata | undefined,
   ): FoundryInternalDoc {
-    return {
+    const internalDoc: FoundryInternalDoc = {
       ...this.createBaseInternalDoc(ref, metadata),
       syncSession: undefined,
     };
+
+    // Data loads are demand-driven, but writes are not: callers may populate a document before
+    // opening a subscription. Capturing from creation means those writes are held for the first
+    // sync session rather than never being seen by a publish handler at all.
+    this.eventService.beginDocumentCapture(
+      ref.id,
+      internalDoc.yDoc,
+      getClientSupportedVersionRange(ref.schema),
+      () => this.getDocumentSchemaOperationalVersion(ref),
+    );
+
+    return internalDoc;
   }
 
   get hasMetadataSubscriptions(): boolean {

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -148,10 +148,22 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     ref: DocumentRef,
     metadata: DocumentMetadata | undefined,
   ): FoundryInternalDoc {
-    return {
+    const internalDoc: FoundryInternalDoc = {
       ...this.createBaseInternalDoc(ref, metadata),
       syncSession: undefined,
     };
+
+    // Data loads are demand-driven, but writes are not: callers may populate a document before
+    // opening a subscription. Capturing from creation means those writes are held for the first
+    // sync session rather than never being seen by a publish handler at all.
+    this.eventService.beginDocumentCapture(
+      ref.id,
+      internalDoc.yDoc,
+      getClientSupportedVersionRange(ref.schema),
+      () => this.getDocumentSchemaOperationalVersion(ref),
+    );
+
+    return internalDoc;
   }
 
   get hasMetadataSubscriptions(): boolean {

--- a/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
@@ -406,6 +406,26 @@ describe("Foundry Document Status Tracking", () => {
       expect(getOperationalVersion?.()).toBe(3);
     });
 
+    it("should capture local writes from document creation against the synced Y.Doc", async () => {
+      const docRef = createDocRef(mockApp, "test-doc-capture" as DocumentId, testSchema);
+
+      // Capture has to start at creation, before any subscription exists, or writes made before
+      // the first subscription never reach a publish handler.
+      const unsubscribe = service.onStateChange(docRef, () => {});
+      expect(mockEventService.beginDocumentCapture).toHaveBeenCalled();
+
+      await vi.runAllTimersAsync();
+      expect(mockEventService.startDocumentSync).toHaveBeenCalled();
+
+      // Must be the same Y.Doc instance: a different one silently trips the replacement path,
+      // which discards everything captured instead of holding it.
+      const capturedYDoc = mockEventService.beginDocumentCapture.mock.calls[0]?.[1];
+      const syncedYDoc = mockEventService.startDocumentSync.mock.calls[0]?.[1];
+      expect(capturedYDoc).toBe(syncedYDoc);
+
+      unsubscribe();
+    });
+
     it("should handle fast unsubscribe before websocket data sync starts", async () => {
       let resolveMetadata: (document: Document) => void = () => {};
       vi.mocked(Documents.get).mockReturnValueOnce(


### PR DESCRIPTION
## Summary

**This is the headline data-loss fix.** The update listener that publishes local changes was attached in `startDocumentSync`, which only runs once a data subscription registers. Writes made before that produced no event and never reached the server.

Nothing surfaced the loss — the writing client read its own value back correctly. And because a later update references struct ids from the unpublished operations, a receiving peer holds it pending against a causal gap that never closes, so the record is **invisible** on other clients rather than merely late.

## Reported repro

```ts
const docRef = await app.state.createDocument(metadata, DocumentModel);
await docRef.setRecord(DocumentModel.Thing, "thing-1", { counter: 1 });  // no subscription yet
// reads back correctly here ✅ — and never reaches the server

app.state.onStateChange(docRef, noop);
await app.state.waitForDataLoad(docRef);
await docRef.setRecord(DocumentModel.Thing, "thing-2", { counter: 2 });  // correct ordering
```

A second, independent client then sees `{"Thing":{}}` — **neither** record. Reproduced on every run by the reporting team against a real stack.

## The fix

Capture begins when the document is created, via a new `FoundryEventService.beginDocumentCapture` called from `createInternalDoc`. Updates are held and published against the first revision once a sync session establishes one, so each keeps its **own** edit description and schema version rather than being collapsed into one message.

This matches what `DemoDocumentService` already did — it attaches its handler in `createInternalDoc`, which is why demo mode never had this bug. Foundry now converges on that pattern.

Capture also outlives `stopDocumentSync`, so writes made while sync is stopped are held and published on resume. Only `disposeDocument` tears capture down, warning if it discards updates that were never published.

## Why not publish full local state instead

Considered and rejected: cometd caps a serialized message at 65536 chars, which a base64-encoded document state exceeds at roughly 48KB, and the fire-and-forget publish rejection would silently reinstate the data loss. See the parent PR for detail.

## Changes forced by the new lifecycle

**Sync runs are now identified by an explicit token.** Async callbacks previously detected staleness by comparing update-handler identity, which stops being valid once the handler outlives sync — a subscription resolving after `stopDocumentSync` would have been *adopted* instead of unsubscribed. A pre-existing test caught this leak.

**A synchronous failure while starting sync clears the token before rethrowing.** `onStatusChange` fans out to caller-supplied subscribers, and `notifyStatusSubscribers` does not guard them; a stranded token would reject every later start as "already active", wedging the document permanently.

**Schema version resolves at publish, not capture.** Capture can happen before metadata loads, when the operational version is still a schema fallback that can understate what the content needs.

**Replacing a document's `Y.Doc` discards updates held for the previous one, with a warning**, rather than publishing operations the current document does not have.

## Review

Reviewed by three independent reviewers including a cross-provider adversarial pass (OpenAI Codex). Four issues found and fixed — the last three in the list above, plus the queue-growth warning firing only once. Codex also caught that adding a required member to the exported `FoundryEventService` interface is not a patch, hence the **minor** bump for `foundry-event`.

Still open by explicit decision, not oversight: publishes remain fire-and-forget, so a failed flush loses updates with only a log line. That wants retry or a channel error and is its own change.

## Test plan

- [x] 7 new tests in `FoundryEventService.test.ts`, including: a write before any sync session exists; held updates surviving stop and publishing on resume; schema version resolved at publish; no wedge when starting sync throws; loud discard on Y.Doc replacement.
- [x] Verified meaningful by stashing the source — the behaviour tests fail without the fix (**3 failed | 21 passed** → **24 passed**).
- [x] `foundry-event` 57, `foundry` 71, `core` 125, `demo` 11, `react` 21.
- [x] Repo-wide `turbo typecheck` 66/66, `turbo lint` 88/88, `cspell` clean.
- [x] **Real-stack integration test — done.** See below.

---

## ✅ Validated against a live Foundry stack

Real-stack integration tests now exist (added in the PR stacked on top of this one). Two independent PACK clients, real backend, `danube-staging`:

| Test | Without the behavioural fixes | With them |
|---|---|---|
| write before any data subscription | ✗ 36s — never reaches the peer | ✓ |
| write during the initial load | ✗ 36s | ✓ |
| both writes visible to a peer | ✗ 37s | ✓ |
| `data.live` connected once synced | ✗ reads `disconnected` | ✓ |
| `waitForMetadataLoad` rejects | ✗ **90s hang** | ✓ |
| live update client → client | ✓ | ✓ |

The baseline run included the two worker-compatibility fixes (#299, #301) so the process could run in node at all, and **none** of the behavioural ones — so the failures isolate to the bugs these PRs fix. The last row passing in both is the control: sync fundamentally works, so the other five are the specific defects rather than a broken harness.

This replaces the earlier "unit-level only" caveat.
