### PR TITLE
set description in create endpoint

### DIFF
--- a/.changeset/create-document-description.md
+++ b/.changeset/create-document-description.md
@@ -1,0 +1,9 @@
+---
+"@palantir/pack.state.core": minor
+"@palantir/pack.state.demo": minor
+"@palantir/pack.state.foundry": minor
+---
+
+Allow `app.state.createDocument` callers to set an optional description. Foundry forwards the
+description through both the legacy and V2 create endpoints, and the demo service preserves it in
+document metadata.

--- a/packages/state/core/src/types/CreateDocumentMetadata.ts
+++ b/packages/state/core/src/types/CreateDocumentMetadata.ts
@@ -27,8 +27,9 @@ export type CreateDocumentParent =
   };
 
 interface CreateDocumentMetadataBase {
-  readonly name: string;
+  readonly description?: string;
   readonly documentTypeName: string;
+  readonly name: string;
   readonly security?: DocumentSecurity;
 }
 

--- a/packages/state/demo/src/DemoDocumentService.ts
+++ b/packages/state/demo/src/DemoDocumentService.ts
@@ -237,6 +237,7 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
 
   readonly createDocument = async <T extends DocumentSchema>(
     {
+      description,
       documentTypeName,
       name,
       security = EMPTY_DOCUMENT_SECURITY,
@@ -254,6 +255,7 @@ export class DemoDocumentService extends BaseYjsDocumentService<DemoInternalDoc>
     const operationalVersion = schemaMeta.minSupportedVersion ?? schemaMeta.version;
 
     const metadata: DocumentMetadata = {
+      ...(description != null ? { description } : {}),
       documentTypeName,
       name,
       operationalVersion,

--- a/packages/state/foundry/src/FoundryDocumentService.ts
+++ b/packages/state/foundry/src/FoundryDocumentService.ts
@@ -170,7 +170,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     metadata: CreateDocumentMetadata,
     schema: T,
   ): Promise<DocumentRef<T>> => {
-    const { documentTypeName, name, parent, parentFolderRid, security } = metadata;
+    const { description, documentTypeName, name, parent, parentFolderRid, security } = metadata;
     const preview = this.config.usePreviewApi ?? DEFAULT_USE_PREVIEW_API;
     const wireSecurity = getWireSecurity(security);
 
@@ -178,6 +178,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
     if (parent == null) {
       const ontologyRid = metadata.ontologyRid ?? await getOntologyRid(this.app);
       const request: CreateDocumentRequest = {
+        ...(description != null ? { description } : {}),
         documentTypeName,
         name,
         ontologyRid,
@@ -214,6 +215,7 @@ export class FoundryDocumentService extends BaseYjsDocumentService<FoundryIntern
 
       const request: CreateDocumentV2Request = {
         requestBody: {
+          ...(description != null ? { description } : {}),
           documentTypeName,
           name,
           parent,

--- a/packages/state/foundry/src/__tests__/FoundryDocumentCreation.test.ts
+++ b/packages/state/foundry/src/__tests__/FoundryDocumentCreation.test.ts
@@ -101,6 +101,7 @@ describe("FoundryDocumentService document creation", () => {
 
     await service.createDocument(
       {
+        description: "Legacy description",
         documentTypeName: "com.palantir.pack.test",
         name: "Legacy document",
         parentFolderRid: "ri.compass.main.folder.legacy",
@@ -111,6 +112,7 @@ describe("FoundryDocumentService document creation", () => {
     expect(Documents.create).toHaveBeenCalledWith(
       mockOsdkClient,
       {
+        description: "Legacy description",
         documentTypeName: "com.palantir.pack.test",
         name: "Legacy document",
         ontologyRid: "ri.ontology..default",
@@ -130,6 +132,7 @@ describe("FoundryDocumentService document creation", () => {
 
     await service.createDocument(
       {
+        description: "V2 description",
         documentTypeName: "com.palantir.pack.test",
         name: "V2 document",
         parent: {
@@ -144,6 +147,7 @@ describe("FoundryDocumentService document creation", () => {
       mockOsdkClient,
       {
         requestBody: {
+          description: "V2 description",
           documentTypeName: "com.palantir.pack.test",
           name: "V2 document",
           parent: {


### PR DESCRIPTION
Description field was not wired through document creation metadata in createDocument api. This adds it so consumers can set a description.