### PR TITLE
Add live-stack integration tests for document sync

### DIFF
--- a/.changeset/capture-updates-from-doc-creation.md
+++ b/.changeset/capture-updates-from-doc-creation.md
@@ -1,0 +1,14 @@
+---
+"@palantir/pack.state.foundry": patch
+"@palantir/pack.state.foundry-event": minor
+---
+
+Stop losing local writes made before a document's first data subscription opens. The Yjs `update` listener that publishes local changes was attached in `startDocumentSync`, which only runs once a data subscription registers, so any earlier write produced no event and never reached the server. Nothing surfaced the loss — the writing client read its own value back correctly — and because a later update references struct ids from the unpublished operations, receiving peers hold it pending against a causal gap that never closes, making the record invisible rather than merely late.
+
+Capture now begins when the document is created, via a new `FoundryEventService.beginDocumentCapture`. Updates are held and published against the first revision once a sync session establishes one, so each keeps its own edit description and schema version instead of being collapsed into a single full-state message.
+
+Capture also outlives `stopDocumentSync`, so writes made while sync is stopped are held and published when it resumes; only `disposeDocument` tears capture down, warning if it discards updates that were never published. Sync runs are now tracked by an explicit token rather than by the identity of the update handler, which no longer implies that sync is active.
+
+An update's schema version is resolved when it is published rather than when it is captured, since capture can happen before metadata loads, when the operational version is still a schema fallback that can understate what the content needs. Replacing a document's `Y.Doc` discards updates held for the previous one, with a warning, rather than publishing operations the current document does not have.
+
+This is a minor rather than patch release for `@palantir/pack.state.foundry-event`: `beginDocumentCapture` is a required member of the exported `FoundryEventService` interface, so any external implementation of that interface needs to add it.

--- a/.changeset/foundry-channel-liveness.md
+++ b/.changeset/foundry-channel-liveness.md
@@ -1,0 +1,9 @@
+---
+"@palantir/pack.state.foundry": patch
+"@palantir/pack.state.foundry-event": patch
+"@palantir/pack.state.demo": patch
+---
+
+Maintain `live` status for the data and metadata channels. `DocumentStatus` exposes a `live: DocumentLiveStatus` per channel, but the Foundry implementation only ever set it for activity and presence — so `data.live` read `disconnected` permanently against a real stack while data synced perfectly, and `metadata.live` was never set by either implementation. A connection indicator bound to `data.live` therefore worked throughout development against `DemoDocumentService` and then read "disconnected" forever in production.
+
+The data channel now reports `CONNECTING` while its subscription is being established, `CONNECTED` once it is, and `ERROR` if it cannot be established or the server sends a channel error. Data-integrity failures that leave the socket healthy — a revision gap, or an update that will not apply — continue to affect `load` only. The metadata channel reports liveness for its updates subscription in both the Foundry and Demo implementations, including `ERROR` — with the causing error attached — when the subscription fails while the metadata itself remains loaded over HTTP, which is precisely the distinction `live` exists to express.

--- a/.changeset/presync-write-catchup.md
+++ b/.changeset/presync-write-catchup.md
@@ -1,0 +1,9 @@
+---
+"@palantir/pack.state.foundry-event": patch
+---
+
+Stop discarding local writes made while a document's initial load is in flight. Between the Yjs `update` listener being attached in `startDocumentSync` and the server's first revision arriving, local updates hit a `lastRevisionId == null` check and were dropped with only a log line — a publish has to declare the revision it builds on, and there was none yet. Nothing surfaced the loss: the writing client read its own value back correctly, while the update never reached the server and peers never saw it. Those updates are now held and flushed in order once the first revision establishes `lastRevisionId`.
+
+Two cases that were previously silent now say so. Held updates that are still queued when sync stops are discarded with a warning rather than quietly, since a load that never completes leaves them with nothing to publish against. A queue that grows past a threshold warns that the load looks stuck instead of accumulating unnoticed.
+
+This does not address writes made before any data subscription opens. The `update` listener is only attached when the first data subscription registers, so those transactions still produce no event to publish and remain lost.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -44,6 +44,7 @@
     "@palantir/pack.auth": "workspace:*",
     "@palantir/pack.auth.foundry": "workspace:*",
     "@palantir/pack.core": "workspace:*",
+    "@palantir/pack.document-schema.model-types": "workspace:*",
     "@palantir/pack.state.core": "workspace:*",
     "@palantir/pack.state.demo": "workspace:*",
     "@palantir/pack.state.foundry": "workspace:*",
