### PR TITLE
Introduce create document v2 endpoint

### DIFF
--- a/.changeset/create-document-v2.md
+++ b/.changeset/create-document-v2.md
@@ -1,0 +1,9 @@
+---
+"@palantir/pack.state.core": minor
+"@palantir/pack.state.foundry": minor
+---
+
+Add backward-compatible support for the PACK `createV2` document endpoint. Existing
+`createDocument` calls continue to use the legacy endpoint, while providing a namespace or folder
+through `CreateDocumentMetadata.parent` opts into V2. Legacy and V2 routing fields cannot be
+combined.

--- a/packages/state/core/README.md
+++ b/packages/state/core/README.md
@@ -38,6 +38,24 @@ Reference (or _ref_) objects provide the main public api for interacting with do
 
 > **Note:** All ref objects are stable, deduplicated automatically via weak ref caches. This means they are suitable for use as keys in maps, cache deps in react etc, as long as the application holds a ref it will never receive a duplicate.
 
+## Creating Documents
+
+`app.state.createDocument` supports a gradual migration to the V2 create endpoint. The legacy
+endpoint is deprecated and remains available only to avoid breaking existing callers during the
+transition. New callers should use V2, and existing callers should migrate by providing `parent`:
+
+```ts
+await app.state.createDocument({
+  name: "Example",
+  documentTypeName: "com.palantir.pack.example",
+  parent: { type: "parentFolder", folderRid },
+}, schema);
+```
+
+Use `parentFolder` for Compass-backed document types and `namespace` for Artifacts-backed document
+types. V2 metadata cannot include the legacy `parentFolderRid` or `ontologyRid` fields. The legacy
+path remains available during migration but should not be used for new integrations.
+
 ## Internal Notes
 
 ### Document Services

--- a/packages/state/core/src/index.ts
+++ b/packages/state/core/src/index.ts
@@ -41,7 +41,10 @@ export {
 } from "./service/DocumentUpdateSchemaVersion.js";
 export { createInMemoryDocumentServiceConfig } from "./service/InMemoryDocumentService.js";
 export { FileSystemType } from "./types/CreateDocumentMetadata.js";
