### PR TITLE
fix demo auth login loop

### DIFF
--- a/.changeset/lucky-frogs-listen.md
+++ b/.changeset/lucky-frogs-listen.md
@@ -1,0 +1,5 @@
+---
+"@palantir/pack.app": patch
+---
+
+Fix reload loop in demo mode: DemoPublicOauthClient now completes the OAuth callback from signIn()/getToken() instead of its constructor, and signIn() no longer redirects when a valid token already exists

--- a/demos/canvas/app/src/components/home/HomePage.tsx
+++ b/demos/canvas/app/src/components/home/HomePage.tsx
@@ -15,8 +15,10 @@
  */
 
 import { Button, ButtonGroup } from "@blueprintjs/core";
+import { AuthState } from "@palantir/pack.auth";
+import { useAuthState } from "@palantir/pack.state.react";
 import React, { useCallback } from "react";
-import { FILE_SYSTEM_TYPE } from "../../app.js";
+import { app, FILE_SYSTEM_TYPE } from "../../app.js";
 import type { CanvasDocument } from "../../hooks/useCanvasDocuments.js";
 import { useCanvasDocuments } from "../../hooks/useCanvasDocuments.js";
 import { CreateFileDialog } from "./CreateCanvasDialog.js";
@@ -26,6 +28,7 @@ import { DocumentTypeMetadata } from "./DocumentTypeMetadata.js";
 import css from "./HomePage.module.css";
 
 export const HomePage = React.memo(function HomePage() {
+  const authState = useAuthState(app);
   const {
     currentPage,
     documents,
@@ -43,6 +46,22 @@ export const HomePage = React.memo(function HomePage() {
   const showCreateDialog = useCallback(() => {
     setCreateDialogIsOpen(true);
   }, []);
+
+  if (authState === AuthState.Error) {
+    return (
+      <div className={css.pageWrapper}>
+        <div className={css.loading}>Authentication error</div>
+      </div>
+    );
+  }
+
+  if (authState !== AuthState.Authenticated) {
+    return (
+      <div className={css.pageWrapper}>
+        <div className={css.loading}>Signing in...</div>
+      </div>
+    );
+  }
 
   // Only show full-page loading on initial load, not during pagination
   const isInitialLoading = isLoading && documents.length === 0;

--- a/packages/app/src/auth/DemoPublicOauthClient.ts
+++ b/packages/app/src/auth/DemoPublicOauthClient.ts
@@ -48,23 +48,28 @@ export class DemoPublicOauthClient {
     this.eventListeners = new Map();
 
     this.loadTokenFromStorage();
-    this.handleCallbackIfPresent();
   }
 
-  private handleCallbackIfPresent(): void {
+  /**
+   * Completes a pending redirect if the current URL carries our callback params.
+   *
+   * Must NOT be called from the constructor: the `signIn` event it fires would be
+   * emitted before consumers (eg AuthServicePublic) have attached their listeners.
+   */
+  private handleCallbackIfPresent(): Token | undefined {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
     const state = params.get("state");
 
     if (code == null || state == null) {
-      return;
+      return undefined;
     }
 
     const savedState = sessionStorage.getItem("demo-oauth-state");
     const returnUrl = sessionStorage.getItem("demo-oauth-return-url");
 
     if (savedState !== state) {
-      return;
+      return undefined;
     }
 
     sessionStorage.removeItem("demo-oauth-state");
@@ -79,12 +84,20 @@ export class DemoPublicOauthClient {
     if (returnUrl != null) {
       window.history.replaceState({}, "", returnUrl);
     }
+
+    return token;
   }
 
   getToken = async (): Promise<string> => {
     const token = this.getTokenOrUndefined();
     if (token != null) {
       return token;
+    }
+
+    // Complete a pending redirect before concluding we're unauthenticated.
+    const callbackToken = this.handleCallbackIfPresent();
+    if (callbackToken != null) {
+      return callbackToken.access_token;
     }
 
     if (this.autoSignIn) {
@@ -109,7 +122,26 @@ export class DemoPublicOauthClient {
     return this.currentToken.access_token;
   };
 
+  /**
+   * Mirrors the real PublicOauthClient contract: exhaust every non-interactive path
+   * before redirecting. Redirecting unconditionally causes a reload loop for consumers
+   * that call signIn() to kick off the auth flow.
+   */
   signIn = async (): Promise<Token> => {
+    // 1. Already holding a valid token (in memory or restored from storage).
+    const existingToken = this.getTokenOrUndefined() != null ? this.currentToken : undefined;
+    if (existingToken != null) {
+      this.fireEvent("signIn", new CustomEvent("signIn", { detail: existingToken }));
+      return existingToken;
+    }
+
+    // 2. Returning from a redirect - complete it instead of starting another.
+    const callbackToken = this.handleCallbackIfPresent();
+    if (callbackToken != null) {
+      return callbackToken;
+    }
+
+    // 3. No token and nothing to complete, so redirect.
     const state = Math.random().toString(36).substring(7);
     const code = Math.random().toString(36).substring(2);
 
@@ -122,7 +154,10 @@ export class DemoPublicOauthClient {
 
     window.location.href = callbackUrl.toString();
 
-    return new Promise(() => {});
+    // Give the navigation time to happen. Throwing (rather than hanging forever) keeps
+    // `await signIn()` callers from deadlocking if it doesn't.
+    await this.delay(1000);
+    throw new Error("Unable to redirect");
   };
 
   signOut = async (): Promise<void> => {

--- a/packages/app/src/auth/DemoPublicOauthClient.ts
+++ b/packages/app/src/auth/DemoPublicOauthClient.ts
@@ -72,9 +72,7 @@ export class DemoPublicOauthClient {
       return undefined;
     }
 
-    sessionStorage.removeItem("demo-oauth-state");
-    sessionStorage.removeItem("demo-oauth-code-verifier");
-    sessionStorage.removeItem("demo-oauth-return-url");
+    this.clearCallbackSession();
 
     const token = this.generateToken();
     this.currentToken = token;
@@ -86,6 +84,34 @@ export class DemoPublicOauthClient {
     }
 
     return token;
+  }
+
+  /**
+   * Abandons a pending callback we no longer need to consume, restoring the URL it came from.
+   * Only touches a callback whose state matches ours, so unrelated `code`/`state` params on the
+   * page are left alone.
+   */
+  private discardPendingCallback(): void {
+    const params = new URLSearchParams(window.location.search);
+    const state = params.get("state");
+
+    if (params.get("code") == null || state == null) {
+      return;
+    }
+
+    if (sessionStorage.getItem("demo-oauth-state") !== state) {
+      return;
+    }
+
+    const returnUrl = sessionStorage.getItem("demo-oauth-return-url");
+    this.clearCallbackSession();
+    window.history.replaceState({}, "", returnUrl ?? "/");
+  }
+
+  private clearCallbackSession(): void {
+    sessionStorage.removeItem("demo-oauth-state");
+    sessionStorage.removeItem("demo-oauth-code-verifier");
+    sessionStorage.removeItem("demo-oauth-return-url");
   }
 
   getToken = async (): Promise<string> => {
@@ -131,6 +157,7 @@ export class DemoPublicOauthClient {
     // 1. Already holding a valid token (in memory or restored from storage).
     const existingToken = this.getTokenOrUndefined() != null ? this.currentToken : undefined;
     if (existingToken != null) {
+      this.discardPendingCallback();
       this.fireEvent("signIn", new CustomEvent("signIn", { detail: existingToken }));
       return existingToken;
     }

--- a/packages/app/src/auth/__tests__/DemoPublicOauthClient.test.ts
+++ b/packages/app/src/auth/__tests__/DemoPublicOauthClient.test.ts
@@ -107,7 +107,7 @@ describe("DemoPublicOauthClient", () => {
         autoSignIn: true,
       });
 
-      void client();
+      void client().catch(() => {});
 
       await vi.waitFor(() => {
         expect(window.location.href).toContain("code=");
@@ -165,7 +165,7 @@ describe("DemoPublicOauthClient", () => {
     it("should redirect to callback URL with code and state", () => {
       const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
 
-      void client.signIn();
+      void client.signIn().catch(() => {});
 
       expect(window.location.href).toContain(REDIRECT_URL);
       expect(window.location.href).toContain("code=");
@@ -175,7 +175,7 @@ describe("DemoPublicOauthClient", () => {
     it("should store state and return URL in sessionStorage", () => {
       const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
 
-      void client.signIn();
+      void client.signIn().catch(() => {});
 
       expect(sessionStorage.getItem("demo-oauth-state")).toBeDefined();
       expect(sessionStorage.getItem("demo-oauth-return-url")).toBe("https://test.foundry.com/");
@@ -183,7 +183,25 @@ describe("DemoPublicOauthClient", () => {
   });
 
   describe("OAuth callback", () => {
-    it("should handle callback and generate token", () => {
+    it("should not handle callback in the constructor", async () => {
+      const state = "test-state";
+      const code = "test-code";
+
+      sessionStorage.setItem("demo-oauth-state", state);
+      simulateOAuthCallback(state, code);
+
+      const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+
+      // The callback must only be completed from signIn()/getToken(), otherwise the
+      // signIn event fires before consumers can attach listeners.
+      expect(client.getTokenOrUndefined()).toBeUndefined();
+
+      await client.signIn();
+
+      expect(client.getTokenOrUndefined()).toBeDefined();
+    });
+
+    it("should handle callback and generate token", async () => {
       const state = "test-state";
       const code = "test-code";
 
@@ -192,20 +210,57 @@ describe("DemoPublicOauthClient", () => {
       simulateOAuthCallback(state, code);
 
       const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+      await client.signIn();
 
       const token = client.getTokenOrUndefined();
       expect(token).toBeDefined();
       expect(token).toMatch(/^demo\./);
     });
 
-    it("should store token in localStorage after callback", () => {
+    it("should not redirect again when completing a callback", async () => {
+      const state = "test-state";
+      const code = "test-code";
+      const hrefBefore = window.location.href;
+
+      sessionStorage.setItem("demo-oauth-state", state);
+      simulateOAuthCallback(state, code);
+
+      const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+      await client.signIn();
+
+      expect(window.location.href).toBe(hrefBefore);
+    });
+
+    it("should not redirect when a valid token already exists", async () => {
+      const token: Token = {
+        access_token: "existing-token",
+        expires_at: Date.now() + 3600000,
+        expires_in: 3600,
+        refresh_token: "refresh-token",
+      };
+      localStorage.setItem("demo-oauth-token", JSON.stringify(token));
+      const hrefBefore = window.location.href;
+
+      const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+      const listener = vi.fn();
+      client.addEventListener("signIn", listener);
+
+      const result = await client.signIn();
+
+      expect(result.access_token).toBe("existing-token");
+      expect(window.location.href).toBe(hrefBefore);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should store token in localStorage after callback", async () => {
       const state = "test-state";
       const code = "test-code";
 
       sessionStorage.setItem("demo-oauth-state", state);
       simulateOAuthCallback(state, code);
 
-      createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+      const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+      await client.signIn();
 
       const stored = localStorage.getItem("demo-oauth-token");
       expect(stored).toBeDefined();
@@ -218,7 +273,7 @@ describe("DemoPublicOauthClient", () => {
       });
     });
 
-    it("should fire signIn event after callback", () => {
+    it("should fire signIn event after callback", async () => {
       const state = "test-state";
       const code = "test-code";
       const listener = vi.fn();
@@ -229,10 +284,24 @@ describe("DemoPublicOauthClient", () => {
       const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
       client.addEventListener("signIn", listener);
 
-      expect(listener).toHaveBeenCalledTimes(0);
+      await client.signIn();
+
+      expect(listener).toHaveBeenCalledTimes(1);
     });
 
-    it("should reject callback with mismatched state", () => {
+    it("should complete the callback from getToken", async () => {
+      const state = "test-state";
+      const code = "test-code";
+
+      sessionStorage.setItem("demo-oauth-state", state);
+      simulateOAuthCallback(state, code);
+
+      const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+
+      await expect(client()).resolves.toMatch(/^demo\./);
+    });
+
+    it("should reject callback with mismatched state", async () => {
       const state = "test-state";
       const code = "test-code";
 
@@ -241,11 +310,12 @@ describe("DemoPublicOauthClient", () => {
 
       const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
 
+      await expect(client()).rejects.toThrow("Not authenticated");
       expect(client.getTokenOrUndefined()).toBeUndefined();
       expect(localStorage.getItem("demo-oauth-token")).toBeNull();
     });
 
-    it("should use custom userId in generated token", () => {
+    it("should use custom userId in generated token", async () => {
       const state = "test-state";
       const code = "test-code";
 
@@ -255,6 +325,7 @@ describe("DemoPublicOauthClient", () => {
       const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL, {
         mockUserId: "custom-user-123",
       });
+      await client.signIn();
 
       const token = client.getTokenOrUndefined();
       if (!token) throw new Error("Expected token");
@@ -262,7 +333,7 @@ describe("DemoPublicOauthClient", () => {
       expect(payload.sub).toBe("custom-user-123");
     });
 
-    it("should include foundry URL in generated token", () => {
+    it("should include foundry URL in generated token", async () => {
       const state = "test-state";
       const code = "test-code";
 
@@ -270,6 +341,7 @@ describe("DemoPublicOauthClient", () => {
       simulateOAuthCallback(state, code);
 
       const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+      await client.signIn();
 
       const token = client.getTokenOrUndefined();
       if (!token) throw new Error("Expected token");
@@ -412,10 +484,10 @@ describe("DemoPublicOauthClient", () => {
       client.addEventListener("signIn", listener);
       client.removeEventListener("signIn", listener);
 
-      expect(() => client.signIn()).not.toThrow();
+      expect(() => void client.signIn().catch(() => {})).not.toThrow();
     });
 
-    it("should handle multiple listeners for same event", () => {
+    it("should handle multiple listeners for same event", async () => {
       const state = "test-state";
       const code = "test-code";
       const listener1 = vi.fn();
@@ -428,8 +500,10 @@ describe("DemoPublicOauthClient", () => {
       client.addEventListener("signIn", listener1);
       client.addEventListener("signIn", listener2);
 
-      expect(listener1).toHaveBeenCalledTimes(0);
-      expect(listener2).toHaveBeenCalledTimes(0);
+      await client.signIn();
+
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
     });
 
     it("should handle null listener gracefully", () => {

--- a/packages/app/src/auth/__tests__/DemoPublicOauthClient.test.ts
+++ b/packages/app/src/auth/__tests__/DemoPublicOauthClient.test.ts
@@ -252,6 +252,49 @@ describe("DemoPublicOauthClient", () => {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
+    it("should drop the pending callback when a valid token already exists", async () => {
+      const state = "test-state";
+      const token: Token = {
+        access_token: "existing-token",
+        expires_at: Date.now() + 3600000,
+        expires_in: 3600,
+        refresh_token: "refresh-token",
+      };
+      localStorage.setItem("demo-oauth-token", JSON.stringify(token));
+      sessionStorage.setItem("demo-oauth-state", state);
+      sessionStorage.setItem("demo-oauth-return-url", "https://test.foundry.com/original");
+      simulateOAuthCallback(state, "test-code");
+
+      const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+      await client.signIn();
+
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        {},
+        "",
+        "https://test.foundry.com/original",
+      );
+      expect(sessionStorage.getItem("demo-oauth-state")).toBeNull();
+      expect(sessionStorage.getItem("demo-oauth-return-url")).toBeNull();
+    });
+
+    it("should leave unrelated callback params alone", async () => {
+      const token: Token = {
+        access_token: "existing-token",
+        expires_at: Date.now() + 3600000,
+        expires_in: 3600,
+        refresh_token: "refresh-token",
+      };
+      localStorage.setItem("demo-oauth-token", JSON.stringify(token));
+      sessionStorage.setItem("demo-oauth-state", "our-state");
+      simulateOAuthCallback("someone-elses-state", "test-code");
+
+      const client = createDemoPublicOauthClient(CLIENT_ID, FOUNDRY_URL, REDIRECT_URL);
+      await client.signIn();
+
+      expect(window.history.replaceState).not.toHaveBeenCalled();
+      expect(sessionStorage.getItem("demo-oauth-state")).toBe("our-state");
+    });
+
     it("should store token in localStorage after callback", async () => {
       const state = "test-state";
       const code = "test-code";


### PR DESCRIPTION
`DemoPublicOauthClient` broke the `PublicOauthClient` contract two ways:

1. It completed the OAuth callback in its **constructor**, so the `signIn` event fired before `AuthServicePublic` attached its listeners. The token existed but nobody heard about it, and state stayed at `Initializing`.
2. `signIn()` **always redirected**, even holding a valid token.

`AuthServicePublic.onAuthStateChange` calls `signIn()` when state is `Initializing`, so any app using the documented `useAuthState` gate looped: subscribe → signIn → redirect → token minted but unheard → still `Initializing` → repeat.

**Changes**
- Callback completion moved out of the constructor into `signIn()`/`getToken()`.
- `signIn()` now follows the real client: valid token → complete pending callback → redirect.
- Redirect path no longer returns a never-resolving promise (which hung `await signIn()`
  forever). Now matches the real client: `await delay(1000); throw`.
- Added the `useAuthState` gate to the canvas HomePage so this is reproducible in-repo.