@@ -57,12 +58,15 @@
     "@osdk/shared.client2": "catalog:"
   },
   "devDependencies": {
+    "@osdk/client": "catalog:",
     "@palantir/pack.monorepo.tsconfig": "workspace:~",
+    "@types/node": "catalog:",
     "happy-dom": "catalog:",
     "rimraf": "catalog:",
     "tslib": "catalog:",
     "typescript": "catalog:",
-    "vitest-mock-extended": "catalog:"
+    "vitest-mock-extended": "catalog:",
+    "zod": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/app/src/__tests__/FoundrySync.integration.test.ts
+++ b/packages/app/src/__tests__/FoundrySync.integration.test.ts
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Runs in node rather than the package default of happy-dom: these tests need a real WebSocket and
+// a genuinely absent `document`/`window`, which is also the environment PACK runs in inside a
+// SharedWorker.
+// @vitest-environment node
+
+import { createClient } from "@osdk/client";
+import { initPackApp } from "@palantir/pack.app";
+import type {
+  DocumentId,
+  DocumentRef,
+  DocumentSchema,
+  RecordId,
+  RecordModel,
+} from "@palantir/pack.document-schema.model-types";
+import { Metadata } from "@palantir/pack.document-schema.model-types";
+import { DocumentLiveStatus, DocumentLoadStatus } from "@palantir/pack.state.core";
+import { afterAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { FoundryTestEnv } from "./testEnv.js";
+import { getFoundryTestEnv } from "./testEnv.js";
+
+const env = getFoundryTestEnv();
+
+/**
+ * These tests talk to a real Foundry stack, so they only run when `.env.local` supplies
+ * credentials. Without it they skip, keeping a credential-free checkout green.
+ */
+const describeIntegration = env == null ? describe.skip : describe;
+
+/** Generous: each case does a document create plus at least one full sync round trip. */
+const TEST_TIMEOUT_MS = 90_000;
+
+const ThingSchema = z.object({ counter: z.number(), label: z.string() });
+type Thing = z.infer<typeof ThingSchema>;
+
+interface ThingModel extends RecordModel<Thing, typeof ThingSchema> {}
+const ThingModel: ThingModel = {
+  __type: {} as Thing,
+  zodSchema: ThingSchema,
+  [Metadata]: { name: "Thing" },
+};
+
+const TestSchema = {
+  Thing: ThingModel,
+  [Metadata]: { version: 1 },
+} as const satisfies DocumentSchema;
+
+type TestApp = ReturnType<ReturnType<typeof initPackApp>["withState"]>["build"] extends
+  () => infer R ? R : never;
+
+/**
+ * A PACK client with its own OSDK client, Yjs client id and CometD session — i.e. what a second
+ * browser tab or a second process would be, which is what the data-loss reports hinge on.
+ */
+function createPackClient(testEnv: FoundryTestEnv): TestApp {
+  // A static token rather than the OAuth redirect flow: these tests exercise sync, not auth.
+  const osdkClient = createClient(
+    testEnv.baseUrl,
+    testEnv.ontologyRid,
+    () => Promise.resolve(testEnv.token),
+  );
+
+  return initPackApp(osdkClient, {
+    app: { appId: "pack-integration-test" },
+    demoMode: false,
+    logLevel: "error",
+    ontologyRid: testEnv.ontologyRid,
+    remote: { baseUrl: testEnv.baseUrl },
+  }).withState().build() as TestApp;
+}
+
+/** Read a record's current value, or undefined when it has not arrived yet. */
+async function readThing(
+  app: TestApp,
+  docRef: DocumentRef<typeof TestSchema>,
+  recordId: string,
+): Promise<Thing | undefined> {
+  const recordRef = docRef.getRecords(ThingModel).get(recordId as RecordId);
+  if (recordRef == null) {
+    return undefined;
+  }
+  return await app.state.getRecordSnapshot(recordRef);
+}
+
+/**
+ * Write through the state module rather than `docRef.setRecord`, whose data parameter is `never` on
+ * the base interface — narrowing it needs a generated SDK's `asVersioned`, and this schema is
+ * declared inline.
+ */
+async function writeThing(
+  app: TestApp,
+  docRef: DocumentRef<typeof TestSchema>,
+  recordId: string,
+  data: Thing,
+): Promise<void> {
+  await app.state.setCollectionRecord(docRef.getRecords(ThingModel), recordId as RecordId, data);
+}
+
+/** Poll rather than await a single event, so a test fails with the value it saw. */
+async function waitFor<T>(
+  read: () => Promise<T | undefined> | T | undefined,
+  timeoutMs = 30_000,
+): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await read();
+    if (value !== undefined) {
+      return value;
+    }
+    await new Promise(resolve => setTimeout(resolve, 250));
+  }
+  return undefined;
+}
+
+describeIntegration("Foundry sync against a live stack", () => {
+  const testEnv = env!;
+  const createdDocuments: Array<{ app: TestApp; docRef: DocumentRef }> = [];
+  const apps: TestApp[] = [];
+
+  function newApp(): TestApp {
+    const app = createPackClient(testEnv);
+    apps.push(app);
+    return app;
+  }
+
+  afterAll(async () => {
+    for (const { app, docRef } of createdDocuments) {
+      await app.state.deleteDocument(docRef).catch(() => {
+        // Best effort: a leaked throwaway document should not fail the run.
+      });
+    }
+  });
+
+  async function createDocument(app: TestApp): Promise<DocumentRef<typeof TestSchema>> {
+    const docRef = await app.state.createDocument({
+      documentTypeName: testEnv.documentTypeName,
+      name: `pack-integration-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+      parentFolderRid: testEnv.parentFolderRid,
+    }, TestSchema);
+    createdDocuments.push({ app, docRef: docRef as DocumentRef });
+    return docRef;
+  }
+
+  /** Open the same document from an independent client and read a record once data has loaded. */
+  async function readFromSecondClient(
+    docId: string,
+    recordId: string,
+  ): Promise<Thing | undefined> {
+    const reader = newApp();
+    const docRef = reader.state.createDocRef(docId as DocumentId, TestSchema);
+    const unsubscribe = reader.state.onStateChange(docRef, () => {});
+    try {
+      await reader.state.waitForDataLoad(docRef);
+      return await waitFor(() => readThing(reader, docRef, recordId));
+    } finally {
+      unsubscribe();
+    }
+  }
+
+  it("propagates a write made before any data subscription", async () => {
+    const writer = newApp();
+    const docRef = await createDocument(writer);
+
+    // The reported repro: written with no subscription open, so before this fix no update handler
+    // existed to publish it. It reads back locally either way, which is what made it silent.
+    await writeThing(writer, docRef, "thing-1", { counter: 1, label: "before-subscribe" });
+    expect(await readThing(writer, docRef, "thing-1"))
+      .toMatchObject({ label: "before-subscribe" });
+
+    const unsubscribe = writer.state.onStateChange(docRef, () => {});
+    await writer.state.waitForDataLoad(docRef);
+
+    const seen = await readFromSecondClient(docRef.id, "thing-1");
+    unsubscribe();
+
+    expect(seen).toMatchObject({ counter: 1, label: "before-subscribe" });
+  }, TEST_TIMEOUT_MS);
+
+  it("propagates a write made while the initial load is still in flight", async () => {
+    const writer = newApp();
+    const docRef = await createDocument(writer);
+
+    // Subscribing starts the load; writing immediately lands in the window before the server's
+    // first revision arrives, where updates used to be dropped with only a log line.
+    const unsubscribe = writer.state.onStateChange(docRef, () => {});
+    await writeThing(writer, docRef, "thing-2", { counter: 2, label: "during-load" });
+    await writer.state.waitForDataLoad(docRef);
+
+    const seen = await readFromSecondClient(docRef.id, "thing-2");
+    unsubscribe();
+
+    expect(seen).toMatchObject({ counter: 2, label: "during-load" });
+  }, TEST_TIMEOUT_MS);
+
+  it("keeps both a pre-subscription and a post-load write visible to a peer", async () => {
+    const writer = newApp();
+    const docRef = await createDocument(writer);
+
+    // The full reported sequence. The second write was also invisible to peers, because it
+    // referenced struct ids from the unpublished first one.
+    await writeThing(writer, docRef, "thing-1", { counter: 1, label: "before-subscribe" });
+    const unsubscribe = writer.state.onStateChange(docRef, () => {});
+    await writer.state.waitForDataLoad(docRef);
+    await writeThing(writer, docRef, "thing-2", { counter: 2, label: "after-load" });
+
+    const reader = newApp();
+    const readerRef = reader.state.createDocRef(docRef.id, TestSchema);
+    const readerUnsubscribe = reader.state.onStateChange(readerRef, () => {});
+    await reader.state.waitForDataLoad(readerRef);
+
+    const both = await waitFor(async () => {
+      const first = await readThing(reader, readerRef, "thing-1");
+      const second = await readThing(reader, readerRef, "thing-2");
+      return first != null && second != null ? { first, second } : undefined;
+    });
+
+    readerUnsubscribe();
+    unsubscribe();
+
+    expect(both?.first).toMatchObject({ label: "before-subscribe" });
+    expect(both?.second).toMatchObject({ label: "after-load" });
+  }, TEST_TIMEOUT_MS);
+
+  it("reports the data channel as connected once sync is established", async () => {
+    const app = newApp();
+    const docRef = await createDocument(app);
+
+    const unsubscribe = app.state.onStateChange(docRef, () => {});
+    await app.state.waitForDataLoad(docRef);
+
+    const status = app.state.getDocumentStatus(docRef);
+    unsubscribe();
+
+    // Read `disconnected` here permanently before the liveness fix, while data synced fine.
+    expect(status.data.load).toBe(DocumentLoadStatus.LOADED);
+    expect(status.data.live).toBe(DocumentLiveStatus.CONNECTED);
+    expect(status.metadata.live).toBe(DocumentLiveStatus.CONNECTED);
+  }, TEST_TIMEOUT_MS);
+
+  it("rejects waitForMetadataLoad when nothing will start a load", async () => {
+    const app = newApp();
+    const docRef = await createDocument(app);
+    const detachedRef = app.state.createDocRef(docRef.id, TestSchema);
+
+    // Hung forever before the guard. Uses a real ref so the failure is the guard, not a bad id.
+    const unsubscribe = app.state.onStateChange(detachedRef, () => {});
+    unsubscribe();
+
+    await expect(app.state.waitForMetadataLoad(detachedRef)).rejects.toThrow(
+      /no metadata subscription is registered|Metadata load/,
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it("delivers a live update from one client to another", async () => {
+    const writer = newApp();
+    const docRef = await createDocument(writer);
+    const writerUnsubscribe = writer.state.onStateChange(docRef, () => {});
+    await writer.state.waitForDataLoad(docRef);
+
+    const reader = newApp();
+    const readerRef = reader.state.createDocRef(docRef.id, TestSchema);
+    const readerUnsubscribe = reader.state.onStateChange(readerRef, () => {});
+    await reader.state.waitForDataLoad(readerRef);
+
+    await writeThing(writer, docRef, "live-1", { counter: 42, label: "live" });
+
+    const seen = await waitFor(() => readThing(reader, readerRef, "live-1"));
+
+    readerUnsubscribe();
+    writerUnsubscribe();
+
+    expect(seen).toMatchObject({ counter: 42, label: "live" });
+  }, TEST_TIMEOUT_MS);
+});

--- a/packages/app/src/__tests__/testEnv.ts
+++ b/packages/app/src/__tests__/testEnv.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Settings a live-stack integration run needs. Absent when the repo has no `.env.local`, which is
+ * the normal case: integration tests skip rather than fail so a checkout without stack credentials
+ * still passes.
+ */
+export interface FoundryTestEnv {
+  readonly baseUrl: string;
+  readonly documentTypeName: string;
+  readonly ontologyRid: string;
+  readonly parentFolderRid: string | undefined;
+  readonly token: string;
+}
+
+/**
+ * Reads `.env.local` from the repo root. Written by hand rather than pulled from a dotenv
+ * dependency: this is the only consumer, and the file is a flat `KEY=value` list.
+ *
+ * The `VITE_` prefix is kept because the same file drives the browser harness these tests were
+ * derived from, so one file serves both.
+ */
+export function getFoundryTestEnv(): FoundryTestEnv | undefined {
+  const values = { ...readEnvFile(), ...process.env };
+
+  const baseUrl = values.VITE_FOUNDRY_API_URL;
+  const documentTypeName = values.VITE_PACK_DOCUMENT_TYPE_NAME;
+  const ontologyRid = values.VITE_FOUNDRY_ONTOLOGY_RID;
+  const token = values.VITE_DEV_FOUNDRY_TOKEN;
+
+  if (!baseUrl || !documentTypeName || !ontologyRid || !token) {
+    return undefined;
+  }
+
+  return {
+    baseUrl,
+    documentTypeName,
+    ontologyRid,
+    parentFolderRid: values.VITE_PACK_PARENT_FOLDER_RID || undefined,
+    token,
+  };
+}
+
+function readEnvFile(): Record<string, string> {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../../..");
+
+  let contents: string;
+  try {
+    contents = readFileSync(join(repoRoot, ".env.local"), "utf8");
+  } catch {
+    return {};
+  }
+
+  const values: Record<string, string> = {};
+  for (const line of contents.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      continue;
+    }
+    const separator = trimmed.indexOf("=");
+    if (separator === -1) {
+      continue;
+    }
+    values[trimmed.slice(0, separator)] = trimmed.slice(separator + 1).replace(/^["']|["']$/g, "");
+  }
+  return values;
+}

--- a/packages/state/demo/src/DemoDocumentService.ts
+++ b/packages/state/demo/src/DemoDocumentService.ts
@@ -367,6 +367,7 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
       return;
     }
     this.updateMetadataStatus(internalDoc, docRef, {
+      live: DocumentLiveStatus.CONNECTING,
       load: DocumentLoadStatus.LOADING,
     });
 
@@ -376,6 +377,7 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
       if (metadata == null) {
         this.updateMetadataStatus(internalDoc, docRef, {
           error: toUnknownChannelError(new Error("Document not found")),
+          live: DocumentLiveStatus.ERROR,
           load: DocumentLoadStatus.ERROR,
         });
         return;
@@ -391,11 +393,13 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
       });
 
       this.updateMetadataStatus(internalDoc, docRef, {
+        live: DocumentLiveStatus.CONNECTED,
         load: DocumentLoadStatus.LOADED,
       });
     }).catch((error: unknown) => {
       this.updateMetadataStatus(internalDoc, docRef, {
         error: toUnknownChannelError(error),
+        live: DocumentLiveStatus.ERROR,
         load: DocumentLoadStatus.ERROR,
       });
     });
@@ -455,9 +459,14 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
   }
 
   protected onMetadataSubscriptionClosed(
-    _internalDoc: DemoInternalDoc,
-    _docRef: DocumentRef,
+    internalDoc: DemoInternalDoc,
+    docRef: DocumentRef,
   ): void {
+    if (internalDoc.metadataStatus.live !== DocumentLiveStatus.DISCONNECTED) {
+      this.updateMetadataStatus(internalDoc, docRef, {
+        live: DocumentLiveStatus.DISCONNECTED,
+      });
+    }
   }
 
   protected onDataSubscriptionClosed(

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -109,6 +109,19 @@ export interface SyncSession {
   readonly documentId: DocumentId;
 }
 
+/**
+ * A local Yjs update captured for publishing. Kept unresolved rather than as a finished
+ * `DocumentPublishMessage` so the schema version is decided when it is sent, not when it is made.
+ */
+interface PendingPublish {
+  readonly description?: DocumentPublishMessage["description"];
+  /** Resolves the document's operational version at publish time; absent for callers without one. */
+  readonly getDocumentSchemaOperationalVersion?: () => number;
+  /** Version stamped on the originating transaction, when it carried one. */
+  readonly transactionSchemaVersion?: number;
+  readonly update: Uint8Array;
+}
+
 interface SyncSessionInternal extends SyncSession {
   documentSubscriptionId?: SubscriptionId;
   lastRevisionId?: number;
@@ -123,7 +136,13 @@ interface SyncSessionInternal extends SyncSession {
    * yet — a publish has to declare the revision it builds on — so they are held here and flushed in
    * order once the initial load establishes `lastRevisionId`.
    */
-  pendingPublishes: DocumentPublishMessage[];
+  pendingPublishes: PendingPublish[];
+  /**
+   * Identifies the current run of sync. Async callbacks compare against it to tell whether the run
+   * that started them is still the current one. The update handler cannot serve as that token: it
+   * outlives sync so local writes are still captured while sync is stopped.
+   */
+  syncToken?: object;
   yDoc?: y.Doc;
 }
 
@@ -132,6 +151,18 @@ interface SyncSessionInternal extends SyncSession {
  * our PACK Foundry backend's cometd service.
  */
 export interface FoundryEventService {
+  /**
+   * Begin capturing local Yjs updates for a document before any sync session exists, so writes
+   * made before the first data subscription opens are held rather than lost. Safe to call more
+   * than once for the same document.
+   */
+  beginDocumentCapture(
+    documentId: DocumentId,
+    yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    getDocumentSchemaOperationalVersion?: () => number,
+  ): void;
+
   disposeDocument(documentId: DocumentId): void;
 
   publishCustomPresence(
@@ -210,22 +241,52 @@ class FoundryEventServiceImpl implements FoundryEventService {
     return session;
   }
 
-  startDocumentSync(
+  beginDocumentCapture(
     documentId: DocumentId,
     yDoc: y.Doc,
     clientSupportedVersionRange: ClientSupportedVersionRange,
-    onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
     getDocumentSchemaOperationalVersion?: () => number,
-  ): SyncSession {
-    const session = this.getOrCreateSession(documentId);
+  ): void {
+    this.captureLocalUpdates(
+      documentId,
+      yDoc,
+      clientSupportedVersionRange,
+      getDocumentSchemaOperationalVersion,
+    );
+  }
 
-    if (
-      session.localYDocUpdateHandler != null
-      || session.documentSubscriptionId != null
-    ) {
-      throw new Error(`Document data sync already active for document ${documentId}`);
+  /**
+   * Start listening for local Yjs updates so none are missed, whether or not sync is running.
+   * Updates are held until a sync session establishes the revision to publish them against.
+   *
+   * Idempotent per Y.Doc: re-attaching for the same Y.Doc swaps in a handler bound to the latest
+   * arguments, leaving exactly one listener attached.
+   */
+  private captureLocalUpdates(
+    documentId: DocumentId,
+    yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    getDocumentSchemaOperationalVersion?: () => number,
+  ): (update: Uint8Array, origin: unknown, doc: y.Doc, transaction: y.Transaction) => void {
+    const session = this.getOrCreateSession(documentId);
+    const isReplacingYDoc = session.yDoc != null && session.yDoc !== yDoc;
+
+    if (session.localYDocUpdateHandler != null) {
+      session.yDoc?.off("update", session.localYDocUpdateHandler);
     }
-    session.yDoc = yDoc;
+
+    if (isReplacingYDoc) {
+      // Held updates describe operations in the previous Y.Doc. Publishing them against a document
+      // that has been replaced would inject state the local document no longer has, so they are
+      // dropped — loudly, because dropping writes is exactly what this queue exists to prevent.
+      if (session.pendingPublishes.length > 0) {
+        this.logger.warn("Discarding local document updates captured for a replaced Y.Doc", {
+          docId: documentId,
+          discardedCount: session.pendingPublishes.length,
+        });
+        session.pendingPublishes = [];
+      }
+    }
 
     const localYDocUpdateHandler = (
       update: Uint8Array,
@@ -239,29 +300,73 @@ class FoundryEventServiceImpl implements FoundryEventService {
 
       this.publishOrQueueUpdate(session, clientSupportedVersionRange, update, {
         description: isEditDescription(origin) ? createDocumentEditDescription(origin) : undefined,
-        documentUpdateSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction)
-          ?? getDocumentSchemaOperationalVersion?.()
-          ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
+        getDocumentSchemaOperationalVersion,
+        // Absent when the transaction carried no version. Left unresolved here so a queued update
+        // picks up the operational version at publish time: capture can happen before metadata
+        // loads, when the fallback would understate the version the content actually needs.
+        transactionSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction),
       });
     };
 
+    session.yDoc = yDoc;
     session.localYDocUpdateHandler = localYDocUpdateHandler;
     yDoc.on("update", localYDocUpdateHandler);
 
-    onStatusChange({
-      live: DocumentLiveStatus.CONNECTING,
-      load: DocumentLoadStatus.LOADING,
-    });
+    return localYDocUpdateHandler;
+  }
+
+  startDocumentSync(
+    documentId: DocumentId,
+    yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
+    getDocumentSchemaOperationalVersion?: () => number,
+  ): SyncSession {
+    const session = this.getOrCreateSession(documentId);
+
+    if (session.syncToken != null) {
+      throw new Error(`Document data sync already active for document ${documentId}`);
+    }
+    const syncToken = {};
+    session.syncToken = syncToken;
+
+    try {
+      // Capture normally began at document creation. Re-attaching here covers a caller that starts
+      // sync without having begun capture, and a document whose Y.Doc was replaced.
+      this.captureLocalUpdates(
+        documentId,
+        yDoc,
+        clientSupportedVersionRange,
+        getDocumentSchemaOperationalVersion,
+      );
+
+      // Fans out to caller-supplied status subscribers, which are not guarded against throwing.
+      onStatusChange({
+        live: DocumentLiveStatus.CONNECTING,
+        load: DocumentLoadStatus.LOADING,
+      });
+    } catch (e) {
+      // Without this the token stays set and every later start is rejected as already active,
+      // wedging the document for the lifetime of the session.
+      session.syncToken = undefined;
+      throw e;
+    }
 
     const channelId = getDocumentUpdatesChannelId(documentId);
 
     this.eventService.subscribe(
       channelId,
       (message: DocumentUpdateMessage) => {
-        if (session.localYDocUpdateHandler !== localYDocUpdateHandler) {
+        if (session.syncToken !== syncToken) {
           return;
         }
-        this.handleDocumentUpdateMessage(session, message, yDoc, onStatusChange);
+        this.handleDocumentUpdateMessage(
+          session,
+          message,
+          yDoc,
+          clientSupportedVersionRange,
+          onStatusChange,
+        );
       },
       () => ({
         clientId: session.clientId,
@@ -269,7 +374,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         lastRevisionId: session.lastRevisionId?.toString(),
       } satisfies DocumentUpdateSubscriptionRequest),
     ).then(subscriptionId => {
-      if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
+      if (session.syncToken === syncToken) {
         session.documentSubscriptionId = subscriptionId;
         // The channel is subscribed, so the data channel is live. Reported separately from `load`,
         // which stays LOADING until the first update arrives. Matches how the activity and presence
@@ -281,7 +386,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         this.eventService.unsubscribe(subscriptionId);
       }
     }).catch((e: unknown) => {
-      if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
+      if (session.syncToken === syncToken) {
         onStatusChange({
           error: toUnknownChannelError(
             new Error("Failed to setup document data subscription", { cause: e }),
@@ -470,27 +575,15 @@ class FoundryEventServiceImpl implements FoundryEventService {
       return;
     }
 
-    if (internalSession.localYDocUpdateHandler != null) {
-      internalSession.yDoc?.off("update", internalSession.localYDocUpdateHandler);
-      internalSession.localYDocUpdateHandler = undefined;
-    }
-
     if (internalSession.documentSubscriptionId) {
       this.eventService.unsubscribe(internalSession.documentSubscriptionId);
       internalSession.documentSubscriptionId = undefined;
     }
+    internalSession.syncToken = undefined;
     internalSession.lastRevisionId = undefined;
-    // Sync stopped before the initial load established a revision, so these were never publishable
-    // and there is nothing to send them against now. They stay in the local Y.Doc but the server
-    // never learns of them — the same loss this queue exists to prevent, so say so out loud.
-    if (internalSession.pendingPublishes.length > 0) {
-      this.logger.warn("Discarding local document updates held for a load that never completed", {
-        docId: internalSession.documentId,
-        discardedCount: internalSession.pendingPublishes.length,
-      });
-      internalSession.pendingPublishes = [];
-    }
-    internalSession.yDoc = undefined;
+    // The update handler and any held updates deliberately survive: the document is still open and
+    // writable, so writes made while sync is stopped are captured and published when sync resumes.
+    // Only disposeDocument tears capture down.
   }
 
   unsubscribe(subscriptionId: SubscriptionId): void {
@@ -504,6 +597,24 @@ class FoundryEventServiceImpl implements FoundryEventService {
       return;
     }
     this.stopDocumentSync(session);
+
+    if (session.localYDocUpdateHandler != null) {
+      session.yDoc?.off("update", session.localYDocUpdateHandler);
+      session.localYDocUpdateHandler = undefined;
+    }
+    session.yDoc = undefined;
+
+    // The document is going away, so held updates have no future sync session to publish them.
+    // They are lost from the server's perspective — the loss this queue exists to prevent, so it
+    // is stated rather than left silent.
+    if (session.pendingPublishes.length > 0) {
+      this.logger.warn("Discarding local document updates that were never published", {
+        docId: session.documentId,
+        discardedCount: session.pendingPublishes.length,
+      });
+      session.pendingPublishes = [];
+    }
+
     this.sessions.delete(sessionId);
   }
 
@@ -516,29 +627,16 @@ class FoundryEventServiceImpl implements FoundryEventService {
     session: SyncSessionInternal,
     clientSupportedVersionRange: ClientSupportedVersionRange,
     update: Uint8Array,
-    options: {
-      description?: DocumentPublishMessage["description"];
-      documentUpdateSchemaVersion: number;
-    },
+    options: Omit<PendingPublish, "update">,
   ): void {
-    const publishMessage: DocumentPublishMessage = {
-      clientId: session.clientId,
-      clientSupportedVersionRange,
-      description: options.description,
-      documentUpdateSchemaVersion: options.documentUpdateSchemaVersion,
-      editId: generateId(),
-      yjsUpdate: {
-        data: Base64.fromUint8Array(update),
-      },
-    };
-
     if (session.lastRevisionId == null) {
-      session.pendingPublishes.push(publishMessage);
+      session.pendingPublishes.push({ ...options, update });
       const pendingCount = session.pendingPublishes.length;
       // Nothing bounds the queue: an initial load that never completes grows it for as long as
-      // edits keep arriving. Warn on crossing the threshold rather than dropping edits, since
-      // dropping is the failure this queue exists to prevent.
-      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
+      // edits keep arriving. Warn periodically rather than dropping edits, since dropping is the
+      // failure this queue exists to prevent — and warn again as it keeps growing, so a stalled
+      // load does not go quiet after one message.
+      if (pendingCount % PENDING_PUBLISH_WARN_THRESHOLD === 0) {
         this.logger.warn("Local document updates are piling up while the initial load completes", {
           docId: session.documentId,
           pendingCount,
@@ -552,13 +650,30 @@ class FoundryEventServiceImpl implements FoundryEventService {
       return;
     }
 
-    this.publishUpdate(session, publishMessage);
+    this.publishUpdate(session, clientSupportedVersionRange, { ...options, update });
   }
 
   private publishUpdate(
     session: SyncSessionInternal,
-    publishMessage: DocumentPublishMessage,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    pending: PendingPublish,
   ): void {
+    const publishMessage: DocumentPublishMessage = {
+      clientId: session.clientId,
+      clientSupportedVersionRange,
+      description: pending.description,
+      // Resolved here rather than at capture: an update held through the initial load was captured
+      // before metadata was available, when the operational version would still be a schema
+      // fallback that can understate what the content needs.
+      documentUpdateSchemaVersion: pending.transactionSchemaVersion
+        ?? pending.getDocumentSchemaOperationalVersion?.()
+        ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
+      editId: generateId(),
+      yjsUpdate: {
+        data: Base64.fromUint8Array(pending.update),
+      },
+    };
+
     void this.eventService.publish(
       getDocumentPublishChannelId(session.documentId),
       publishMessage,
@@ -570,7 +685,10 @@ class FoundryEventServiceImpl implements FoundryEventService {
   }
 
   /** Flush updates held while the revision was unknown, preserving the order they were made in. */
-  private flushPendingPublishes(session: SyncSessionInternal): void {
+  private flushPendingPublishes(
+    session: SyncSessionInternal,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+  ): void {
     if (session.pendingPublishes.length === 0) {
       return;
     }
@@ -582,8 +700,8 @@ class FoundryEventServiceImpl implements FoundryEventService {
       pendingCount: pending.length,
     });
 
-    for (const publishMessage of pending) {
-      this.publishUpdate(session, publishMessage);
+    for (const pendingPublish of pending) {
+      this.publishUpdate(session, clientSupportedVersionRange, pendingPublish);
     }
   }
 
@@ -591,6 +709,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     session: SyncSessionInternal,
     message: DocumentUpdateMessage,
     yDoc: y.Doc,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
     onStatusChange: (status: Partial<DocumentSyncStatus>) => void,
   ): void {
     switch (message.type) {
@@ -674,7 +793,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         session.lastRevisionId = Number(revisionId);
 
         // The revision is known, so anything held during the load can go out now.
-        this.flushPendingPublishes(session);
+        this.flushPendingPublishes(session, clientSupportedVersionRange);
 
         onStatusChange({
           load: DocumentLoadStatus.LOADED,

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -39,6 +39,7 @@ import {
   toUnknownChannelError,
 } from "@palantir/pack.document-schema.model-types";
 import {
+  DocumentLiveStatus,
   DocumentLoadStatus,
   type DocumentSyncStatus,
   getDocumentUpdateSchemaVersionFromTransaction,
@@ -267,6 +268,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
     yDoc.on("update", localYDocUpdateHandler);
 
     onStatusChange({
+      live: DocumentLiveStatus.CONNECTING,
       load: DocumentLoadStatus.LOADING,
     });
 
@@ -288,6 +290,12 @@ class FoundryEventServiceImpl implements FoundryEventService {
     ).then(subscriptionId => {
       if (session.localYDocUpdateHandler === localYDocUpdateHandler) {
         session.documentSubscriptionId = subscriptionId;
+        // The channel is subscribed, so the data channel is live. Reported separately from `load`,
+        // which stays LOADING until the first update arrives. Matches how the activity and presence
+        // channels report liveness on subscription establishment.
+        onStatusChange({
+          live: DocumentLiveStatus.CONNECTED,
+        });
       } else {
         this.eventService.unsubscribe(subscriptionId);
       }
@@ -297,6 +305,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
           error: toUnknownChannelError(
             new Error("Failed to setup document data subscription", { cause: e }),
           ),
+          live: DocumentLiveStatus.ERROR,
           load: DocumentLoadStatus.ERROR,
         });
       } else {
@@ -522,8 +531,12 @@ class FoundryEventServiceImpl implements FoundryEventService {
           errorInstanceId,
           args,
         });
+        // A channel-level error from the server means the subscription itself is unusable, so
+        // liveness fails with the load. Data-integrity failures below (revision gap, update that
+        // will not apply) leave `live` alone: the connection is still up, only the state is stale.
         onStatusChange({
           error: toChannelError(code, errorInstanceId),
+          live: DocumentLiveStatus.ERROR,
           load: DocumentLoadStatus.ERROR,
         });
         break;

--- a/packages/state/foundry-event/src/FoundryEventService.ts
+++ b/packages/state/foundry-event/src/FoundryEventService.ts
@@ -71,6 +71,9 @@ export interface PresencePublishOptions {
 
 const UPDATE_ORIGIN_REMOTE = "remote" as const;
 
+/** Queue depth at which held updates stop looking like a normal load and start looking stuck. */
+const PENDING_PUBLISH_WARN_THRESHOLD = 100;
+
 const getDocumentUpdatesChannelId = (
   documentId: DocumentId,
 ): TypedReceiveChannelId<DocumentUpdateMessage> =>
@@ -115,6 +118,12 @@ interface SyncSessionInternal extends SyncSession {
     doc: y.Doc,
     transaction: y.Transaction,
   ) => void;
+  /**
+   * Local updates produced before the server's first revision is known. They cannot be published
+   * yet — a publish has to declare the revision it builds on — so they are held here and flushed in
+   * order once the initial load establishes `lastRevisionId`.
+   */
+  pendingPublishes: DocumentPublishMessage[];
   yDoc?: y.Doc;
 }
 
@@ -192,6 +201,7 @@ class FoundryEventServiceImpl implements FoundryEventService {
         documentSubscriptionId: undefined,
         lastRevisionId: undefined,
         localYDocUpdateHandler: undefined,
+        pendingPublishes: [],
         yDoc: undefined,
       };
       this.sessions.set(sessionId, session);
@@ -227,40 +237,11 @@ class FoundryEventServiceImpl implements FoundryEventService {
         return;
       }
 
-      const lastRevisionId = session.lastRevisionId;
-      if (lastRevisionId == null) {
-        this.logger.error(
-          "Cannot publish document update before initial load is complete. The local state will remain inconsistent.",
-          { docId: documentId },
-        );
-        return;
-      }
-
-      const publishChannelId = getDocumentPublishChannelId(documentId);
-      const editId = generateId();
-      const description = isEditDescription(origin)
-        ? createDocumentEditDescription(origin)
-        : undefined;
-      const documentUpdateSchemaVersion = getDocumentUpdateSchemaVersionFromTransaction(transaction)
-        ?? getDocumentSchemaOperationalVersion?.()
-        ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange);
-      const publishMessage: DocumentPublishMessage = {
-        clientId: session.clientId,
-        clientSupportedVersionRange,
-        description,
-        documentUpdateSchemaVersion,
-        editId,
-        yjsUpdate: {
-          data: Base64.fromUint8Array(update),
-        },
-      };
-      void this.eventService.publish(
-        publishChannelId,
-        publishMessage,
-      ).catch((error: unknown) => {
-        this.logger.error("Failed to publish document update", error, {
-          docId: documentId,
-        });
+      this.publishOrQueueUpdate(session, clientSupportedVersionRange, update, {
+        description: isEditDescription(origin) ? createDocumentEditDescription(origin) : undefined,
+        documentUpdateSchemaVersion: getDocumentUpdateSchemaVersionFromTransaction(transaction)
+          ?? getDocumentSchemaOperationalVersion?.()
+          ?? getFallbackDocumentUpdateSchemaVersion(clientSupportedVersionRange),
       });
     };
 
@@ -499,6 +480,16 @@ class FoundryEventServiceImpl implements FoundryEventService {
       internalSession.documentSubscriptionId = undefined;
     }
     internalSession.lastRevisionId = undefined;
+    // Sync stopped before the initial load established a revision, so these were never publishable
+    // and there is nothing to send them against now. They stay in the local Y.Doc but the server
+    // never learns of them — the same loss this queue exists to prevent, so say so out loud.
+    if (internalSession.pendingPublishes.length > 0) {
+      this.logger.warn("Discarding local document updates held for a load that never completed", {
+        docId: internalSession.documentId,
+        discardedCount: internalSession.pendingPublishes.length,
+      });
+      internalSession.pendingPublishes = [];
+    }
     internalSession.yDoc = undefined;
   }
 
@@ -514,6 +505,86 @@ class FoundryEventServiceImpl implements FoundryEventService {
     }
     this.stopDocumentSync(session);
     this.sessions.delete(sessionId);
+  }
+
+  /**
+   * Publish a local Yjs update, or hold it until the initial load establishes the revision it
+   * builds on. Updates were previously dropped with only a log line in that window, which lost
+   * them silently.
+   */
+  private publishOrQueueUpdate(
+    session: SyncSessionInternal,
+    clientSupportedVersionRange: ClientSupportedVersionRange,
+    update: Uint8Array,
+    options: {
+      description?: DocumentPublishMessage["description"];
+      documentUpdateSchemaVersion: number;
+    },
+  ): void {
+    const publishMessage: DocumentPublishMessage = {
+      clientId: session.clientId,
+      clientSupportedVersionRange,
+      description: options.description,
+      documentUpdateSchemaVersion: options.documentUpdateSchemaVersion,
+      editId: generateId(),
+      yjsUpdate: {
+        data: Base64.fromUint8Array(update),
+      },
+    };
+
+    if (session.lastRevisionId == null) {
+      session.pendingPublishes.push(publishMessage);
+      const pendingCount = session.pendingPublishes.length;
+      // Nothing bounds the queue: an initial load that never completes grows it for as long as
+      // edits keep arriving. Warn on crossing the threshold rather than dropping edits, since
+      // dropping is the failure this queue exists to prevent.
+      if (pendingCount === PENDING_PUBLISH_WARN_THRESHOLD) {
+        this.logger.warn("Local document updates are piling up while the initial load completes", {
+          docId: session.documentId,
+          pendingCount,
+        });
+      } else {
+        this.logger.debug("Holding local document update until the initial load completes", {
+          docId: session.documentId,
+          pendingCount,
+        });
+      }
+      return;
+    }
+
+    this.publishUpdate(session, publishMessage);
+  }
+
+  private publishUpdate(
+    session: SyncSessionInternal,
+    publishMessage: DocumentPublishMessage,
+  ): void {
+    void this.eventService.publish(
+      getDocumentPublishChannelId(session.documentId),
+      publishMessage,
+    ).catch((error: unknown) => {
+      this.logger.error("Failed to publish document update", error, {
+        docId: session.documentId,
+      });
+    });
+  }
+
+  /** Flush updates held while the revision was unknown, preserving the order they were made in. */
+  private flushPendingPublishes(session: SyncSessionInternal): void {
+    if (session.pendingPublishes.length === 0) {
+      return;
+    }
+
+    const pending = session.pendingPublishes;
+    session.pendingPublishes = [];
+    this.logger.debug("Publishing local document updates held during the initial load", {
+      docId: session.documentId,
+      pendingCount: pending.length,
+    });
+
+    for (const publishMessage of pending) {
+      this.publishUpdate(session, publishMessage);
+    }
   }
 
   private handleDocumentUpdateMessage(
@@ -601,6 +672,9 @@ class FoundryEventServiceImpl implements FoundryEventService {
           }
         }
         session.lastRevisionId = Number(revisionId);
+
+        // The revision is known, so anything held during the load can go out now.
+        this.flushPendingPublishes(session);
 
         onStatusChange({
           load: DocumentLoadStatus.LOADED,

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -19,6 +19,8 @@ import type { PackAppInternal } from "@palantir/pack.core";
 import type { DocumentId } from "@palantir/pack.document-schema.model-types";
 import {
   addDocumentUpdateSchemaVersionToTransaction,
+  DocumentLiveStatus,
+  DocumentLoadStatus,
   type DocumentSyncStatus,
 } from "@palantir/pack.state.core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -390,5 +392,137 @@ describe("FoundryEventService", () => {
     );
 
     expect(secondSession.clientId).not.toBe(firstSession.clientId);
+  });
+
+  describe("data channel liveness", () => {
+    function collectStatus(): {
+      statusUpdates: Array<Partial<DocumentSyncStatus>>;
+      onStatusChange: (status: Partial<DocumentSyncStatus>) => void;
+    } {
+      const statusUpdates: Array<Partial<DocumentSyncStatus>> = [];
+      return { statusUpdates, onStatusChange: status => statusUpdates.push(status) };
+    }
+
+    /** Latest reported value of a single status field, since updates are partial. */
+    function latest<K extends keyof DocumentSyncStatus>(
+      statusUpdates: Array<Partial<DocumentSyncStatus>>,
+      field: K,
+    ): DocumentSyncStatus[K] | undefined {
+      return statusUpdates.filter(s => s[field] !== undefined).at(-1)?.[field];
+    }
+
+    it("reports CONNECTING while the subscription is being established", () => {
+      mocks.eventService.subscribe.mockReturnValue(new Promise(() => {}));
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+
+      expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.CONNECTING);
+      expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.LOADING);
+    });
+
+    it("reports CONNECTED once the subscription is established", async () => {
+      mocks.eventService.subscribe.mockResolvedValue("document-sub" as SubscriptionId);
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+
+      expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.CONNECTED);
+      // Liveness is independent of the load: no update has arrived yet.
+      expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.LOADING);
+    });
+
+    it("stays CONNECTED after the document finishes loading", async () => {
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("document-sub" as SubscriptionId);
+      });
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+      updateCallback?.({
+        baseRevisionId: "0",
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId: "1",
+        type: "update",
+      });
+
+      // The reported regression: data synced correctly while live read DISCONNECTED forever.
+      expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.LOADED);
+      expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.CONNECTED);
+    });
+
+    it("reports ERROR when the subscription cannot be established", async () => {
+      mocks.eventService.subscribe.mockRejectedValue(new Error("no socket"));
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.ERROR);
+      expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.ERROR);
+    });
+
+    it("leaves liveness alone when a revision gap makes local state stale", async () => {
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("document-sub" as SubscriptionId);
+      });
+      const service = createFoundryEventService(app);
+      const { statusUpdates, onStatusChange } = collectStatus();
+
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        new Y.Doc(),
+        { maxVersion: 1, minVersion: 1 },
+        onStatusChange,
+      );
+      await Promise.resolve();
+      const update = (baseRevisionId: string, revisionId: string): DocumentUpdateMessage => ({
+        baseRevisionId,
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId,
+        type: "update",
+      });
+      updateCallback?.(update("0", "1"));
+      // Skips revision 2, so the local state is stale even though the socket is fine.
+      updateCallback?.(update("7", "8"));
+
+      expect(latest(statusUpdates, "load")).toBe(DocumentLoadStatus.ERROR);
+      expect(latest(statusUpdates, "live")).toBe(DocumentLiveStatus.CONNECTED);
+    });
   });
 });

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -23,6 +23,7 @@ import {
   DocumentLoadStatus,
   type DocumentSyncStatus,
 } from "@palantir/pack.state.core";
+import { Base64 } from "js-base64";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { createFoundryEventService } from "../FoundryEventService.js";
@@ -392,6 +393,116 @@ describe("FoundryEventService", () => {
     );
 
     expect(secondSession.clientId).not.toBe(firstSession.clientId);
+  });
+
+  describe("updates made before the initial revision is known", () => {
+    /** Server acknowledgement that establishes lastRevisionId and completes the initial load. */
+    function initialRevision(): DocumentUpdateMessage {
+      return {
+        baseRevisionId: "0",
+        clientId: "server",
+        clientSupportedVersionRange: { maxVersion: 1, minVersion: 1 },
+        editIds: [],
+        revisionId: "1",
+        type: "update",
+      };
+    }
+
+    /** Rebuild what a peer would see from every update this client published, in order. */
+    function applyPublishedUpdates(): Y.Doc {
+      const peerDoc = new Y.Doc();
+      for (const call of mocks.eventService.publish.mock.calls) {
+        const message = call[1] as PublishedDocumentUpdate;
+        const data = message.yjsUpdate?.data;
+        if (typeof data === "string") {
+          Y.applyUpdate(peerDoc, Base64.toUint8Array(data));
+        }
+      }
+      return peerDoc;
+    }
+
+    function startSyncCapturingServer(yDoc: Y.Doc): {
+      service: ReturnType<typeof createFoundryEventService>;
+      deliverInitialRevision: () => void;
+    } {
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+
+      const service = createFoundryEventService(app);
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+
+      return { service, deliverInitialRevision: () => updateCallback?.(initialRevision()) };
+    }
+
+    it("holds a write made during the load instead of dropping it", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      // The handler is attached but lastRevisionId is still unknown. This previously logged
+      // "Cannot publish document update before initial load is complete" and discarded the update.
+      yDoc.getMap("Shape").set("shape-1", "during-load");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(1);
+      expect(applyPublishedUpdates().getMap("Shape").get("shape-1")).toBe("during-load");
+    });
+
+    it("preserves the order of writes held across the load", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("first", "during-load");
+      yDoc.getMap("Shape").set("second", "also-during-load");
+      deliverInitialRevision();
+      yDoc.getMap("Shape").set("third", "after-load");
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(3);
+      const peerShapes = applyPublishedUpdates().getMap("Shape");
+      expect(peerShapes.get("first")).toBe("during-load");
+      expect(peerShapes.get("second")).toBe("also-during-load");
+      expect(peerShapes.get("third")).toBe("after-load");
+    });
+
+    it("publishes nothing when no local write was made during the load", async () => {
+      const yDoc = new Y.Doc();
+      const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      deliverInitialRevision();
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+    });
+
+    it("warns rather than staying silent when a load never completes", async () => {
+      const yDoc = new Y.Doc();
+      const { service } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("shape-1", "never-published");
+      logger.warn.mockClear();
+
+      // The load never established a revision, so the held update has nothing to publish against
+      // and is dropped. It must not be dropped quietly.
+      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Discarding local document updates"),
+        expect.objectContaining({ discardedCount: 1 }),
+      );
+    });
   });
 
   describe("data channel liveness", () => {

--- a/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
+++ b/packages/state/foundry-event/src/__tests__/FoundryEventService.test.ts
@@ -330,6 +330,11 @@ describe("FoundryEventService", () => {
 
     service.stopDocumentSync(session);
 
+    // Capture outlives sync so writes made while stopped are still held; only disposal detaches.
+    expect(activeOff).not.toHaveBeenCalled();
+
+    service.disposeDocument("doc-1" as DocumentId);
+
     expect(activeOff).toHaveBeenCalledWith("update", expect.any(Function));
     expect(rejectedOff).not.toHaveBeenCalled();
     expect(mocks.eventService.subscribe).toHaveBeenCalledTimes(1);
@@ -442,6 +447,34 @@ describe("FoundryEventService", () => {
       return { service, deliverInitialRevision: () => updateCallback?.(initialRevision()) };
     }
 
+    it("holds a write made before any sync session exists", async () => {
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+
+      // Capture begins when the document is created, well before a data subscription opens.
+      service.beginDocumentCapture("doc-1" as DocumentId, yDoc, { maxVersion: 1, minVersion: 1 });
+      yDoc.getMap("Shape").set("shape-1", "before-any-sync");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+      await Promise.resolve();
+      updateCallback?.(initialRevision());
+
+      // One update carrying the original transaction, not a full-state snapshot of the document.
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(1);
+      expect(applyPublishedUpdates().getMap("Shape").get("shape-1")).toBe("before-any-sync");
+    });
+
     it("holds a write made during the load instead of dropping it", async () => {
       const yDoc = new Y.Doc();
       const { deliverInitialRevision } = startSyncCapturingServer(yDoc);
@@ -485,7 +518,146 @@ describe("FoundryEventService", () => {
       expect(mocks.eventService.publish).not.toHaveBeenCalled();
     });
 
-    it("warns rather than staying silent when a load never completes", async () => {
+    it("keeps held updates across a stop and publishes them when sync resumes", async () => {
+      const yDoc = new Y.Doc();
+      const { service } = startSyncCapturingServer(yDoc);
+      await Promise.resolve();
+
+      yDoc.getMap("Shape").set("shape-1", "held-across-stop");
+      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+
+      // Stopping sync does not end the document, so the write must survive to the next session.
+      yDoc.getMap("Shape").set("shape-2", "written-while-stopped");
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+
+      let resumedCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        resumedCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-2" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+      await Promise.resolve();
+      resumedCallback?.(initialRevision());
+
+      expect(mocks.eventService.publish).toHaveBeenCalledTimes(2);
+      const peerShapes = applyPublishedUpdates().getMap("Shape");
+      expect(peerShapes.get("shape-1")).toBe("held-across-stop");
+      expect(peerShapes.get("shape-2")).toBe("written-while-stopped");
+    });
+
+    it("resolves the schema version when publishing, not when capturing", async () => {
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+
+      // Capture happens before metadata loads, when the operational version is still a fallback.
+      let operationalVersion = 1;
+      service.beginDocumentCapture(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 5, minVersion: 1 },
+        () => operationalVersion,
+      );
+      yDoc.getMap("Shape").set("shape-1", "captured-early");
+
+      // Metadata lands during the load and raises the operational version.
+      operationalVersion = 3;
+
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        yDoc,
+        { maxVersion: 5, minVersion: 1 },
+        () => {},
+        () => operationalVersion,
+      );
+      await Promise.resolve();
+      updateCallback?.(initialRevision());
+
+      const publishCall = mocks.eventService.publish.mock.calls[0] as
+        | [unknown, PublishedDocumentUpdate]
+        | undefined;
+      expect(publishCall?.[1].documentUpdateSchemaVersion).toBe(3);
+    });
+
+    it("does not wedge the document when starting sync throws", () => {
+      const yDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+      mocks.eventService.subscribe.mockResolvedValue("sub-1" as SubscriptionId);
+
+      const failingStatusCallback = () => {
+        throw new Error("subscriber blew up");
+      };
+
+      expect(() =>
+        service.startDocumentSync(
+          "doc-1" as DocumentId,
+          yDoc,
+          { maxVersion: 1, minVersion: 1 },
+          failingStatusCallback,
+        )
+      ).toThrow("subscriber blew up");
+
+      // The failed attempt must not leave the document permanently "already active".
+      expect(() =>
+        service.startDocumentSync(
+          "doc-1" as DocumentId,
+          yDoc,
+          { maxVersion: 1, minVersion: 1 },
+          () => {},
+        )
+      ).not.toThrow();
+    });
+
+    it("discards held updates loudly when the Y.Doc is replaced", async () => {
+      const originalYDoc = new Y.Doc();
+      const service = createFoundryEventService(app);
+      service.beginDocumentCapture("doc-1" as DocumentId, originalYDoc, {
+        maxVersion: 1,
+        minVersion: 1,
+      });
+      originalYDoc.getMap("Shape").set("shape-1", "belongs-to-old-doc");
+      logger.warn.mockClear();
+
+      // Held updates describe operations in a document that is being replaced, so publishing them
+      // against the replacement would inject state it does not have.
+      const replacementYDoc = new Y.Doc();
+      service.beginDocumentCapture("doc-1" as DocumentId, replacementYDoc, {
+        maxVersion: 1,
+        minVersion: 1,
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("replaced Y.Doc"),
+        expect.objectContaining({ discardedCount: 1 }),
+      );
+
+      let updateCallback: ((message: DocumentUpdateMessage) => void) | undefined;
+      mocks.eventService.subscribe.mockImplementation((_channel, callback) => {
+        updateCallback = callback as (message: DocumentUpdateMessage) => void;
+        return Promise.resolve("sub-1" as SubscriptionId);
+      });
+      service.startDocumentSync(
+        "doc-1" as DocumentId,
+        replacementYDoc,
+        { maxVersion: 1, minVersion: 1 },
+        () => {},
+      );
+      await Promise.resolve();
+      updateCallback?.(initialRevision());
+
+      expect(mocks.eventService.publish).not.toHaveBeenCalled();
+    });
+
+    it("warns rather than staying silent when a disposed document had unpublished writes", async () => {
       const yDoc = new Y.Doc();
       const { service } = startSyncCapturingServer(yDoc);
       await Promise.resolve();
@@ -493,9 +665,8 @@ describe("FoundryEventService", () => {
       yDoc.getMap("Shape").set("shape-1", "never-published");
       logger.warn.mockClear();
 
-      // The load never established a revision, so the held update has nothing to publish against
-      // and is dropped. It must not be dropped quietly.
-      service.stopDocumentSync({ clientId: "unused", documentId: "doc-1" as DocumentId });
+      // Disposal ends the document, so held updates have no future session to publish them.
+      service.disposeDocument("doc-1" as DocumentId);
 
       expect(mocks.eventService.publish).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -146,10 +146,22 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     ref: DocumentRef,
     metadata: DocumentMetadata | undefined,
   ): FoundryInternalDoc {
-    return {
+    const internalDoc: FoundryInternalDoc = {
       ...this.createBaseInternalDoc(ref, metadata),
       syncSession: undefined,
     };
+
+    // Data loads are demand-driven, but writes are not: callers may populate a document before
+    // opening a subscription. Capturing from creation means those writes are held for the first
+    // sync session rather than never being seen by a publish handler at all.
+    this.eventService.beginDocumentCapture(
+      ref.id,
+      internalDoc.yDoc,
+      getClientSupportedVersionRange(ref.schema),
+      () => this.getDocumentSchemaOperationalVersion(ref),
+    );
+
+    return internalDoc;
   }
 
   get hasMetadataSubscriptions(): boolean {

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -366,6 +366,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     internalDoc.metadataSubscriptionOpenToken = openToken;
 
     this.updateMetadataStatus(internalDoc, docRef, {
+      live: DocumentLiveStatus.CONNECTING,
       load: DocumentLoadStatus.LOADING,
     });
 
@@ -398,6 +399,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
           error: toUnknownChannelError(
             new Error("Failed to load document metadata", { cause: e }),
           ),
+          live: DocumentLiveStatus.ERROR,
           load: DocumentLoadStatus.ERROR,
         });
       });
@@ -420,6 +422,9 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
           return;
         }
         internalDoc.metadataSubscriptionId = subscriptionId;
+        this.updateMetadataStatus(internalDoc, docRef, {
+          live: DocumentLiveStatus.CONNECTED,
+        });
       })
       .catch((e: unknown) => {
         if (!this.isMetadataOpenGeneration(internalDoc, docRef, openToken)) {
@@ -434,6 +439,14 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         }
         this.logger.error("Failed to subscribe to metadata updates", e, {
           docId: docRef.id,
+        });
+        // `load` is deliberately omitted so it stays LOADED: the metadata itself was fetched over
+        // HTTP and is valid, only the live updates channel is dead — which is what `live` exists to
+        // express. `error` is still set so the failed liveness is explainable; omitting `load` also
+        // means the merge preserves it rather than clearing the error.
+        this.updateMetadataStatus(internalDoc, docRef, {
+          error: toUnknownChannelError(e),
+          live: DocumentLiveStatus.ERROR,
         });
       });
   }
@@ -565,7 +578,12 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     }
     if (internalDoc.metadataStatus.load === DocumentLoadStatus.LOADING) {
       this.updateMetadataStatus(internalDoc, docRef, {
+        live: DocumentLiveStatus.DISCONNECTED,
         load: DocumentLoadStatus.UNLOADED,
+      });
+    } else if (internalDoc.metadataStatus.live !== DocumentLiveStatus.DISCONNECTED) {
+      this.updateMetadataStatus(internalDoc, docRef, {
+        live: DocumentLiveStatus.DISCONNECTED,
       });
     }
   }

--- a/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryStatusTracking.test.ts
@@ -24,7 +24,12 @@ import { Documents } from "@osdk/foundry.pack";
 import type { PackAppInternal } from "@palantir/pack.core";
 import type { DocumentId, DocumentSchema } from "@palantir/pack.document-schema.model-types";
 import { ChannelErrorCode, Metadata } from "@palantir/pack.document-schema.model-types";
-import { createDocRef, DocumentLoadStatus, type DocumentStatus } from "@palantir/pack.state.core";
+import {
+  createDocRef,
+  DocumentLiveStatus,
+  DocumentLoadStatus,
+  type DocumentStatus,
+} from "@palantir/pack.state.core";
 import type {
   FoundryEventService,
   SubscriptionId,
@@ -1052,6 +1057,156 @@ describe("Foundry Document Status Tracking", () => {
       expect(finalStatus).toBeDefined();
       expect(finalStatus?.metadata.load).toBe(DocumentLoadStatus.LOADED);
       expect(finalStatus?.data.load).toBe(DocumentLoadStatus.LOADED);
+    });
+  });
+
+  describe("metadata channel liveness", () => {
+    const unsubscribes: Array<() => void> = [];
+
+    afterEach(() => {
+      unsubscribes.forEach(fn => {
+        fn();
+      });
+      unsubscribes.length = 0;
+    });
+
+    it("should report CONNECTED once the metadata updates subscription is established", async () => {
+      const docRef = createDocRef(mockApp, "test-doc-live-1" as DocumentId, testSchema);
+
+      unsubscribes.push(service.onMetadataChange(docRef, () => {}));
+
+      expect(service.getDocumentStatus(docRef).metadata.live).toBe(DocumentLiveStatus.CONNECTING);
+
+      await vi.runAllTimersAsync();
+
+      expect(service.getDocumentStatus(docRef).metadata.live).toBe(DocumentLiveStatus.CONNECTED);
+      expect(service.getDocumentStatus(docRef).metadata.load).toBe(DocumentLoadStatus.LOADED);
+    });
+
+    it("should stay CONNECTING while metadata is loaded but the subscription is pending", async () => {
+      // Never resolves, so the updates subscription stays in flight.
+      mockEventService.subscribeToMetadataUpdates.mockReturnValueOnce(new Promise(() => {}));
+
+      const docRef = createDocRef(mockApp, "test-doc-live-pending" as DocumentId, testSchema);
+
+      unsubscribes.push(service.onMetadataChange(docRef, () => {}));
+      await vi.runAllTimersAsync();
+
+      // The metadata document arrived over HTTP, but `live` describes the updates subscription,
+      // which is not established yet. The intervening `{ load: LOADED }` update must not drop the
+      // CONNECTING set before it.
+      const status = service.getDocumentStatus(docRef);
+      expect(status.metadata.load).toBe(DocumentLoadStatus.LOADED);
+      expect(status.metadata.live).toBe(DocumentLiveStatus.CONNECTING);
+    });
+
+    it("should report ERROR liveness but keep metadata loaded when the subscription fails", async () => {
+      mockEventService.subscribeToMetadataUpdates.mockRejectedValueOnce(
+        new Error("window is not defined"),
+      );
+
+      const docRef = createDocRef(mockApp, "test-doc-live-2" as DocumentId, testSchema);
+
+      unsubscribes.push(service.onMetadataChange(docRef, () => {}));
+      await vi.runAllTimersAsync();
+
+      // Metadata was fetched over HTTP, so it is genuinely loaded; only live updates are dead.
+      const status = service.getDocumentStatus(docRef);
+      expect(status.metadata.load).toBe(DocumentLoadStatus.LOADED);
+      expect(status.metadata.live).toBe(DocumentLiveStatus.ERROR);
+      // The failed liveness must be explainable, matching activity and presence.
+      expect(status.metadata.error).toMatchObject({ code: ChannelErrorCode.UNKNOWN });
+    });
+
+    it("should keep the data load status when the event service reports liveness alone", async () => {
+      // The event service emits partial status updates. A liveness-only update must not disturb
+      // the load status set when the data subscription opened.
+      mockEventService.startDocumentSync.mockImplementationOnce(
+        (documentId, _yDoc, _versionRange, onStatusChange) => {
+          void Promise.resolve().then(() => {
+            onStatusChange({ live: DocumentLiveStatus.CONNECTED });
+          });
+          return { clientId: "test-client-partial", documentId };
+        },
+      );
+
+      const docRef = createDocRef(mockApp, "test-doc-live-partial" as DocumentId, testSchema);
+
+      unsubscribes.push(service.onStateChange(docRef, () => {}));
+      await vi.runAllTimersAsync();
+
+      const status = service.getDocumentStatus(docRef);
+      expect(status.data.live).toBe(DocumentLiveStatus.CONNECTED);
+      // No update has arrived, so the load is still in flight rather than reset.
+      expect(status.data.load).toBe(DocumentLoadStatus.LOADING);
+    });
+
+    it("should preserve the load status and error across partial liveness updates", async () => {
+      mockEventService.subscribeToMetadataUpdates.mockRejectedValueOnce(
+        new Error("window is not defined"),
+      );
+
+      const docRef = createDocRef(mockApp, "test-doc-live-5" as DocumentId, testSchema);
+
+      const unsubscribe = service.onMetadataChange(docRef, () => {});
+      await vi.runAllTimersAsync();
+      expect(service.getDocumentStatus(docRef).metadata.error).toBeDefined();
+
+      // A later data-channel update must not disturb the metadata channel: updateChannelStatus
+      // merges per channel, and omitted fields fall back to the current value.
+      unsubscribes.push(service.onStateChange(docRef, () => {}));
+      await vi.runAllTimersAsync();
+
+      const status = service.getDocumentStatus(docRef);
+      expect(status.metadata.load).toBe(DocumentLoadStatus.LOADED);
+      expect(status.metadata.live).toBe(DocumentLiveStatus.ERROR);
+      expect(status.metadata.error).toBeDefined();
+
+      unsubscribe();
+    });
+
+    it("should surface data liveness reported by the event service", async () => {
+      // The event service owns the data subscription, so it reports liveness through the
+      // startDocumentSync status callback. This asserts the value survives the status merge and
+      // reaches DocumentStatus.data.live, which read DISCONNECTED forever against a real stack.
+      mockEventService.startDocumentSync.mockImplementationOnce(
+        (documentId, _yDoc, _versionRange, onStatusChange) => {
+          void Promise.resolve().then(() => {
+            onStatusChange({ live: DocumentLiveStatus.CONNECTED });
+            onStatusChange({ load: DocumentLoadStatus.LOADED });
+          });
+          return { clientId: "test-client-live", documentId };
+        },
+      );
+
+      const docRef = createDocRef(mockApp, "test-doc-live-4" as DocumentId, testSchema);
+
+      expect(service.getDocumentStatus(docRef).data.live).toBe(DocumentLiveStatus.DISCONNECTED);
+
+      const unsubscribe = service.onStateChange(docRef, () => {});
+      await vi.runAllTimersAsync();
+
+      const status = service.getDocumentStatus(docRef);
+      expect(status.data.load).toBe(DocumentLoadStatus.LOADED);
+      expect(status.data.live).toBe(DocumentLiveStatus.CONNECTED);
+
+      unsubscribe();
+
+      expect(service.getDocumentStatus(docRef).data.live).toBe(DocumentLiveStatus.DISCONNECTED);
+    });
+
+    it("should report DISCONNECTED after the metadata subscription closes", async () => {
+      const docRef = createDocRef(mockApp, "test-doc-live-3" as DocumentId, testSchema);
+
+      const unsubscribe = service.onMetadataChange(docRef, () => {});
+      await vi.runAllTimersAsync();
+      expect(service.getDocumentStatus(docRef).metadata.live).toBe(DocumentLiveStatus.CONNECTED);
+
+      unsubscribe();
+
+      expect(service.getDocumentStatus(docRef).metadata.live).toBe(
+        DocumentLiveStatus.DISCONNECTED,
+      );
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,9 +398,6 @@ importers:
       '@osdk/api':
         specifier: 'catalog:'
         version: 2.5.2
-      '@osdk/client':
-        specifier: 'catalog:'
-        version: 2.5.2
       '@osdk/oauth':
         specifier: 'catalog:'
         version: 1.4.0
@@ -416,6 +413,9 @@ importers:
       '@palantir/pack.core':
         specifier: workspace:*
         version: link:../core
+      '@palantir/pack.document-schema.model-types':
+        specifier: workspace:*
+        version: link:../document-schema/model-types
       '@palantir/pack.state.core':
         specifier: workspace:*
         version: link:../state/core
@@ -432,9 +432,15 @@ importers:
         specifier: 'catalog:'
         version: 1.3.3
     devDependencies:
+      '@osdk/client':
+        specifier: 'catalog:'
+        version: 2.5.2
       '@palantir/pack.monorepo.tsconfig':
         specifier: workspace:~
         version: link:../monorepo/tsconfig
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.19.19
       happy-dom:
         specifier: 'catalog:'
         version: 20.0.11
@@ -449,7 +455,10 @@ importers:
         version: 5.9.3
       vitest-mock-extended:
         specifier: 'catalog:'
-        version: 3.1.0(typescript@5.9.3)(vitest@4.1.10(@types/node@22.19.1)(@vitest/coverage-v8@4.0.14(vitest@4.0.14(@types/node@22.19.1)(happy-dom@20.0.11)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.2)))(happy-dom@20.0.11)(vite@7.2.6(@types/node@22.19.1)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.2)))
+        version: 3.1.0(typescript@5.9.3)(vitest@4.1.10(@types/node@20.19.19)(@vitest/coverage-v8@4.0.14(vitest@4.0.14(@types/node@22.19.1)(happy-dom@20.0.11)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.2)))(happy-dom@20.0.11)(vite@7.2.6(@types/node@20.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.2)))
+      zod:
+        specifier: 'catalog:'
+        version: 4.1.13
 
   packages/auth/core:
     dependencies:


### PR DESCRIPTION
## Summary

Every fix in this stack was found against a real Foundry stack but verified only by unit tests. These reproduce the reported failures end to end — two independent PACK clients against a real backend — and pin the behaviour that resolves them.

## Results

Run against `danube-staging` with a throwaway document type:

| Test | Baseline | With the fixes |
|---|---|---|
| write before any data subscription | ✗ 36s — never reaches the peer | ✓ |
| write during the initial load | ✗ 36s | ✓ |
| both writes visible to a peer | ✗ 37s | ✓ |
| `data.live` connected once synced | ✗ reads `disconnected` | ✓ |
| `waitForMetadataLoad` rejects | ✗ **90s hang** | ✓ |
| live update client → client | ✓ | ✓ |

The baseline included only the two worker-compatibility fixes (#299, #301), needed for the process to run in node at all, and **none** of the behavioural ones — so the failures isolate to the bugs #300, #302, #303 and #304 fix.

The last row passing in **both** columns is the control. Sync fundamentally works, so the other five failures are the specific defects rather than a broken harness.

## Design notes

**Skips without credentials.** The suite reads `.env.local` at the repo root and skips entirely when it is absent, so a credential-free checkout passes and CI is unaffected. Confirmed: `6 skipped` with no env, `6 passed` with it.

**Runs in node, not the package default of happy-dom.** PACK needs a real WebSocket here, and a genuinely absent `document`/`window` is also what it faces inside a SharedWorker — which is where these bugs were originally found. Set per-file via `// @vitest-environment node`.

**Writes go through `state.setCollectionRecord`.** `docRef.setRecord`'s data parameter is `never` on the base interface and needs a generated SDK's `asVersioned` to narrow. The schema here is declared inline, so there is nothing to narrow with.

**Two independent `initPackApp` instances**, each with its own OSDK client, Yjs client id and CometD session — which is what a second tab or process is, and what the reports hinge on.

**Static bearer token** rather than the OAuth redirect flow: these tests exercise sync, not auth.

**Documents are cleaned up** in `afterAll`, best-effort so a leaked throwaway cannot fail the run.

## Prerequisites

⚠️ Stacked on #304, but running these locally also needs **#299** and **#301** merged — they supply the `document` guard and the cometd `window` alias without which the process cannot start in node. Until then a local run with `.env.local` present fails with `ReferenceError: document is not defined`. CI is unaffected because it has no credentials and skips.

## Running them

```bash
cp /path/to/.env.local .              # repo root, gitignored
pnpm exec turbo run build             # REQUIRED — vitest resolves workspace deps to build/
cd packages/app && pnpm test src/__tests__/FoundrySync.integration.test.ts
```

The build step is not optional and is easy to miss: vitest resolves workspace packages to their `build/` output, so stale artifacts silently exercise the wrong code. That cost me a debugging cycle — the tests appeared to fail against fixes that were present in `src`.

## Test plan

- [x] 6 tests passing against a live stack.
- [x] Same 6 failing on a baseline without the behavioural fixes, confirming they are meaningful.
- [x] 6 skipped with no `.env.local`.
- [x] `typecheck`, `eslint`, `dprint`, `cspell` clean.