-export type { CreateDocumentMetadata } from "./types/CreateDocumentMetadata.js";
+export type {
+  CreateDocumentMetadata,
+  CreateDocumentParent,
+} from "./types/CreateDocumentMetadata.js";
 export { createDocRef, invalidDocRef, isValidDocRef } from "./types/DocumentRefImpl.js";
 export { DocumentLiveStatus, DocumentLoadStatus } from "./types/DocumentService.js";
 export type {

--- a/packages/state/core/src/types/CreateDocumentMetadata.ts
+++ b/packages/state/core/src/types/CreateDocumentMetadata.ts
@@ -16,19 +16,43 @@
 
 import type { DocumentSecurity } from "@palantir/pack.document-schema.model-types";
 
-export interface CreateDocumentMetadata {
+export type CreateDocumentParent =
+  | {
+    readonly type: "parentFolder";
+    readonly folderRid: string;
+  }
+  | {
+    readonly type: "namespace";
+    readonly namespaceRid: string;
+  };
+
+interface CreateDocumentMetadataBase {
   readonly name: string;
   readonly documentTypeName: string;
   readonly security?: DocumentSecurity;
-  readonly parentFolderRid?: string;
-  /**
-   * Ontology to create the document in. When omitted, the app's default ontology is used. Provide
-   * this to create in a different ontology (e.g. multi-tenant hosts that pick an ontology per
-   * document); the document's target ontology travels in the create request, so the app's OSDK
-   * client does not need to be bound to it.
-   */
-  readonly ontologyRid?: string;
 }
+
+export type CreateDocumentMetadata =
+  & CreateDocumentMetadataBase
+  & (
+    | {
+      readonly parent?: never;
+      readonly parentFolderRid?: string;
+      /**
+       * Ontology to create the document in. When omitted, the app's default ontology is used.
+       */
+      readonly ontologyRid?: string;
+    }
+    | {
+      /**
+       * Parent used by the V2 create endpoint. The parent type must match the document type's file
+       * system: `parentFolder` for Compass or `namespace` for Artifacts.
+       */
+      readonly parent: CreateDocumentParent;
+      readonly parentFolderRid?: never;
+      readonly ontologyRid?: never;
+    }
+  );
 
 export const FileSystemType = {
   ARTIFACTS: "ARTIFACTS",

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -17,6 +17,7 @@
 import type {
   ClientSupportedVersionRange,
   CreateDocumentRequest,
+  CreateDocumentV2Request,
   DiscretionaryPrincipal,
   DiscretionaryPrincipal as WireDiscretionaryPrincipal,
   Document as WireDocument,
@@ -168,27 +169,59 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     metadata: CreateDocumentMetadata,
     schema: T,
   ): Promise<DocumentRef<T>> => {
-    const { documentTypeName, name, parentFolderRid, security } = metadata;
-    const ontologyRid = metadata.ontologyRid ?? await getOntologyRid(this.app);
+    const { documentTypeName, name, parent, parentFolderRid, security } = metadata;
+    const preview = this.config.usePreviewApi ?? DEFAULT_USE_PREVIEW_API;
+    const wireSecurity = getWireSecurity(security);
 
-    const request: CreateDocumentRequest = {
-      documentTypeName: documentTypeName,
-      name: name,
-      ontologyRid: ontologyRid,
-      security: getWireSecurity(security),
-    };
+    let createResponse: WireDocument;
+    if (parent == null) {
+      const ontologyRid = metadata.ontologyRid ?? await getOntologyRid(this.app);
+      const request: CreateDocumentRequest = {
+        documentTypeName,
+        name,
+        ontologyRid,
+        security: wireSecurity,
+      };
 
-    if (parentFolderRid != null) {
-      request.parentFolderRid = parentFolderRid;
+      if (parentFolderRid != null) {
+        request.parentFolderRid = parentFolderRid;
+      }
+
+      createResponse = await Documents.create(
+        this.app.config.osdkClient,
+        request,
+        { preview },
+      );
+    } else {
+      if (parentFolderRid != null || metadata.ontologyRid != null) {
+        throw new Error(
+          "CreateDocumentMetadata cannot combine parent with parentFolderRid or ontologyRid",
+        );
+      }
+      const isValidParentFolder = parent.type === "parentFolder"
+        && typeof parent.folderRid === "string"
+        && !("namespaceRid" in parent);
+      const isValidNamespace = parent.type === "namespace"
+        && typeof parent.namespaceRid === "string"
+        && !("folderRid" in parent);
+      if (!isValidParentFolder && !isValidNamespace) {
+        throw new Error("Invalid CreateDocumentMetadata.parent");
+      }
+
+      const request: CreateDocumentV2Request = {
+        requestBody: {
+          documentTypeName,
+          name,
+          parent,
+          security: wireSecurity,
+        },
+      };
+      createResponse = await Documents.createV2(
+        this.app.config.osdkClient,
+        request,
+        { preview },
+      );
     }
-
-    const createResponse = await Documents.create(
-      this.app.config.osdkClient,
-      request,
-      {
-        preview: this.config.usePreviewApi ?? DEFAULT_USE_PREVIEW_API,
-      },
-    );
 
     const documentId = createResponse.id as DocumentId;
     const docRef = this.createDocRef(documentId, schema);

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -187,6 +187,9 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
         request.parentFolderRid = parentFolderRid;
       }
 
+      this.logger.warn(
+        "The legacy document create endpoint is deprecated; provide CreateDocumentMetadata.parent to use createV2",
+      );
       createResponse = await Documents.create(
         this.app.config.osdkClient,
         request,

--- a/packages/state/foundry/src/__tests__/FoundryDocumentCreation.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryDocumentCreation.test.ts
@@ -93,6 +93,7 @@ describe("FoundryDocumentService document creation", () => {
   beforeEach(() => {
     vi.mocked(Documents.create).mockReset().mockResolvedValue(document);
     vi.mocked(Documents.createV2).mockReset().mockResolvedValue(document);
+    mockLogger.warn.mockClear();
   });
 
   it("keeps existing createDocument calls on the legacy endpoint", async () => {
@@ -119,6 +120,9 @@ describe("FoundryDocumentService document creation", () => {
       { preview: true },
     );
     expect(Documents.createV2).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "The legacy document create endpoint is deprecated; provide CreateDocumentMetadata.parent to use createV2",
+    );
   });
 
   it("uses createV2 when a namespace parent is provided", async () => {
@@ -152,6 +156,7 @@ describe("FoundryDocumentService document creation", () => {
       { preview: true },
     );
     expect(Documents.create).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 
   it("supports folder parents on createV2", async () => {

--- a/packages/state/foundry/src/__tests__/FoundryDocumentCreation.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryDocumentCreation.test.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Document } from "@osdk/foundry.pack";
+import { Documents } from "@osdk/foundry.pack";
+import type { PackAppInternal } from "@palantir/pack.core";
+import type { DocumentSchema } from "@palantir/pack.document-schema.model-types";
+import { Metadata } from "@palantir/pack.document-schema.model-types";
+import type { CreateDocumentMetadata } from "@palantir/pack.state.core";
+import type { FoundryEventService } from "@palantir/pack.state.foundry-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { internalCreateFoundryDocumentService } from "../FoundryDocumentService.js";
+
+vi.mock("@osdk/foundry.pack", () => ({
+  Documents: {
+    create: vi.fn(),
+    createV2: vi.fn(),
+  },
+}));
+
+const mockLogger = {
+  child: vi.fn(),
+  debug: vi.fn((..._args: unknown[]) => {}),
+  error: vi.fn((..._args: unknown[]) => {}),
+  info: vi.fn((..._args: unknown[]) => {}),
+  warn: vi.fn((..._args: unknown[]) => {}),
+};
+mockLogger.child.mockReturnValue(mockLogger);
+
+const mockOsdkClient = {};
+const mockApp = {
+  getModule: vi.fn().mockReturnValue({}),
+  config: {
+    logger: mockLogger,
+    ontologyRid: "ri.ontology..default",
+    osdkClient: mockOsdkClient,
+  },
+} as unknown as PackAppInternal;
+
+const testSchema = {
+  [Metadata]: {
+    version: 1,
+  },
+} as const satisfies DocumentSchema;
+
+const document = { id: "ri.pack.document..test" } as Document;
+const wireSecurity = {
+  discretionary: {
+    editors: [],
+    owners: [],
+    viewers: [],
+  },
+  mandatory: {
+    classification: [],
+    markings: [],
+  },
+};
+
+const mixedCreateMetadata = {
+  documentTypeName: "com.palantir.pack.test",
+  name: "Invalid document",
+  ontologyRid: "ri.ontology..legacy",
+  parent: {
+    type: "namespace",
+    namespaceRid: "ri.artifacts.main.namespace.test",
+  },
+} as unknown as CreateDocumentMetadata;
+
+const malformedParentMetadata = {
+  documentTypeName: "com.palantir.pack.test",
+  name: "Invalid document",
+  parent: {
+    type: "namespace",
+    folderRid: "ri.compass.main.folder.test",
+  },
+} as unknown as CreateDocumentMetadata;
+
+describe("FoundryDocumentService document creation", () => {
+  beforeEach(() => {
+    vi.mocked(Documents.create).mockReset().mockResolvedValue(document);
+    vi.mocked(Documents.createV2).mockReset().mockResolvedValue(document);
+  });
+
+  it("keeps existing createDocument calls on the legacy endpoint", async () => {
+    const service = internalCreateFoundryDocumentService(mockApp, {}, mock<FoundryEventService>());
+
+    await service.createDocument(
+      {
+        documentTypeName: "com.palantir.pack.test",
+        name: "Legacy document",
+        parentFolderRid: "ri.compass.main.folder.legacy",
+      },
+      testSchema,
+    );
+
+    expect(Documents.create).toHaveBeenCalledWith(
+      mockOsdkClient,
+      {
+        documentTypeName: "com.palantir.pack.test",
+        name: "Legacy document",
+        ontologyRid: "ri.ontology..default",
+        parentFolderRid: "ri.compass.main.folder.legacy",
+        security: wireSecurity,
+      },
+      { preview: true },
+    );
+    expect(Documents.createV2).not.toHaveBeenCalled();
+  });
+
+  it("uses createV2 when a namespace parent is provided", async () => {
+    const service = internalCreateFoundryDocumentService(mockApp, {}, mock<FoundryEventService>());
+
+    await service.createDocument(
+      {
+        documentTypeName: "com.palantir.pack.test",
+        name: "V2 document",
+        parent: {
+          type: "namespace",
+          namespaceRid: "ri.artifacts.main.namespace.test",
+        },
+      },
+      testSchema,
+    );
+
+    expect(Documents.createV2).toHaveBeenCalledWith(
+      mockOsdkClient,
+      {
+        requestBody: {
+          documentTypeName: "com.palantir.pack.test",
+          name: "V2 document",
+          parent: {
+            type: "namespace",
+            namespaceRid: "ri.artifacts.main.namespace.test",
+          },
+          security: wireSecurity,
+        },
+      },
+      { preview: true },
+    );
+    expect(Documents.create).not.toHaveBeenCalled();
+  });
+
+  it("supports folder parents on createV2", async () => {
+    const service = internalCreateFoundryDocumentService(mockApp, {}, mock<FoundryEventService>());
+
+    await service.createDocument(
+      {
+        documentTypeName: "com.palantir.pack.test",
+        name: "V2 document",
+        parent: {
+          type: "parentFolder",
+          folderRid: "ri.compass.main.folder.test",
+        },
+      },
+      testSchema,
+    );
+
+    expect(Documents.createV2).toHaveBeenCalledWith(
+      mockOsdkClient,
+      {
+        requestBody: {
+          documentTypeName: "com.palantir.pack.test",
+          name: "V2 document",
+          parent: {
+            type: "parentFolder",
+            folderRid: "ri.compass.main.folder.test",
+          },
+          security: wireSecurity,
+        },
+      },
+      { preview: true },
+    );
+    expect(Documents.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects metadata that mixes legacy and V2 routing", async () => {
+    const service = internalCreateFoundryDocumentService(mockApp, {}, mock<FoundryEventService>());
+
+    await expect(service.createDocument(mixedCreateMetadata, testSchema)).rejects.toThrow(
+      "CreateDocumentMetadata cannot combine parent with parentFolderRid or ontologyRid",
+    );
+    expect(Documents.create).not.toHaveBeenCalled();
+    expect(Documents.createV2).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed V2 parent variants", async () => {
+    const service = internalCreateFoundryDocumentService(mockApp, {}, mock<FoundryEventService>());
+
+    await expect(service.createDocument(malformedParentMetadata, testSchema)).rejects.toThrow(
+      "Invalid CreateDocumentMetadata.parent",
+    );
+    expect(Documents.create).not.toHaveBeenCalled();
+    expect(Documents.createV2).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^2.56.0
       version: 2.56.0
     '@osdk/foundry.pack':
-      specifier: ^2.68.0
-      version: 2.68.0
+      specifier: ^2.72.0
+      version: 2.72.0
     '@osdk/oauth':
       specifier: ^1.4.0
       version: 1.4.0
@@ -662,7 +662,7 @@ importers:
         version: 2.5.2
       '@osdk/foundry.pack':
         specifier: 'catalog:'
-        version: 2.68.0
+        version: 2.72.0
       '@palantir/pack.document-schema.model-types':
         specifier: workspace:~
         version: link:../model-types
@@ -1162,7 +1162,7 @@ importers:
         version: 2.5.2
       '@osdk/foundry.pack':
         specifier: 'catalog:'
-        version: 2.68.0
+        version: 2.72.0
       '@palantir/pack.auth':
         specifier: workspace:*
         version: link:../../auth/core
@@ -1214,7 +1214,7 @@ importers:
         version: 2.5.2
       '@osdk/foundry.pack':
         specifier: 'catalog:'
-        version: 2.68.0
+        version: 2.72.0
       '@palantir/pack.auth':
         specifier: workspace:*
         version: link:../../auth/core
@@ -3959,11 +3959,11 @@ packages:
   '@osdk/foundry.core@2.56.0':
     resolution: {integrity: sha512-lm7c5IxHfmaAhSv3FB7od+YpvA1mTGP12FBEdQYQ7FqnJTLEB+GLaHLzvX+1WsSFJA/LxnasRV3ztWfjy1Qe+w==}
 
-  '@osdk/foundry.core@2.68.0':
-    resolution: {integrity: sha512-65Qs0obdgAPDzXKL6jCWpfa0OueraA+dEYuduuPVXb+WpS6KwBas5R8gGYv1wPa/GgHuU7wIJ+P8PcL//tcQOg==}
+  '@osdk/foundry.core@2.72.0':
+    resolution: {integrity: sha512-jrP9GLUhf8VteR2bX+g/wegS92WztbDGC/IvPoSO67jxykcF0cW+zblxdGPNjXqnrDj5tmytxHMxhsdPgx993g==}
 
-  '@osdk/foundry.filesystem@2.68.0':
-    resolution: {integrity: sha512-hmgRu1H7MaI0kdcNvawk/3U6p/oKvHeD2W25m7i8rjS8qY22KaZez+F+x7kzLhD7e9L0hN4j5RO4JgCSDSJKPg==}
+  '@osdk/foundry.filesystem@2.72.0':
+    resolution: {integrity: sha512-nqPl2+eei8YSUuIZO3jhvTnepuGlXjluapqw16FGjcEo5hco7aVZXIvsUFBDnDsqGH4W+q5ufqgMiTlA9XeqTQ==}
 
   '@osdk/foundry.geo@2.30.0':
     resolution: {integrity: sha512-VsYE9vtDwUVxfHlQLKxfDq6YrknPoPt6Gf3Ui0ojY7STqT/FTJlyH8aG+D3zosUVKeTZNXZ3ybc51GhB8kuYSQ==}
@@ -3971,14 +3971,14 @@ packages:
   '@osdk/foundry.geo@2.56.0':
     resolution: {integrity: sha512-ZB7RzItE3JJSsP7MPBihz8Zq7a361MtdUfxA+zHQbdaqCwZqukZ1ghJm/0mc/rQmHkV7bt3/SVknGOcHhVj3/g==}
 
-  '@osdk/foundry.geo@2.68.0':
-    resolution: {integrity: sha512-RwsDB8vnvawAAlsULCux++OdqEgIfxOvYROKlQIYjZxGg5L1yarkiGUZ48cukj/FBTd5fB6Rlht7W8qWrHjCiQ==}
+  '@osdk/foundry.geo@2.72.0':
+    resolution: {integrity: sha512-+bbJN0RTOBjUdbi81bCCS7viaLwUJr7e4Wm7v1L81VDUhxl2uS57+pXGSMnAMP0Ve7Nwx5kIpPVtRsygVHj5MQ==}
 
   '@osdk/foundry.ontologies@2.30.0':
     resolution: {integrity: sha512-hmUhGJ846r8FDqkDZbt9P4tSzTcYzTatwrCVr4wN43WNRMIARvPLGnKCs9lk/nL1DOoUG6AM1v2RfvfLryQngA==}
 
-  '@osdk/foundry.pack@2.68.0':
-    resolution: {integrity: sha512-cFH5i3oxmkOYQV5b7R87CPx4Ork4idXWINfM4ZatlPQfb/Wjws06Ke61g0Nzpregr5jpUGgOA+lC7r52xoJgPQ==}
+  '@osdk/foundry.pack@2.72.0':
+    resolution: {integrity: sha512-EPhkTodNMHTBTvLBYBxz6uPo+aJlWjN42rdmXZ6m2RntEDY3HxWFRXPEagPZu6w8suG33EoajYlTdI9FJMYWpg==}
 
   '@osdk/generator-converters@2.5.2':
     resolution: {integrity: sha512-k7sJM00w70A4g6OB0LKq1Gfmka8kiiPNAPeX/CK9sT5DfwGwfJ7wIZrXJVSkSwNlEqVr6zSKSbwwgmU/FyMqQQ==}
@@ -14835,16 +14835,16 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.core@2.68.0':
+  '@osdk/foundry.core@2.72.0':
     dependencies:
-      '@osdk/foundry.geo': 2.68.0
+      '@osdk/foundry.geo': 2.72.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.filesystem@2.68.0':
+  '@osdk/foundry.filesystem@2.72.0':
     dependencies:
-      '@osdk/foundry.core': 2.68.0
+      '@osdk/foundry.core': 2.72.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -14861,7 +14861,7 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.6.0
 
-  '@osdk/foundry.geo@2.68.0':
+  '@osdk/foundry.geo@2.72.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
@@ -14875,10 +14875,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.4.0
 
-  '@osdk/foundry.pack@2.68.0':
+  '@osdk/foundry.pack@2.72.0':
     dependencies:
-      '@osdk/foundry.core': 2.68.0
-      '@osdk/foundry.filesystem': 2.68.0
+      '@osdk/foundry.core': 2.72.0
+      '@osdk/foundry.filesystem': 2.72.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   "@osdk/api": ^2.5.2
   "@osdk/client": ^2.5.2
   "@osdk/foundry.admin": ^2.56.0
-  "@osdk/foundry.pack": ^2.68.0
+  "@osdk/foundry.pack": ^2.72.0
   "@osdk/oauth": ^1.4.0
   "@osdk/react": ^0.6.0
   "@osdk/shared.client2": ^1.0.0


### PR DESCRIPTION

  Adds backward-compatible support for the PACK createV2 document endpoint while preserving the existing
  app.state.createDocument API.

  ## Why

  The legacy create endpoint is to be deprecated. V2 identifies the target using a namespace or parent folder directly
  instead of an ontology RID, but existing callers need time to migrate without breaking.

  ## How it works

  Calls without metadata.parent continue using the legacy endpoint. Providing either a namespace or parent-
  folder variant routes the request to Documents.createV2.

  The metadata types and runtime validation prevent mixing legacy and V2 routing fields.